### PR TITLE
fix: Hide `CoreText` in preview if empty value. WF-20

### DIFF
--- a/src/ui/src/core_components/base/BaseEmptiness.vue
+++ b/src/ui/src/core_components/base/BaseEmptiness.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="displayEmpty" class="BaseEmptiness">
+	<div class="BaseEmptiness">
 		<div class="content">
 			<div class="title">
 				<h3>Empty {{ definition.name }}</h3>
@@ -9,7 +9,6 @@
 			</div>
 		</div>
 	</div>
-	<slot v-else-if="displayContent" />
 </template>
 
 <script setup lang="ts">
@@ -19,7 +18,6 @@ import injectionKeys from "../../injectionKeys";
 const props = defineProps({
 	componentId: { type: String, required: true },
 	message: { type: String, required: false, default: undefined },
-	isEmpty: { type: Boolean },
 });
 
 const wf = inject(injectionKeys.core);
@@ -27,12 +25,8 @@ const component = computed(() => wf.getComponentById(props.componentId));
 const definition = computed(() =>
 	wf.getComponentDefinition(component.value.type),
 );
-
-const isBeingEdited = inject(injectionKeys.isBeingEdited);
-
-const displayEmpty = computed(() => isBeingEdited.value && props.isEmpty);
-const displayContent = computed(() => !displayEmpty.value && !props.isEmpty);
 </script>
+
 <style scoped>
 @import "../../renderer/sharedStyles.css";
 

--- a/src/ui/src/core_components/base/BaseEmptiness.vue
+++ b/src/ui/src/core_components/base/BaseEmptiness.vue
@@ -1,0 +1,62 @@
+<template>
+	<div v-if="displayEmpty" class="BaseEmptiness">
+		<div class="content">
+			<div class="title">
+				<h3>Empty {{ definition.name }}</h3>
+			</div>
+			<div v-if="message" class="message">
+				{{ message }}
+			</div>
+		</div>
+	</div>
+	<slot v-else-if="displayContent" />
+</template>
+
+<script setup lang="ts">
+import { computed, inject } from "vue";
+import injectionKeys from "../../injectionKeys";
+
+const props = defineProps({
+	componentId: { type: String, required: true },
+	message: { type: String, required: false, default: undefined },
+	isEmpty: { type: Boolean },
+});
+
+const wf = inject(injectionKeys.core);
+const component = computed(() => wf.getComponentById(props.componentId));
+const definition = computed(() =>
+	wf.getComponentDefinition(component.value.type),
+);
+
+const isBeingEdited = inject(injectionKeys.isBeingEdited);
+
+const displayEmpty = computed(() => isBeingEdited.value && props.isEmpty);
+const displayContent = computed(() => !displayEmpty.value && !props.isEmpty);
+</script>
+<style scoped>
+@import "../../renderer/sharedStyles.css";
+
+.BaseEmptiness {
+	background: #e4e7ed;
+	color: #4f4f4f;
+	padding: 16px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	min-height: 100%;
+}
+
+.content {
+	text-align: center;
+}
+
+.title > h3 {
+	color: #4f4f4f;
+}
+
+.message {
+	opacity: 0.5;
+	margin-top: 8px;
+}
+</style>

--- a/src/ui/src/core_components/content/CoreMessage.vue
+++ b/src/ui/src/core_components/content/CoreMessage.vue
@@ -24,16 +24,13 @@ else:
 			</LoadingSymbol>
 			<span>{{ messageWithoutPrefix }}</span>
 		</div>
-		<div v-else class="empty">
-			<h3>Blank message</h3>
-		</div>
+		<BaseEmptiness v-else :component-id="componentId" />
 	</div>
 </template>
 
 <script lang="ts">
-import LoadingSymbol from "../../renderer/LoadingSymbol.vue";
-import { FieldCategory, FieldType } from "../../writerTypes";
 import { cssClasses, primaryTextColor } from "../../renderer/sharedStyleFields";
+import { FieldCategory, FieldType } from "../../writerTypes";
 
 const description =
 	"A component that displays a message in various styles, including success, error, warning, and informational.";
@@ -86,10 +83,14 @@ export default {
 	},
 };
 </script>
+
 <script setup lang="ts">
 import { computed, inject } from "vue";
 import injectionKeys from "../../injectionKeys";
+import LoadingSymbol from "../../renderer/LoadingSymbol.vue";
+import BaseEmptiness from "../base/BaseEmptiness.vue";
 
+const componentId = inject(injectionKeys.componentId);
 const fields = inject(injectionKeys.evaluatedFields);
 const isBeingEdited = inject(injectionKeys.isBeingEdited);
 
