### PR TITLE
fix: npm run custom.dev run dev server instead of custom.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"dev": "npm run -w writer-ui dev",
 		"storybook": "npm run -w writer-ui storybook",
 		"storybook.build": "npm run -w writer-ui storybook.build",
-		"custom.dev": "npm run -w writer-ui dev",
+		"custom.dev": "npm run -w writer-ui custom.dev",
 
 		"cli:test": "pytest tests -o log_cli=true ",
 		"cli:lint": "mypy ./src/writer --exclude app_templates/* && ruff check",

--- a/src/ui/vite.config.custom.ts
+++ b/src/ui/vite.config.custom.ts
@@ -46,6 +46,7 @@ export default defineConfig({
 		},
 	},
 	server: {
+		port: 5174,
 		proxy: {
 			"/api": {
 				target: "http://127.0.0.1:5000",


### PR DESCRIPTION
fix #518

I set the port to match the one specified in the documentation.

![image](https://github.com/user-attachments/assets/70a3dccd-cc4f-4ceb-97c1-ba6793ef2bc5)
---