### PR TITLE
feat: trigger a calculated property on mutation

### DIFF
--- a/docs/framework/application-state.mdx
+++ b/docs/framework/application-state.mdx
@@ -113,3 +113,33 @@ The front-end cannot directly display complex data types such as Pandas datafram
     Pandas dataframes are converted to JSON and can be used in _Dataframe_ components.
   </Tab>
 </Tabs>
+
+## State schema
+
+State schema is a feature that allows you to define the structure of the state.
+This is useful for ensuring that the state is always in the expected format.
+
+Schema allows you to use features like
+
+* typing checking with mypy / ruff
+* autocomplete in IDEs
+* declare dictionaries
+* automatically calculate mutations on properties
+
+more into [Advanced > State schema](./state-schema)
+
+```python
+import writer as wf
+
+class AppSchema(wf.WriterState):
+    counter: int
+
+initial_state = wf.init_state({
+    "counter": 0
+}, schema=AppSchema)
+
+# Event handler
+# It receives the session state as an argument and mutates it
+def increment(state: AppSchema):
+    state.counter += 1
+```

--- a/docs/framework/event-handlers.mdx
+++ b/docs/framework/event-handlers.mdx
@@ -136,6 +136,28 @@ def hande_click_cleaner(state):
 ```
 </CodeGroup>
 
+## Mutation event
+
+You can subscribe to mutations on a specific key in the state.
+This is useful when you want to trigger a function every time a specific key is mutated.
+
+```python
+import writer as wf
+
+def _increment_counter(state):
+    state['my_counter'] += 1
+
+state = wf.init_state({"a": 1, "my_counter": 0})
+state.subscribe_mutation('a', _increment_counter)
+
+state['a'] = 2  # trigger _increment_counter mutation
+```
+
+```python
+state.subscribe_mutation('a.b', _increment_counter)  # subscribe to nested key
+state.subscribe_mutation(['title', 'app.title'], _increment_counter)  # subscribe to multiple keys
+```
+
 ## Receiving a payload
 
 Several events include additional data, known as the event's payload. The event handler can receive that data using the `payload` argument.

--- a/docs/framework/event-handlers.mdx
+++ b/docs/framework/event-handlers.mdx
@@ -141,7 +141,8 @@ def hande_click_cleaner(state):
 You can subscribe to mutations on a specific key in the state.
 This is useful when you want to trigger a function every time a specific key is mutated.
 
-```python
+<CodeGroup>
+```python simple subscription
 import writer as wf
 
 def _increment_counter(state):
@@ -153,10 +154,44 @@ state.subscribe_mutation('a', _increment_counter)
 state['a'] = 2  # trigger _increment_counter mutation
 ```
 
-```python
-state.subscribe_mutation('a.b', _increment_counter)  # subscribe to nested key
+```python multiple subscriptions
+import writer as wf
+
+def _increment_counter(state):
+    state['my_counter'] += 1
+
+state = wf.init_state({
+	'title': 'Hello',
+	'app': {'title', 'Writer Framework'},
+	'my_counter': 0}
+)
+
 state.subscribe_mutation(['title', 'app.title'], _increment_counter)  # subscribe to multiple keys
+
+state['title'] = "Hello Pigeon"  # trigger _increment_counter mutation
 ```
+
+```python trigger event handler
+import writer as wf
+
+def _increment_counter(state, context: dict, payload: dict, session: dict, ui: WriterUIManager):
+	if context['event'] == 'mutation' and context['mutation'] == 'a':
+		if payload['previous_value'] > payload['new_value']:
+			state['my_counter'] += 1
+
+state = wf.init_state({"a": 1, "my_counter": 0})
+state.subscribe_mutation('a', _increment_counter)
+
+state['a'] = 2  # increment my_counter
+state['a'] = 3  # increment my_counter
+state['a'] = 2  # do nothing
+```
+</CodeGroup>
+
+<Tip>
+`subscribe_mutation` is compatible with event handler signature. It will accept all the arguments
+of the event handler (`context`, `payload`, ...).
+</Tip>
 
 ## Receiving a payload
 

--- a/docs/framework/state-schema.mdx
+++ b/docs/framework/state-schema.mdx
@@ -62,6 +62,30 @@ initial_state = wf.init_state({
 }, schema=AppSchema)
 ```
 
