### PR TITLE
ci: bump Node version to `20.x`

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: "20.x"
           cache: npm
 
       - name: install python3 environment

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: "20.x"
           cache: npm
 
       - name: install python3 environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: "20.x"
           cache: npm
 
       - name: install python3 environment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Use Node.js
               uses: actions/setup-node@v4
               with:
-                node-version: "18.x"
+                node-version: "20.x"
                 cache: npm
 
             - name: install python3 environment


### PR DESCRIPTION
I just saw a mismatch of Node.js version between package.json ([which mention v20.x](https://github.com/writer/writer-framework/blob/67f4317691c2d0dc9b43ad68331aa9f23b812676/package.json#L11)) and CI ([which use v18.x](https://github.com/writer/writer-framework/blob/67f4317691c2d0dc9b43ad68331aa9f23b812676/.github/workflows/ci.yml#L34))