### PR TITLE
feat(ui): add filter to `BuilderSidebarToolbar`. WF-42

### DIFF
--- a/src/ui/src/builder/BuilderSidebarTitleSearch.vue
+++ b/src/ui/src/builder/BuilderSidebarTitleSearch.vue
@@ -1,0 +1,99 @@
+<template>
+	<div v-if="isSearchActive" class="BuilderSidebarTitleSearch">
+		<input
+			ref="searchInput"
+			v-model="searchQuery"
+			type="text"
+			placeholder="Search..."
+		/>
+		<slot />
+		<i
+			:class="{ disabled: disabled }"
+			class="searchIcon material-symbols-outlined"
+			title="Close"
+			tabindex="0"
+			@keydown.enter="toggleSearch"
+			@click="toggleSearch"
+		>
+			close
+		</i>
+	</div>
+	<div v-else class="BuilderSidebarTitleSearch">
+		<i class="material-symbols-outlined">{{ icon }}</i>
+		<h3>{{ title }}</h3>
+		<i
+			title="Search"
+			class="searchIcon material-symbols-outlined"
+			tabindex="0"
+			@keydown.enter="toggleSearch"
+			@click="toggleSearch"
+		>
+			search
+		</i>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { nextTick, ref, Ref } from "vue";
+
+defineProps({
+	icon: { type: String, required: true },
+	title: { type: String, required: true },
+	disabled: { type: Boolean, required: false },
+});
+
+const searchQuery = defineModel({ type: String, default: "" });
+
+defineEmits({});
+
+const searchInput: Ref<HTMLInputElement> = ref(null);
+const isSearchActive: Ref<boolean> = ref(false);
+
+async function toggleSearch() {
+	isSearchActive.value = !isSearchActive.value;
+	if (isSearchActive.value) {
+		await nextTick();
+		searchInput.value.focus();
+	} else {
+		searchQuery.value = "";
+	}
+}
+</script>
+
+<style scoped>
+@import "./sharedStyles.css";
+
+.BuilderSidebarTitleSearch {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	font-size: 1rem;
+
+	background: var(--builderBackgroundColor);
+	padding: 16px;
+	top: 0;
+	position: sticky;
+	font-size: 1rem;
+}
+
+.BuilderSidebarTitleSearch h3 {
+	font-weight: 500;
+	font-size: 0.875rem;
+	flex-grow: 1;
+}
+
+.BuilderSidebarTitleSearch .searchIcon {
+	cursor: pointer;
+}
+
+.BuilderSidebarTitleSearch .searchIcon.disabled {
+	color: var(--builderDisabledColor);
+}
+
+.BuilderSidebarTitleSearch input {
+	outline: 0;
+	border: 0;
+	flex-grow: 1;
+	width: 50%;
+}
+</style>

--- a/src/ui/src/builder/BuilderSidebarTree.vue
+++ b/src/ui/src/builder/BuilderSidebarTree.vue
@@ -1,23 +1,11 @@
 <template>
 	<div class="BuilderSidebarTree">
-		<div v-if="!isSearchActive" class="sectionTitle">
-			<i class="material-symbols-outlined"> account_tree </i>
-			<h3>Component Tree</h3>
-			<i
-				title="Search"
-				class="searchIcon material-symbols-outlined"
-				@click="toggleSearch"
-			>
-				search
-			</i>
-		</div>
-		<div v-if="isSearchActive" class="sectionTitle">
-			<input
-				ref="searchInput"
-				v-model="searchQuery"
-				type="text"
-				placeholder="Search..."
-			/>
+		<BuilderSidebarTitleSearch
+			v-model="searchQuery"
+			title="Component Tree"
+			icon="account_tree"
+			:disabled="!matchAvailable"
+		>
 			<i
 				:class="{ disabled: !matchAvailable }"
 				class="searchIcon material-symbols-outlined"
@@ -26,6 +14,8 @@
 						? `Go to match ${previousMatchIndex + 1} of ${matchingComponents.length}`
 						: `Previous match`
 				"
+				tabindex="0"
+				@keydown.enter="goToPreviousMatch"
 				@click="goToPreviousMatch"
 			>
 				navigate_before
@@ -38,19 +28,13 @@
 						? `Go to match ${nextMatchIndex + 1} of ${matchingComponents.length}`
 						: `Next match`
 				"
+				tabindex="0"
+				@keydown.enter="goToNextMatch"
 				@click="goToNextMatch"
 			>
 				navigate_next
 			</i>
-			<i
-				:class="{ disabled: !matchAvailable }"
-				class="searchIcon material-symbols-outlined"
-				title="Close"
-				@click="toggleSearch"
-			>
-				close
-			</i>
-		</div>
+		</BuilderSidebarTitleSearch>
 		<div ref="componentTree" class="components">
 			<div
 				v-for="component in rootComponents"
@@ -79,6 +63,7 @@ import BuilderTreeBranch from "./BuilderTreeBranch.vue";
 import injectionKeys from "../injectionKeys";
 import { Component } from "../writerTypes";
 import { watch } from "vue";