+## Calculated properties
+
+Calculated properties are updated automatically when a dependency changes.
+They can be used to calculate values derived from application state.
+
+```python
+class MyAppState(wf.State):
+  counter: List[int]
+
+class MyState(wf.WriterState):
+  counter: List[int]
+
+  @wf.property(['counter', 'app.counter'])
+  def total_counter(self):
+    return sum(self.counter) + sum(self.app.counter)
+
+initial_state = wf.init_state({
+    "counter": 0,
+    "my_app": {
+        "counter": 0
+    }
+}, schema=MyState)
+```
+
 ## Multi-level dictionary
 
 Some components like _Vega Lite Chart_ require specifying a graph in the form of a multi-level dictionary.

--- a/src/writer/__init__.py
+++ b/src/writer/__init__.py
@@ -17,6 +17,9 @@ from writer.core import (
     session_manager,
     session_verifier,
 )
+from writer.core import (
+    writerproperty as property,
+)
 from writer.ui import WriterUIManager
 
 VERSION = importlib.metadata.version("writer")
@@ -94,6 +97,7 @@ def init_state(raw_state: Dict[str, Any], schema: Optional[Type[S]] = None) -> U
         raise ValueError("Root schema must inherit from WriterState")
 
     _initial_state: S = new_initial_state(concrete_schema, raw_state)
+
     return _initial_state
 
 

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -19,7 +19,7 @@ from pydantic import ValidationError
 from watchdog.observers.polling import PollingObserver
 
 from writer import VERSION
