### PR TITLE
fix: custom stylesheet and js are not loaded after OIDC authentication

### DIFF
--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -132,7 +132,7 @@ class AppProcess(multiprocessing.Process):
 
         import writer
 
-        session = writer.session_manager.get_session(payload.proposedSessionId, restore_intial_mails=True)
+        session = writer.session_manager.get_session(payload.proposedSessionId, restore_initial_mail=True)
         if session is None:
             session = writer.session_manager.get_new_session(payload.cookies, payload.headers, payload.proposedSessionId)
 

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -132,9 +132,10 @@ class AppProcess(multiprocessing.Process):
 
         import writer
 
-        session = writer.session_manager.get_session(payload.proposedSessionId)
+        session = writer.session_manager.get_session(payload.proposedSessionId, restore_intial_mails=True)
         if session is None:
             session = writer.session_manager.get_new_session(payload.cookies, payload.headers, payload.proposedSessionId)
+
         if session is None:
             raise MessageHandlingException("Session rejected.")
 

--- a/src/writer/auth.py
+++ b/src/writer/auth.py
@@ -188,14 +188,14 @@ class Oidc(Auth):
         redirect_url = urljoin(self.host_url, self.callback_authorize)
         host_url_path = urlpath(self.host_url)
         callback_authorize_path = urljoin(host_url_path, self.callback_authorize)
-        asset_assets_path = urljoin(host_url_path, "assets")
+        static_assets_path = urljoin(host_url_path, "static")
 
         logger.debug(f"[auth] oidc - url redirect: {redirect_url}")
         logger.debug(f"[auth] oidc - endpoint authorize: {self.url_authorize}")
         logger.debug(f"[auth] oidc - endpoint token: {self.url_oauthtoken}")
         logger.debug(f"[auth] oidc - path: {host_url_path}")
         logger.debug(f"[auth] oidc - authorize path: {callback_authorize_path}")
-        logger.debug(f"[auth] oidc - asset path: {asset_assets_path}")
+        logger.debug(f"[auth] oidc - static asset path: {static_assets_path}")
         self.authlib = OAuth2Session(
             client_id=self.client_id,
             client_secret=self.client_secret,
@@ -211,7 +211,7 @@ class Oidc(Auth):
         async def oidc_middleware(request: Request, call_next):
             session = request.cookies.get('session')
 
-            if session is not None or request.url.path in [callback_authorize_path] or request.url.path.startswith(asset_assets_path):
+            if session is not None or request.url.path in [callback_authorize_path] or request.url.path.startswith(static_assets_path):
                 response: Response = await call_next(request)
                 return response
             else:

--- a/src/writer/core.py
+++ b/src/writer/core.py
@@ -1626,12 +1626,12 @@ class SessionManager:
         self.sessions[new_id] = new_session
         return new_session
 
-    def get_session(self, session_id: Optional[str], restore_intial_mails: bool = False) -> Optional[WriterSession]:
+    def get_session(self, session_id: Optional[str], restore_initial_mail: bool = False) -> Optional[WriterSession]:
         if session_id is None:
             return None
 
         session = self.sessions.get(session_id)
-        if session is not None and restore_intial_mails is True:
+        if session is not None and restore_initial_mail is True:
             session.session_state.mail = copy.copy(initial_state.mail)
 
         return session

--- a/src/writer/core.py
+++ b/src/writer/core.py
@@ -1622,16 +1622,19 @@ class SessionManager:
             new_id = self._generate_session_id()
         else:
             new_id = proposed_session_id
-        new_session = WriterSession(
-            new_id, cookies, headers)
+        new_session = WriterSession(new_id, cookies, headers)
         self.sessions[new_id] = new_session
         return new_session
 
-    def get_session(self, session_id: Optional[str]) -> Optional[WriterSession]:
+    def get_session(self, session_id: Optional[str], restore_intial_mails: bool = False) -> Optional[WriterSession]:
         if session_id is None:
             return None
 
-        return self.sessions.get(session_id)
+        session = self.sessions.get(session_id)
+        if session is not None and restore_intial_mails is True:
+            session.session_state.mail = copy.copy(initial_state.mail)
+
+        return session
 
     def _generate_session_id(self) -> str:
         return secrets.token_hex(SessionManager.TOKEN_SIZE_BYTES)
@@ -2552,4 +2555,4 @@ def _split_record_as_pandas_record_and_index(param: dict, index_columns: list) -
 state_serialiser = StateSerialiser()
 initial_state = WriterState()
 base_component_tree = core_ui.build_base_component_tree()
-session_manager = SessionManager()
+session_manager: SessionManager = SessionManager()


### PR DESCRIPTION
This resets the mails when the session is retrieved again in the initialization process. `/static` assets can be retrieved without authentication.

fix #535 