+import BuilderSidebarTitleSearch from "./BuilderSidebarTitleSearch.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -86,23 +71,11 @@ const ssbm = inject(injectionKeys.builderManager);
 const { createAndInsertComponent, goToComponentParentPage } =
 	useComponentActions(wf, ssbm);
 
-const searchInput: Ref<HTMLInputElement> = ref(null);
-const isSearchActive: Ref<boolean> = ref(false);
 const searchQuery: Ref<string> = ref(null);
 const matchIndex: Ref<number> = ref(-1);
 const rootComponents = computed(() => {
 	return wf.getComponents(null, { sortedByPosition: true });
 });
-
-async function toggleSearch() {
-	isSearchActive.value = !isSearchActive.value;
-	if (isSearchActive.value) {
-		await nextTick();
-		searchInput.value.focus();
-	} else {
-		searchQuery.value = null;
-	}
-}
 
 function determineMatch(component: Component, query: string): boolean {
 	if (component.id.toLocaleLowerCase().includes(query)) return true;
@@ -158,7 +131,6 @@ function goToNextMatch() {
 }
 
 const matchingComponents: ComputedRef<Component[]> = computed(() => {
-	if (!isSearchActive.value) return;
 	if (!searchQuery.value) return;
 	const query = searchQuery.value.toLocaleLowerCase();
 	const components = wf.getComponents();
@@ -192,33 +164,8 @@ async function addPage() {
 	flex-direction: column;
 }
 
-.sectionTitle {
-	background: var(--builderBackgroundColor);
-	padding: 16px;
-	top: 0;
-	position: sticky;
-	font-size: 1rem;
-}
-
-.sectionTitle h3 {
-	font-weight: 500;
-	font-size: 0.875rem;
-	flex-grow: 1;
-}
-
-.sectionTitle .searchIcon {
-	cursor: pointer;
-}
-
-.sectionTitle .searchIcon.disabled {
+.searchIcon.disabled {
 	color: var(--builderDisabledColor);
-}
-
-.sectionTitle input {
-	outline: 0;
-	border: 0;
-	flex-grow: 1;
-	width: 50%;
 }
 
 .components {

--- a/tests/e2e/tests/sidebar.spec.ts
+++ b/tests/e2e/tests/sidebar.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("sidebar", () => {
+	let url: string;
+
+	test.beforeAll(async ({ request }) => {
+		const response = await request.post(`/preset/empty_page`);
+		expect(response.ok()).toBeTruthy();
+		({ url } = await response.json());
+	});
+
+	test.afterAll(async ({ request }) => {
+		await request.delete(url);
+	});
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto(url);
+		test.setTimeout(5000);
+	});
+
+	test.describe("Toolkit", () => {
+		test("should filter", async ({ page }) => {
+			// click on icon to begin search
+			await page
+				.locator(
+					`.BuilderSidebarToolbar .BuilderSidebarTitleSearch i[title="Search"]`,
+				)
+				.click();
+
+			// search a button
+			await page
+				.locator(`.BuilderSidebarToolbar .BuilderSidebarTitleSearch input`)
+				.fill("button");
+
+			// should have only one result
+			expect(
+				await page.locator(`.BuilderSidebarToolbar .component`).count(),
+			).toBe(1);
+
+			// close search
+			await page
+				.locator(
+					`.BuilderSidebarToolbar .BuilderSidebarTitleSearch i[title="Close"]`,
+				)
+				.click();
+
+			// should reset the search
+			expect(
+				await page.locator(`.BuilderSidebarToolbar .component`).count(),
+			).not.toBe(1);
+		});
+
+		test("should be compatible with keyboard navigation", async ({ page }) => {
+			// click on icon to begin search
+			await page
+				.locator(
+					`.BuilderSidebarToolbar .BuilderSidebarTitleSearch i[title="Search"]`,
+				)
+				.click();
+
+			// search a button
+			await page
+				.locator(`.BuilderSidebarToolbar .BuilderSidebarTitleSearch input`)
+				.fill("button");
+
+			// should have only one result
+			expect(
+				await page.locator(`.BuilderSidebarToolbar .component`).count(),
+			).toBe(1);
+
+			await page.keyboard.press("Tab");
+			await page.keyboard.press("Enter");
+
+			// should reset the search
+			expect(
+				await page.locator(`.BuilderSidebarToolbar .component`).count(),
+			).not.toBe(1);
+		});
+	});
+});


### PR DESCRIPTION
I introduced a component named `BuilderSidebarTitleSearch` which extract the existing search logic of `BuilderSidebarTree` and use it for `BuilderSidebarToolbar`.

I also took the opportunity to improve the accessibility since we use `<i>` elements as button, but they're not focusable and clickable with the keyboard.

And finally, I introduced an E2E test which cover the new feature.

https://github.com/user-attachments/assets/21771c20-02db-4a43-a27a-be11632fb209