-from writer.core import EventHandlerRegistry, MiddlewareRegistry, WriterSession
+from writer.core import EventHandlerRegistry, MiddlewareRegistry, WriterSession, use_request_context
 from writer.core_ui import ingest_bmc_component_tree
 from writer.ss_types import (
     AppProcessServerRequest,
@@ -232,71 +232,72 @@ class AppProcess(multiprocessing.Process):
         """
         import writer
 
-        session = None
-        type = request.type
+        with use_request_context(session_id, request):
+            session = None
+            type = request.type
 
-        if type == "sessionInit":
-            si_req_payload = InitSessionRequestPayload.parse_obj(
-                request.payload)
-            return AppProcessServerResponse(
-                status="ok",
-                status_message=None,
-                payload=self._handle_session_init(si_req_payload)
-            )
+            if type == "sessionInit":
+                si_req_payload = InitSessionRequestPayload.parse_obj(
+                    request.payload)
+                return AppProcessServerResponse(
+                    status="ok",
+                    status_message=None,
+                    payload=self._handle_session_init(si_req_payload)
+                )
 
-        session = writer.session_manager.get_session(session_id)
-        if not session:
-            raise MessageHandlingException("Session not found.")
-        session.update_last_active_timestamp()
+            session = writer.session_manager.get_session(session_id)
+            if not session:
+                raise MessageHandlingException("Session not found.")
+            session.update_last_active_timestamp()
 
-        if type == "checkSession":
-            return AppProcessServerResponse(
-                status="ok",
-                status_message=None,
-                payload=None
-            )
+            if type == "checkSession":
+                return AppProcessServerResponse(
+                    status="ok",
+                    status_message=None,
+                    payload=None
+                )
 
-        if type == "event":
-            ev_req_payload = WriterEvent.parse_obj(request.payload)
-            return AppProcessServerResponse(
-                status="ok",
-                status_message=None,
-                payload=self._handle_event(session, ev_req_payload)
-            )
-        
-        if type == "stateEnquiry":
-            return AppProcessServerResponse(
-                status="ok",
-                status_message=None,
-                payload=self._handle_state_enquiry(session)
-            )
+            if type == "event":
+                ev_req_payload = WriterEvent.parse_obj(request.payload)
+                return AppProcessServerResponse(
+                    status="ok",
+                    status_message=None,
+                    payload=self._handle_event(session, ev_req_payload)
+                )
 
-        if type == "stateContent":
-            return AppProcessServerResponse(
-                status="ok",
-                status_message=None,
-                payload=self._handle_state_content(session)
-            )
+            if type == "stateEnquiry":
+                return AppProcessServerResponse(
+                    status="ok",
+                    status_message=None,
+                    payload=self._handle_state_enquiry(session)
+                )
 
-        if type == "setUserinfo":
-            session.userinfo = request.payload
-            return AppProcessServerResponse(
-                status="ok",
-                status_message=None,
-                payload=None
-            )
+            if type == "stateContent":
+                return AppProcessServerResponse(
+                    status="ok",
+                    status_message=None,
+                    payload=self._handle_state_content(session)
+                )
 
-        if self.mode == "edit" and type == "componentUpdate":
-            cu_req_payload = ComponentUpdateRequestPayload.parse_obj(
-                request.payload)
-            self._handle_component_update(session, cu_req_payload)
-            return AppProcessServerResponse(
-                status="ok",
-                status_message=None,
-                payload=None
-            )
+            if type == "setUserinfo":
+                session.userinfo = request.payload
+                return AppProcessServerResponse(
+                    status="ok",
+                    status_message=None,
+                    payload=None
+                )
 
-        raise MessageHandlingException("Invalid event.")
+            if self.mode == "edit" and type == "componentUpdate":
+                cu_req_payload = ComponentUpdateRequestPayload.parse_obj(
+                    request.payload)
+                self._handle_component_update(session, cu_req_payload)
+                return AppProcessServerResponse(
+                    status="ok",
+                    status_message=None,
+                    payload=None
+                )
+
+            raise MessageHandlingException("Invalid event.")
 
     def _execute_user_code(self) -> None:
         """

--- a/src/writer/core.py
+++ b/src/writer/core.py
@@ -18,7 +18,6 @@ import traceback
 import types
 import urllib.request
 from abc import ABCMeta
-from functools import partial, wraps
 from multiprocessing.process import BaseProcess
 from types import ModuleType
 from typing import (
@@ -92,7 +91,7 @@ def import_failure(rvalue: Any = None):
     :param rvalue: the value to return
     """
     def decorator(func):
-        @wraps(func)
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):
             try:
                 return func(*args, **kwargs)
@@ -567,7 +566,7 @@ class State(metaclass=StateMeta):
         self._state_proxy: StateProxy = StateProxy(raw_state)
         self.ingest(raw_state)
 
-        # Cette étape enregistre les propriétés associés à l'instance
+        # This step saves the properties associated with the instance
         for attribute in calculated_properties_per_state_type.get(self.__class__, []):
             getattr(self, attribute)
 
@@ -704,7 +703,7 @@ class State(metaclass=StateMeta):
         for p in path_list:
             state_proxy = self._state_proxy
             path_parts = p.split(".")
-            final_handler = partial(handler, self)
+            final_handler = functools.partial(handler, self)
             for i, path_part in enumerate(path_parts):
                 if i == len(path_parts) - 1:
                     local_mutation = MutationSubscription(path_parts[-1], final_handler)

--- a/src/writer/core.py
+++ b/src/writer/core.py
@@ -679,7 +679,7 @@ class State(metaclass=StateMeta):
                 self._state_proxy[key] = value
 
 
-    def subscribe_mutation(self, path: Union[str, List[str]], handler: Callable[['State'], None]) -> None:
+    def subscribe_mutation(self, path: Union[str, List[str]], handler: Callable[['State'], None], initial_triggered: bool = False) -> None:
         """
         Automatically triggers a handler when a mutation occurs in the state.
 
@@ -713,7 +713,8 @@ class State(metaclass=StateMeta):
                     # At startup, the application must be informed of the
                     # existing states. To cause this, we trigger manually
                     # the handler.
-                    final_handler()
+                    if initial_triggered is True:
+                        final_handler()
                 elif path_part in state_proxy:
                     state_proxy = state_proxy[path_part]
                 else:
@@ -2132,7 +2133,7 @@ def writerproperty(path: Union[str, List[str]]):
                 def calculated_property_handler(state):
                     instance._state_proxy[property_name] = self.func(state)
 
-                instance.subscribe_mutation(path, calculated_property_handler)
+                instance.subscribe_mutation(path, calculated_property_handler, initial_triggered=True)
                 self.instances.add(instance)
 
             return self.func(instance)

--- a/tests/backend/fixtures/writer_fixtures.py
+++ b/tests/backend/fixtures/writer_fixtures.py
@@ -1,0 +1,40 @@
+import contextlib
+import copy
+
+from writer import WriterState, core, core_ui
+from writer.core import Config, SessionManager
+
+
+@contextlib.contextmanager
+def new_app_context():
+    """
+    Creates a new application context for testing, independent of the global state.
+
+    This fixture avoids conflicts between tests that use the same global state.
+    At the end of the context, the global state is restored to its original state.
+
+    >>> with writer_fixtures.new_app_context():
+    >>>     initial_state = wf.init_state({
+    >>>            "counter": 0,
+    >>>            "total": 0
+    >>>     }, schema=MyState)
+    """
+    saved_context_vars = {}
+    core_context_vars = ['initial_state', 'base_component_tree', 'session_manager']
+    core_config_vars = copy.deepcopy(core.Config)
+
+    for var in core_context_vars:
+        saved_context_vars[var] = getattr(core, var)
+
+    core.initial_state = WriterState()
+    core.base_component_tree = core_ui.build_base_component_tree()
+    core.session_manager = SessionManager()
+    Config.mode = "run"
+    Config.logger = None
+
+    yield
+
+    for var in core_context_vars:
+        setattr(core, var, saved_context_vars[var])
+
+    core.Config = core_config_vars

--- a/tests/backend/test_core.py
+++ b/tests/backend/test_core.py
@@ -30,7 +30,7 @@ from writer.core import (
 from writer.core_ui import Component
 from writer.ss_types import WriterEvent
 
-from backend.fixtures import core_ui_fixtures
+from backend.fixtures import core_ui_fixtures, writer_fixtures
 from tests.backend import test_app_dir
 
 raw_state_dict = {
@@ -507,27 +507,28 @@ class TestState:
         """
         Tests that a mutation handler is triggered on a typed state and can use attributes directly.
         """
-        # Assign
-        class MyState(wf.WriterState):
-            counter: int
-            total: int
+        with writer_fixtures.new_app_context():
+            # Assign
+            class MyState(wf.WriterState):
+                counter: int
+                total: int
 
-        def cumulative_sum(state: MyState):
-            state.total += state.counter
+            def cumulative_sum(state: MyState):
+                state.total += state.counter
 
-        initial_state = wf.init_state({
-            "counter": 0,
-            "total": 0
-        }, schema=MyState)
+            initial_state = wf.init_state({
+                "counter": 0,
+                "total": 0
+            }, schema=MyState)
 
-        initial_state.subscribe_mutation('counter', cumulative_sum)
+            initial_state.subscribe_mutation('counter', cumulative_sum)
 
-        # Acts
-        initial_state['counter'] = 1
-        initial_state['counter'] = 3
+            # Acts
+            initial_state['counter'] = 1
+            initial_state['counter'] = 3
 
-        # Assert
-        assert initial_state['total'] == 4
+            # Assert
+            assert initial_state['total'] == 4
 
 class TestWriterState:
 

--- a/tests/backend/test_core.py
+++ b/tests/backend/test_core.py
@@ -503,6 +503,27 @@ class TestState:
         except RecursionError:
             assert True
 
+    def test_subscribe_mutation_should_raise_accept_event_handler_as_callback(self):
+        """
+        Tests that the handler that subscribes to a mutation can accept an event as a parameter
+        """
+        # Assign
+        def _increment_counter(state, payload, context: dict, ui):
+            state['my_counter'] += 1
+
+            # Assert
+            assert payload['mutation_previous_value'] == 1
+            assert payload['mutation_value'] == 2
+            assert context['mutation'] == 'a'
+
+        _state = WriterState({"a": 1, "my_counter": 0})
+        _state.user_state.get_mutations_as_dict()
+
+        # Acts
+        _state.subscribe_mutation('a', _increment_counter)
+        _state['a'] = 2
+
+
     def test_subscribe_mutation_with_typed_state_should_manage_mutation(self):
         """
         Tests that a mutation handler is triggered on a typed state and can use attributes directly.


### PR DESCRIPTION
implement https://github.com/FabienArcellier/writer-framework/issues/37

![Peek 2024-08-01 08-09](https://github.com/user-attachments/assets/3c16396a-0e7b-4a8f-a173-122687ade80a)

### Simple subscription

```python
def _increment_counter(state):
    state['my_counter'] += 1

_state = wf.init_state({"a": 1, "my_counter": 0})
_state.subscribe_mutation('a', _increment_counter)

_state['a'] = 2 # trigger _increment_counter mutation
```

### Subscription on state with strong type

```python
class MyState(wf.WriterState):
  counter: int
  total: int

def cumulative_sum(state: MyState):
  state.total += state.counter

initial_state = ss.init_state({
    "counter": 0,
    "total": 0
}, schema=MyState)

initial_state.subscribe_mutation('counter', cumulative_sum)

initial_state['counter'] = 2 # trigger the function cumulative_sum
```

### Calculated property

```python
class MyState(wf.WriterState):
    counter: int

    @wf.property('counter')
    def counter_str(self) -> str:
        return str(self.counter)

state = wf.init_state({'counter': 0}, MyState)

state.counter = 2 # trigger mutation for +counter_str 
```

### Subscription with an event handler

```python
def _increment_counter(state: RootState, context: dict, payload: dict, session: dict, ui: wf.WriterUIManager):
	if context['event'] == 'mutation' and context['mutation'] == 'a':
		if payload['previous_value'] < payload['new_value']:
			state['my_counter'] += 1

state = wf.init_state({
	"a": 1, 
	"my_counter": 0,
})

state.subscribe_mutation('a', _increment_counter)
```

### In preparation of dot support expression

```python
def cumulative_sum(state):
    state['total'] += state['a.b']

initial_state = wf.init_state({
    "a.b": 0,
    "total": 0
})

initial_state.subscribe_mutation('a\.b', cumulative_sum)
```