### PR TITLE
chore(ui): use local fonts instead of CDN. WF-27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2587,6 +2587,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@fontsource-variable/material-symbols-outlined": {
+			"version": "5.0.34",
+			"resolved": "https://registry.npmjs.org/@fontsource-variable/material-symbols-outlined/-/material-symbols-outlined-5.0.34.tgz",
+			"integrity": "sha512-dC6BoXU93VMjNlfbn4YRdqsSOFp6Smue2KZgZJ8wy2x0OeyA73hgJyb5i6mV6JZnuaiJHMwqTfwJQ3FtSPKFnw=="
+		},
+		"node_modules/@fontsource/poppins": {
+			"version": "5.0.14",
+			"resolved": "https://registry.npmjs.org/@fontsource/poppins/-/poppins-5.0.14.tgz",
+			"integrity": "sha512-nmM1zpPo3Uh4JcGAVSQuWaZNYh2FbbwWhZ5t6hRaynmJaNTBW85d3nEh9zMmzI0HX7X5xqQVdRHeDatKpOGsnA=="
+		},
 		"node_modules/@googlemaps/js-api-loader": {
 			"version": "1.16.6",
 			"resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.6.tgz",
@@ -23098,6 +23108,8 @@
 			"version": "0.0.0",
 			"dependencies": {
 				"@apache-arrow/ts": "^15.0.2",
+				"@fontsource-variable/material-symbols-outlined": "^5.0.34",
+				"@fontsource/poppins": "^5.0.14",
 				"@googlemaps/js-api-loader": "^1.16.6",
 				"@monaco-editor/loader": "^1.3.3",
 				"@tato30/vue-pdf": "^1.9.6",

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -3,10 +3,6 @@
 	<head>
 		<meta charset="UTF-8" />
 		<link rel="icon" type="image/png" href="./static/favicon.png?2" />
-		<link rel="preconnect" href="https://fonts.googleapis.com">
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-		<link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
-		<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Writer Framework</title>
 		<style>
@@ -24,7 +20,9 @@
 			}
 
 			.material-symbols-outlined {
+				font-family: 'Material Symbols Outlined Variable', sans-serif;
 				font-size: 100%;
+				font-style: normal;
 			}
 
 			#app {

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -16,6 +16,8 @@
 	},
 	"dependencies": {
 		"@apache-arrow/ts": "^15.0.2",
+		"@fontsource-variable/material-symbols-outlined": "^5.0.34",
+		"@fontsource/poppins": "^5.0.14",
 		"@googlemaps/js-api-loader": "^1.16.6",
 		"@monaco-editor/loader": "^1.3.3",
 		"@tato30/vue-pdf": "^1.9.6",

--- a/src/ui/src/fonts.ts
+++ b/src/ui/src/fonts.ts
@@ -1,0 +1,12 @@
+import "@fontsource-variable/material-symbols-outlined";
+
+import "@fontsource/poppins/300-italic.css";
+import "@fontsource/poppins/300.css";
+import "@fontsource/poppins/400-italic.css";
+import "@fontsource/poppins/400.css";
+import "@fontsource/poppins/500-italic.css";
+import "@fontsource/poppins/500.css";
+import "@fontsource/poppins/600-italic.css";
+import "@fontsource/poppins/600.css";
+import "@fontsource/poppins/700-italic.css";
+import "@fontsource/poppins/700.css";

--- a/src/ui/src/main.ts
+++ b/src/ui/src/main.ts
@@ -1,9 +1,10 @@
 import * as vue from "vue";
 import { App, createApp } from "vue";
-import injectionKeys from "./injectionKeys";
-import { generateCore } from "./core";
-import { generateBuilderManager } from "./builder/builderManager.js";
 import VueDOMPurifyHTML from "vue-dompurify-html";
+import { generateBuilderManager } from "./builder/builderManager.js";
+import { generateCore } from "./core";
+import "./fonts";
+import injectionKeys from "./injectionKeys";
 
 /**
  * RemixIcon by remixicon.com


### PR DESCRIPTION
Use [Fontsource](https://fontsource.org/) with NPM instead of relying on https://fonts.google.com

Try to spot the difference (I don't see any :monocle_face: )

| before | CDN |
|--|--|
| ![Screenshot 2024-07-06 at 22-36-55 Hello Writer Framework Builder](https://github.com/writer/writer-framework/assets/11815139/7d713dc5-a56f-46bd-b438-8fa80aae02c4) | ![Screenshot 2024-07-06 at 22-36-36 Hello Writer Framework Builder](https://github.com/writer/writer-framework/assets/11815139/a2630901-0851-4aa5-a903-f714975c0542) |
