### PR TITLE
fix: `BaseSelect` handle `number` value. WF-28

### DIFF
--- a/src/ui/src/core_components/base/BaseSelect.vue
+++ b/src/ui/src/core_components/base/BaseSelect.vue
@@ -93,21 +93,21 @@
 </template>
 
 <script setup lang="ts">
-import { computed, Ref, toRefs } from "vue";
-import { nextTick } from "vue";
-import { ref } from "vue";
-import { watch } from "vue";
+import { computed, nextTick, PropType, Ref, ref, toRefs, watch } from "vue";
 
 const emit = defineEmits(["change"]);
 
-const props = defineProps<{
-	baseId: string;
-	activeValue: any;
-	options: Record<string, string>;
-	maximumCount: number;
-	mode: "single" | "multiple";
-	placeholder?: string;
-}>();
+const props = defineProps({
+	baseId: { type: String, required: true },
+	activeValue: { required: true, validator: () => true },
+	options: {
+		type: Object as PropType<Record<string, string | number | undefined>>,
+		required: true,
+	},
+	maximumCount: { type: Number, required: true },
+	mode: { type: String as PropType<"single" | "multiple">, required: true },
+	placeholder: { type: String, required: false, default: undefined },
+});
 
 const { baseId, activeValue, options, maximumCount, mode, placeholder } =
 	toRefs(props);
@@ -131,8 +131,9 @@ const listOptions = computed(() => {
 			selectedOptions.value.includes(optionKey)
 		)
 			return;
+
 		if (
-			!option
+			!String(option)
 				.toLocaleLowerCase()
 				.includes(activeText.value.toLocaleLowerCase())
 		)


### PR DESCRIPTION
A quick fix to handle number values in `BaseSelect` (used in `MultiSelect` & `SelectInput`).

[Screencast from 2024-06-28 09-27-30.webm](https://github.com/writer/writer-framework/assets/11815139/69ac333a-f248-44ad-9ff0-2257c5b2f291)

I also did a small refactoring on props definition, because using object is more robust (it does a runtime check)
