### PR TITLE
fix(ui): avoid builder `textarea` H resizable. WF-40

### DIFF
--- a/src/ui/src/builder/BuilderFieldsObject.vue
+++ b/src/ui/src/builder/BuilderFieldsObject.vue
@@ -2,7 +2,7 @@
 	<BuilderTemplateInput
 		class="BuilderFieldsObject"
 		:data-automation-key="props.fieldKey"
-		multiline="true"
+		multiline
 		variant="code"
 		:value="component.content[fieldKey]"
 		:placeholder="templateField.placeholder"

--- a/src/ui/src/builder/BuilderFieldsText.vue
+++ b/src/ui/src/builder/BuilderFieldsText.vue
@@ -16,7 +16,7 @@
 		</template>
 		<template v-else-if="templateField.control == FieldControl.Textarea">
 			<BuilderTemplateInput
-				multiline="true"
+				multiline
 				variant="text"
 				class="content"
 				:value="component.content[fieldKey]"

--- a/src/ui/src/builder/BuilderTemplateInput.vue
+++ b/src/ui/src/builder/BuilderTemplateInput.vue
@@ -39,6 +39,7 @@
 				autocorrect="off"
 				autocomplete="off"
 				spellcheck="false"
+				rows="3"
 				:placeholder="props.placeholder"
 				@input="handleInput"
 			></textarea>
@@ -236,5 +237,9 @@ const handleBlur = () => {
 
 .fieldStateAutocompleteOption:hover {
 	background-color: var(--builderSubtleHighlightColorSolid);
+}
+
+textarea {
+	resize: vertical;
 }
 </style>


### PR DESCRIPTION
Fix small regression from https://github.com/writer/writer-framework/pull/383 which removed the `resize` CSS rule on `<textarea>`.

Also increase a bit the default height of textarea to 3 rows (default is 2) 

https://github.com/user-attachments/assets/9bed78f3-1e06-40bf-b141-ef8d2a999db9

