### PR TITLE
fix(ui): fix `CoreDataFrame` download for big file. WF-39

### DIFF
--- a/src/ui/src/core_components/content/CoreDataframe.vue
+++ b/src/ui/src/core_components/content/CoreDataframe.vue
@@ -426,12 +426,13 @@ function download() {
 	const csv = table.value.toCSV();
 	const el = document.createElement("a");
 
-	// btoa only supports ASCII
+	const blob = new Blob([csv], { type: "text/csv" });
+	const url = URL.createObjectURL(blob);
 
-	const s = String.fromCharCode(...new TextEncoder().encode(csv));
-	el.href = "data:text/plain;base64," + window.btoa(s);
+	el.href = url;
 	el.download = "data.csv";
 	el.click();
+	URL.revokeObjectURL(url);
 }
 
 async function applyOrder() {


### PR DESCRIPTION
The issue was too many parameters was given to `String.fromCharCode()` and make and error like "Maximum call stack size exceeded".

In fact, there is no need to try to convert the CSV to base64. So I simply used `Blob` and then `URL.createObjectURL` instead which should be more efficient.

Note, it also improve the mime/type declared, which make the OS open the file with a better software (Libreoffice instead of Text Editor for me)