### PR TITLE
fix: handle template in `BuilderFieldsKeyValue`. WF-31

### DIFF
--- a/src/ui/src/builder/BuilderSettingsProperties.vue
+++ b/src/ui/src/builder/BuilderSettingsProperties.vue
@@ -49,6 +49,7 @@
 							class="content"
 							:field-key="fieldKey"
 							:component-id="selectedComponent.id"
+							:instance-path="selectedInstancePath"
 						></BuilderFieldsKeyValue>
 
 						<BuilderFieldsText
@@ -118,19 +119,24 @@
 
 <script setup lang="ts">
 import { computed, inject } from "vue";
-import BuilderFieldsKeyValue from "./BuilderFieldsKeyValue.vue";
-import { FieldType, FieldCategory } from "../writerTypes";
+import injectionKeys from "../injectionKeys";
+import { parseInstancePathString } from "../renderer/instancePath";
+import { FieldCategory, FieldType, InstancePath } from "../writerTypes";
+import BuilderFieldsAlign from "./BuilderFieldsAlign.vue";
 import BuilderFieldsColor from "./BuilderFieldsColor.vue";
+import BuilderFieldsKeyValue from "./BuilderFieldsKeyValue.vue";
+import BuilderFieldsObject from "./BuilderFieldsObject.vue";
+import BuilderFieldsPadding from "./BuilderFieldsPadding.vue";
 import BuilderFieldsShadow from "./BuilderFieldsShadow.vue";
 import BuilderFieldsText from "./BuilderFieldsText.vue";
-import BuilderFieldsObject from "./BuilderFieldsObject.vue";
 import BuilderFieldsWidth from "./BuilderFieldsWidth.vue";
