### PR TITLE
feat: Feature flags

### DIFF
--- a/apps/hello/main.py
+++ b/apps/hello/main.py
@@ -8,6 +8,9 @@ from writer.core import WriterState
 
 # EVENT HANDLERS
 
+wf.Config.feature_flags.append("dog")
+wf.Config.feature_flags.append("duck")
+
 def handle_timer_tick(state: WriterState):
     df = state["random_df"]
     for i in range(5):

--- a/apps/hello/main.py
+++ b/apps/hello/main.py
@@ -8,9 +8,6 @@ from writer.core import WriterState
 
 # EVENT HANDLERS
 
-wf.Config.feature_flags.append("dog")
-wf.Config.feature_flags.append("duck")
-
 def handle_timer_tick(state: WriterState):
     df = state["random_df"]
     for i in range(5):

--- a/src/ui/src/builder/BuilderHeader.vue
+++ b/src/ui/src/builder/BuilderHeader.vue
@@ -82,16 +82,29 @@ const animate = () => {
 };
 
 const syncHealthStatus = () => {
+	let s = "";
+	const featureFlags = wf.getFeatureFlags();
+
 	switch (wf.syncHealth.value) {
 		case "offline":
-			return "Offline. Not syncing.";
+			s += "Offline. Not syncing.";
+			break;
 		case "connected":
-			return "Online. Syncing...";
+			s += "Online. Syncing...";
+			break;
 		case "idle":
-			return "Sync not initialised.";
+			s += "Sync not initialised.";
+			break;
 		case "suspended":
-			return "Sync suspended.";
+			s += "Sync suspended.";
+			break;
 	}
+
+	if (featureFlags.length > 0) {
+		s += ` Feature flags: ${featureFlags.join(", ")}`;
+	}
+
+	return s;
 };
 
 function showStateExplorer() {

--- a/src/ui/src/builder/BuilderHeader.vue
+++ b/src/ui/src/builder/BuilderHeader.vue
@@ -83,8 +83,6 @@ const animate = () => {
 
 const syncHealthStatus = () => {
 	let s = "";
-	const featureFlags = wf.getFeatureFlags();
-
 	switch (wf.syncHealth.value) {
 		case "offline":
 			s += "Offline. Not syncing.";
@@ -100,8 +98,8 @@ const syncHealthStatus = () => {
 			break;
 	}
 
-	if (featureFlags.length > 0) {
-		s += ` Feature flags: ${featureFlags.join(", ")}`;
+	if (wf.featureFlags.value.length > 0) {
+		s += ` Feature flags: ${wf.featureFlags.value.join(", ")}`;
 	}
 
 	return s;

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -24,7 +24,7 @@ export function generateCore() {
 	let sessionId: string = null;
 	const sessionTimestamp: Ref<number> = ref(null);
 	const mode: Ref<"run" | "edit"> = ref(null);
-	const featureFlags: Ref<string[]> = ref([]);
+	const featureFlags = shallowRef<string[]>([]);
 	const runCode: Ref<string> = ref(null);
 	const components: Ref<ComponentMap> = ref({});
 	const userFunctions: Ref<UserFunction[]> = ref([]);

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -24,6 +24,7 @@ export function generateCore() {
 	let sessionId: string = null;
 	const sessionTimestamp: Ref<number> = ref(null);
 	const mode: Ref<"run" | "edit"> = ref(null);
+	const featureFlags: Ref<string[]> = ref([]);
 	const runCode: Ref<string> = ref(null);
 	const components: Ref<ComponentMap> = ref({});
 	const userFunctions: Ref<UserFunction[]> = ref([]);
@@ -98,6 +99,7 @@ export function generateCore() {
 		collateMail(initData.mail);
 		sessionId = initData.sessionId;
 		sessionTimestamp.value = new Date().getTime();
+		featureFlags.value = initData.featureFlags;
 
 		// Only returned for edit (Builder) mode
 
@@ -567,6 +569,10 @@ export function generateCore() {
 		return userState.value;
 	}
 
+	function getFeatureFlags() {
+		return featureFlags.value;
+	}
+
 	const core = {
 		webSocket,
 		syncHealth,
@@ -594,6 +600,7 @@ export function generateCore() {
 		getSessionTimestamp,
 		getUserState,
 		isChildOf,
+		getFeatureFlags,
 	};
 
 	return core;

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -600,7 +600,7 @@ export function generateCore() {
 		getSessionTimestamp,
 		getUserState,
 		isChildOf,
-		getFeatureFlags,
+		featureFlags: readonly(featureFlags),
 	};
 
 	return core;

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ref, Ref } from "vue";
+import { readonly, ref, Ref, shallowRef } from "vue";
 import {
 	Component,
 	ComponentMap,
@@ -567,10 +567,6 @@ export function generateCore() {
 
 	function getUserState() {
 		return userState.value;
-	}
-
-	function getFeatureFlags() {
-		return featureFlags.value;
 	}
 
 	const core = {

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -150,7 +150,8 @@ class AppProcess(multiprocessing.Process):
             sessionId=session.session_id,
             mail=session.session_state.mail,
             components=session.session_component_tree.to_dict(),
-            userFunctions=self._get_user_functions()
+            userFunctions=self._get_user_functions(),
+            featureFlags=writer.Config.feature_flags
         )
 
         session.session_state.clear_mail()

--- a/src/writer/core.py
+++ b/src/writer/core.py
@@ -131,7 +131,7 @@ class Config:
     is_mail_enabled_for_log: bool = False
     mode: str = "run"
     logger: Optional[logging.Logger] = None
-    feature_flags = []
+    feature_flags: list[str] = []
 
 @dataclasses.dataclass
 class MutationSubscription:

--- a/src/writer/core.py
+++ b/src/writer/core.py
@@ -131,6 +131,7 @@ class Config:
     is_mail_enabled_for_log: bool = False
     mode: str = "run"
     logger: Optional[logging.Logger] = None
+    feature_flags = []
 
 @dataclasses.dataclass
 class MutationSubscription:

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -149,7 +149,8 @@ def get_asgi_app(
             mail=payload.mail,
             components=payload.components,
             userFunctions=payload.userFunctions,
-            extensionPaths=cached_extension_paths
+            extensionPaths=cached_extension_paths,
+            featureFlags=payload.featureFlags
         )
 
     def _get_edit_starter_pack(payload: InitSessionResponsePayload):
@@ -163,7 +164,8 @@ def get_asgi_app(
             components=payload.components,
             userFunctions=payload.userFunctions,
             runCode=run_code,
-            extensionPaths=cached_extension_paths
+            extensionPaths=cached_extension_paths,
+            featureFlags=payload.featureFlags
         )
 
     @app.get("/api/health")

--- a/src/writer/ss_types.py
+++ b/src/writer/ss_types.py
@@ -43,6 +43,7 @@ class InitResponseBody(BaseModel):
     components: Dict
     userFunctions: List[Dict]
     extensionPaths: List
+    featureFlags: List[str]
 
 
 class InitResponseBodyRun(InitResponseBody):
@@ -129,6 +130,7 @@ class InitSessionResponsePayload(BaseModel):
     mail: List
     userFunctions: List[Dict]
     components: Dict
+    featureFlags: List[str]
 
 
 class InitSessionResponse(AppProcessServerResponse):

--- a/tests/backend/test_serve.py
+++ b/tests/backend/test_serve.py
@@ -169,3 +169,19 @@ class TestServe:
         with fastapi.testclient.TestClient(asgi_app) as client:
             res = client.get("/probes/healthcheck")
             assert res.status_code == 404
+
+    def test_feature_flags(self):
+        """
+        This test verifies that feature flags are carried to the frontend.
+
+        """
+        asgi_app: fastapi.FastAPI = writer.serve.get_asgi_app(
+            test_app_dir, "run")
+        with fastapi.testclient.TestClient(asgi_app) as client:
+            res = client.post("/api/init", json={
+                "proposedSessionId": None
+            }, headers={
+                "Content-Type": "application/json"
+            })
+            feature_flags = res.json().get("featureFlags")
+            assert feature_flags == ["flag_one", "flag_two"]

--- a/tests/backend/testapp/main.py
+++ b/tests/backend/testapp/main.py
@@ -9,6 +9,8 @@ import plotly.express as px
 import writer as wf
 import writer.core
 
+writer.Config.feature_flags.append("flag_one")
+writer.Config.feature_flags.append("flag_two")
 
 @wf.middleware()
 def my_middleware(state):


### PR DESCRIPTION
This PR introduces a new feature, **feature flags**.

These are defined in `writer.Config.feature_flags` and carried to the frontend, shipped as part of the `init` package.

The main objective is to allow the development and beta testing of big features (like Workflows) without disrupting the release cycle.

This is a minimal implementation, if necessary, future development can include:
- Setting feature flags via CLI (CLI -> `AppRunner` -> `AppProcess` -> `writer.Config`)
- Filtering available components via feature flag