@@ -156,15 +157,5 @@ const rootStyle = computed(() => {
 }
 .loadingSymbol {
 	margin: -8px 0 -8px 0;
-}
-
-.empty {
-	padding: 16px;
-	background-color: #e4e7ed;
-}
-
-.empty > h3 {
-	text-align: center;
-	color: var(--primaryTextColor);
 }
 </style>

--- a/src/ui/src/core_components/content/CoreText.vue
+++ b/src/ui/src/core_components/content/CoreText.vue
@@ -1,6 +1,13 @@
 <template>
-	<div ref="rootEl" class="CoreText" :style="rootStyle" @click="handleClick">
-		<BaseEmptiness :is-empty="isEmpty" :component-id="componentId">
+	<div
+		v-if="shouldDisplay"
+		ref="rootEl"
+		class="CoreText"
+		:style="rootStyle"
+		@click="handleClick"
+	>
+		<BaseEmptiness v-if="isEmpty" :component-id="componentId" />
+		<template v-else>
 			<BaseMarkdown
 				v-if="fields.useMarkdown.value == 'yes'"
 				:raw-text="fields.text.value"
@@ -10,7 +17,7 @@
 			<div v-else class="plainText" :style="contentStyle">
 				{{ fields.text.value }}
 			</div>
-		</BaseEmptiness>
+		</template>
 	</div>
 </template>
 
@@ -87,7 +94,9 @@ const fields = inject(injectionKeys.evaluatedFields);
 const componentId = inject(injectionKeys.componentId);
 const wf = inject(injectionKeys.core);
 
+const isBeingEdited = inject(injectionKeys.isBeingEdited);
 const isEmpty = computed(() => !fields.text.value);
+const shouldDisplay = computed(() => !isEmpty.value || isBeingEdited.value);
 
 const rootStyle = computed(() => {
 	const component = wf.getComponentById(componentId);

--- a/src/ui/src/core_components/content/CoreText.vue
+++ b/src/ui/src/core_components/content/CoreText.vue
@@ -1,5 +1,11 @@
 <template>
-	<div ref="rootEl" class="CoreText" :style="rootStyle" @click="handleClick">
+	<div
+		v-if="isDisplayed"
+		ref="rootEl"
+		class="CoreText"
+		:style="rootStyle"
+		@click="handleClick"
+	>
 		<BaseMarkdown
 			v-if="fields.useMarkdown.value == 'yes'"
 			:raw-text="fields.text.value"
@@ -13,9 +19,9 @@
 </template>
 
 <script lang="ts">
-import { FieldCategory, FieldControl, FieldType } from "../../writerTypes";
 import { cssClasses, primaryTextColor } from "../../renderer/sharedStyleFields";
 import { getClick } from "../../renderer/syntheticEvents";
+import { FieldCategory, FieldControl, FieldType } from "../../writerTypes";
 import BaseMarkdown from "../base/BaseMarkdown.vue";
 
 const clickHandlerStub = `
@@ -28,6 +34,8 @@ def click_handler(state):
 const description =
 	"A component to display plain text or formatted text using Markdown syntax.";
 
+const emptyText = "(No text)";
+
 export default {
 	writer: {
 		name: "Text",
@@ -36,7 +44,7 @@ export default {
 		fields: {
 			text: {
 				name: "Text",
-				default: "(No text)",
+				default: emptyText,
 				init: "Text",
 				desc: "Add text directly, or reference state elements with @{my_text}.",
 				type: FieldType.Text,
@@ -83,7 +91,12 @@ import injectionKeys from "../../injectionKeys";
 const rootEl: Ref<HTMLElement> = ref(null);
 const fields = inject(injectionKeys.evaluatedFields);
 const componentId = inject(injectionKeys.componentId);
+const isBeingEdited = inject(injectionKeys.isBeingEdited);
 const wf = inject(injectionKeys.core);
+
+const isDisplayed = computed(
+	() => isBeingEdited.value || fields.text.value !== emptyText,
+);
 
 const rootStyle = computed(() => {
 	const component = wf.getComponentById(componentId);

--- a/src/ui/src/core_components/content/CoreText.vue
+++ b/src/ui/src/core_components/content/CoreText.vue
@@ -1,20 +1,16 @@
 <template>
-	<div
-		v-if="isDisplayed"
-		ref="rootEl"
-		class="CoreText"
-		:style="rootStyle"
-		@click="handleClick"
-	>
-		<BaseMarkdown
-			v-if="fields.useMarkdown.value == 'yes'"
-			:raw-text="fields.text.value"
-			:style="contentStyle"
-		>
-		</BaseMarkdown>
-		<div v-else class="plainText" :style="contentStyle">
-			{{ fields.text.value }}
-		</div>
+	<div ref="rootEl" class="CoreText" :style="rootStyle" @click="handleClick">
+		<BaseEmptiness :is-empty="isEmpty" :component-id="componentId">
+			<BaseMarkdown
+				v-if="fields.useMarkdown.value == 'yes'"
+				:raw-text="fields.text.value"
+				:style="contentStyle"
+			>
+			</BaseMarkdown>
+			<div v-else class="plainText" :style="contentStyle">
+				{{ fields.text.value }}
+			</div>
+		</BaseEmptiness>
 	</div>
 </template>
 
@@ -22,7 +18,6 @@
 import { cssClasses, primaryTextColor } from "../../renderer/sharedStyleFields";
 import { getClick } from "../../renderer/syntheticEvents";
 import { FieldCategory, FieldControl, FieldType } from "../../writerTypes";
-import BaseMarkdown from "../base/BaseMarkdown.vue";
 
 const clickHandlerStub = `
 def click_handler(state):
@@ -34,8 +29,6 @@ def click_handler(state):
 const description =
 	"A component to display plain text or formatted text using Markdown syntax.";
 
-const emptyText = "(No text)";
-
 export default {
 	writer: {
 		name: "Text",
@@ -44,7 +37,6 @@ export default {
 		fields: {
 			text: {
 				name: "Text",
-				default: emptyText,
 				init: "Text",
 				desc: "Add text directly, or reference state elements with @{my_text}.",
 				type: FieldType.Text,
@@ -87,16 +79,15 @@ export default {
 <script setup lang="ts">
 import { Ref, computed, inject, ref } from "vue";
 import injectionKeys from "../../injectionKeys";
+import BaseEmptiness from "../base/BaseEmptiness.vue";
+import BaseMarkdown from "../base/BaseMarkdown.vue";
 
 const rootEl: Ref<HTMLElement> = ref(null);
 const fields = inject(injectionKeys.evaluatedFields);
 const componentId = inject(injectionKeys.componentId);
-const isBeingEdited = inject(injectionKeys.isBeingEdited);
 const wf = inject(injectionKeys.core);
 
-const isDisplayed = computed(
-	() => isBeingEdited.value || fields.text.value !== emptyText,
-);
+const isEmpty = computed(() => !fields.text.value);
 
 const rootStyle = computed(() => {
 	const component = wf.getComponentById(componentId);

--- a/src/ui/src/renderer/ChildlessPlaceholder.vue
+++ b/src/ui/src/renderer/ChildlessPlaceholder.vue
@@ -1,32 +1,23 @@
 <template>
-	<div class="ChildlessPlaceholder">
-		<div class="content">
-			<div class="title">
-				<h3>Empty {{ definition.name }}</h3>
-			</div>
-			<div v-if="message" class="message">
-				{{ message }}
-			</div>
-		</div>
-	</div>
+	<BaseEmptiness
+		class="ChildlessPlaceholder"
+		:component-id="componentId"
+		:message="message"
+	/>
 </template>
+
 <script setup lang="ts">
-import { computed, inject, toRefs } from "vue";
-import { Component } from "../writerTypes";
+import { computed, inject } from "vue";
+import BaseEmptiness from "../core_components/base/BaseEmptiness.vue";
 import injectionKeys from "../injectionKeys";
+import { Component } from "../writerTypes";
 
 const ALLOWED_LIST_MAX_LENGTH = 10;
 const wf = inject(injectionKeys.core);
 
-interface Props {
-	componentId: Component["id"];
-}
-const props = defineProps<Props>();
-const { componentId } = toRefs(props);
-const component = computed(() => wf.getComponentById(componentId.value));
-const definition = computed(() =>
-	wf.getComponentDefinition(component.value.type),
-);
+const props = defineProps({
+	componentId: { type: String, required: true },
+});
 
 const typesToMessage = (
 	types: Component["type"][],
@@ -41,7 +32,7 @@ const typesToMessage = (
 };
 
 const message = computed(() => {
-	const containableTypes = wf.getContainableTypes(componentId.value);
+	const containableTypes = wf.getContainableTypes(props.componentId);
 	let message: string;
 
 	if (containableTypes.length <= ALLOWED_LIST_MAX_LENGTH) {
@@ -52,30 +43,3 @@ const message = computed(() => {
 	return message;
 });
 </script>
-<style scoped>
-@import "./sharedStyles.css";
-
-.ChildlessPlaceholder {
-	background: #e4e7ed;
-	color: #4f4f4f;
-	padding: 16px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 100%;
-	min-height: 100%;
-}
-
-.content {
-	text-align: center;
-}
-
-.title > h3 {
-	color: #4f4f4f;
-}
-
-.message {
-	opacity: 0.5;
-	margin-top: 8px;
-}
-</style>


### PR DESCRIPTION
Simply hide the `CoreText` using `v-if` in preview mode if the value is `emptyText`. We still display the component in edit mode.


[Screencast from 2024-06-29 14-37-01.webm](https://github.com/writer/writer-framework/assets/11815139/12b438b5-dc39-452c-885e-e996b9e8ddfb)