-import BuilderFieldsAlign from "./BuilderFieldsAlign.vue";
-import BuilderFieldsPadding from "./BuilderFieldsPadding.vue";
-import injectionKeys from "../injectionKeys";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
+
+const selectedInstancePath = computed<InstancePath>(() =>
+	parseInstancePathString(ssbm.getSelection()?.instancePath),
+);
 
 const selectedComponent = computed(() => {
 	return wf.getComponentById(ssbm.getSelectedId());

--- a/src/ui/src/builder/BuilderTemplateInput.vue
+++ b/src/ui/src/builder/BuilderTemplateInput.vue
@@ -34,7 +34,7 @@
 				ref="input"
 				v-capture-tabs
 				class="templateInput"
-				:variant="props.vatiant"
+				:variant="props.variant"
 				:value="props.value"
 				autocorrect="off"
 				autocomplete="off"
@@ -60,23 +60,36 @@
 </template>
 
 <script setup lang="ts">
-import { inject, ref, nextTick } from "vue";
-import injectionKeys from "../injectionKeys";
 import Fuse from "fuse.js";
+import { PropType, inject, nextTick, ref } from "vue";
+import injectionKeys from "../injectionKeys";
 
 const emit = defineEmits(["input", "update:value"]);
-const props = defineProps<{
-	inputId?: string;
-	value?: string;
-	multiline?: boolean;
-	variant?: "code" | "text";
-	type?: "state" | "template";
-	options?: Record<string, string>;
-	placeholder?: string;
-}>();
+
+const props = defineProps({
+	inputId: { type: String, required: false, default: undefined },
+	value: { type: String, required: false, default: undefined },
+	multiline: { type: Boolean, required: false },
+	variant: {
+		type: String as PropType<"code" | "text">,
+		required: false,
+		default: undefined,
+	},
+	type: {
+		type: String as PropType<"state" | "template">,
+		required: false,
+		default: undefined,
+	},
+	options: {
+		type: Object as PropType<Record<string, string>>,
+		required: false,
+		default: undefined,
+	},
+	placeholder: { type: String, required: false, default: undefined },
+});
 
 const ss = inject(injectionKeys.core);
-const autocompleteOptions = ref<string[]>([]);
+const autocompleteOptions = ref<{ text: string; type: string }[]>([]);
 const input = ref<HTMLInputElement | null>(null);
 
 defineExpose({

--- a/src/ui/src/renderer/ComponentProxy.vue
+++ b/src/ui/src/renderer/ComponentProxy.vue
@@ -1,28 +1,42 @@
 <script lang="ts">
-import { Ref, computed, h, inject, provide, ref, watch } from "vue";
+import {
+	PropType,
+	Ref,
+	VNode,
+	computed,
+	h,
+	inject,
+	provide,
+	ref,
+	watch,
+} from "vue";
 import { getTemplate } from "../core/templateMap";
+import injectionKeys from "../injectionKeys";
 import {
 	Component,
 	InstancePath,
 	InstancePathItem,
 	UserFunction,
 } from "../writerTypes";
-import ComponentProxy from "./ComponentProxy.vue";
-import { useEvaluator } from "./useEvaluator";
-import injectionKeys from "../injectionKeys";
-import { VNode } from "vue";
 import ChildlessPlaceholder from "./ChildlessPlaceholder.vue";
+import ComponentProxy from "./ComponentProxy.vue";
 import RenderError from "./RenderError.vue";
+import { flattenInstancePath } from "./instancePath";
+import { useEvaluator } from "./useEvaluator";
 
 export default {
-	props: ["componentId", "instancePath", "instanceData"],
+	props: {
+		componentId: { type: String, required: true },
+		instancePath: { type: Array as PropType<InstancePath>, required: true },
+		instanceData: { validator: () => true, required: true },
+	},
 	setup(props) {
 		const wf = inject(injectionKeys.core);
 		const ssbm = inject(injectionKeys.builderManager);
-		const componentId: Component["id"] = props.componentId;
+		const componentId = props.componentId;
 		const component = computed(() => wf.getComponentById(componentId));
 		const template = getTemplate(component.value.type);
-		const instancePath: InstancePath = props.instancePath;
+		const instancePath = props.instancePath;
 		const instanceData = props.instanceData;
 		const { getEvaluatedFields, isComponentVisible } = useEvaluator(wf);
 		const evaluatedFields = getEvaluatedFields(instancePath);
@@ -141,11 +155,6 @@ export default {
 			];
 		};
 
-		const flattenInstancePath = (path: InstancePath) => {
-			return path
-				.map((ie) => `${ie.componentId}:${ie.instanceNumber}`)
-				.join(",");
-		};
 		const flattenedInstancePath = flattenInstancePath(instancePath);
 
 		provide(injectionKeys.evaluatedFields, evaluatedFields);
@@ -153,7 +162,7 @@ export default {
 		provide(injectionKeys.isBeingEdited, isBeingEdited);
 		provide(injectionKeys.isDisabled, isDisabled);
 		provide(injectionKeys.instancePath, instancePath);
-		provide(injectionKeys.instanceData, instanceData);
+		provide(injectionKeys.instanceData, instanceData as any);
 		provide(injectionKeys.renderProxiedComponent, renderProxiedComponent);
 		provide(injectionKeys.getChildrenVNodes, getChildrenVNodes);
 		provide(injectionKeys.flattenedInstancePath, flattenedInstancePath);

--- a/src/ui/src/renderer/instancePath.ts
+++ b/src/ui/src/renderer/instancePath.ts
@@ -1,0 +1,13 @@
+import type { InstancePath } from "../writerTypes";
+
+export function flattenInstancePath(path: InstancePath) {
+	return path.map((ie) => `${ie.componentId}:${ie.instanceNumber}`).join(",");
+}
+
+export function parseInstancePathString(raw?: string): InstancePath {
+	if (!raw) return [];
+	return raw.split(",").map((record) => {
+		const [componentId, instanceNumber] = record.split(":");
+		return { componentId, instanceNumber: Number(instanceNumber) };
+	});
+}


### PR DESCRIPTION
The issue was `BuilderFieldsKeyValue` didn't interpret the template syntax and try to `JSON.parse` it when navigating between "Static List" and "JSON".

I fixed it relying on `useEvaluator().getEvaluatedFields` which take care of getting the current data and parsing template. It simplify a lot the logic of the component!

It just required that I get and parse `instancePath` in the parent.

Now everything works as expected, if user modify a template value in "Static list" mode, the template is overwiten by the plain JSON value. We still handle the "undo/redo" as expected.

[Screencast from 2024-07-01 23-45-17.webm](https://github.com/writer/writer-framework/assets/11815139/4d831d32-1c40-44f3-82b6-b34c06ed14d8)
