### PR TITLE
fix(ui): remove some overflow constraints

### DIFF
--- a/src/ui/src/core_components/layout/CoreSection.vue
+++ b/src/ui/src/core_components/layout/CoreSection.vue
@@ -74,7 +74,6 @@ const fields = inject(injectionKeys.evaluatedFields);
 <style scoped>
 @import "../../renderer/sharedStyles.css";
 .CoreSection {
-	overflow: hidden;
 	border: 1px solid var(--separatorColor);
 	border-radius: 8px;
 	box-shadow: var(--containerShadow);

--- a/src/ui/src/core_components/layout/CoreSteps.vue
+++ b/src/ui/src/core_components/layout/CoreSteps.vue
@@ -82,7 +82,6 @@ instanceData.at(-1).value = stepsData;
 	border: 1px solid var(--separatorColor);
 	border-radius: 8px;
 	background: var(--containerBackgroundColor);
-	overflow: hidden;
 	box-shadow: var(--containerShadow);
 }
 
@@ -103,7 +102,8 @@ instanceData.at(-1).value = stepsData;
 
 .container {
 	background: var(--containerBackgroundColor);
-	box-shadow: var(--containerShadow);
+	border-bottom-left-radius: 8px;
+	border-bottom-right-radius: 8px;
 }
 
 .childless > .container {

--- a/src/ui/src/core_components/layout/CoreTabs.vue
+++ b/src/ui/src/core_components/layout/CoreTabs.vue
@@ -69,7 +69,6 @@ instanceData.at(-1).value = { activeTab: undefined };
 	border-radius: 8px;
 	box-shadow: var(--containerShadow);
 	border: 1px solid var(--separatorColor);
-	overflow: hidden;
 }
 
 .tabSelector {
@@ -89,6 +88,8 @@ instanceData.at(-1).value = { activeTab: undefined };
 
 .container {
 	background: var(--containerBackgroundColor);
+	border-bottom-left-radius: 8px;
+	border-bottom-right-radius: 8px;
 }
 
 .childless > .container {


### PR DESCRIPTION
`CoreSelect` displays a dropdown which is cropped by `overflow: hidden`. Removing this CSS rule prevent that

closes #380

https://github.com/user-attachments/assets/395cc4f2-bd39-4eb5-a234-24f3570a511b

