### PR TITLE
feat: Abstract components

### DIFF
--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ref, Ref } from "vue";
 import {
+	AbstractTemplate,
 	Component,
 	ComponentMap,
 	InstancePath,
@@ -11,6 +12,7 @@ import {
 import {
 	getSupportedComponentTypes,
 	getComponentDefinition,
+	registerAbstractComponentTemplate,
 } from "./templateMap";
 import * as typeHierarchy from "./typeHierarchy";
 import { auditAndFixComponents } from "./auditAndFix";
@@ -98,6 +100,7 @@ export function generateCore() {
 		collateMail(initData.mail);
 		sessionId = initData.sessionId;
 		sessionTimestamp.value = new Date().getTime();
+		loadAbstractTemplates(initData.abstractTemplates);
 
 		// Only returned for edit (Builder) mode
 
@@ -110,6 +113,16 @@ export function generateCore() {
 		const isFixApplied = auditAndFixComponents(initData.components);
 		if (!isFixApplied) return;
 		await sendComponentUpdate();
+	}
+
+	function loadAbstractTemplates(
+		abstractTemplates: Record<string, AbstractTemplate>,
+	) {
+		Object.entries(abstractTemplates ?? {}).forEach(
+			([type, abstractTemplate]) => {
+				registerAbstractComponentTemplate(type, abstractTemplate);
+			},
+		);
 	}
 
 	function getSessionTimestamp() {

--- a/src/ui/src/core/templateMap.ts
+++ b/src/ui/src/core/templateMap.ts
@@ -126,8 +126,6 @@ const templateMap = {
 
 const abstractTemplateMap: Record<string, AbstractTemplate> = {};
 
-templateMap["sectiondiff"] = CoreSection;
-
 if (WRITER_LIVE_CCT === "yes") {
 	/*
 	Assigns the components in custom_components to the template map,

--- a/src/ui/src/writerTypes.ts
+++ b/src/ui/src/writerTypes.ts
@@ -1,9 +1,9 @@
-import { generateCore } from "./core"
-import { generateBuilderManager } from "./builder/builderManager"
+import { generateCore } from "./core";
+import { generateBuilderManager } from "./builder/builderManager";
 
-export type Core = ReturnType<typeof generateCore>
+export type Core = ReturnType<typeof generateCore>;
 
-type ComponentId = string
+type ComponentId = string;
 
 /**
  * Basic building block of applications.
@@ -131,3 +131,8 @@ export type ComponentMap = Record<Component["id"], Component>;
 export type MailItem = { type: string; payload: Record<string, string> };
 
 export type UserFunction = { name: string; args: string[] };
+
+export type AbstractTemplate = {
+	baseType: string;
+	writer: WriterComponentDefinition;
+};

--- a/src/writer/abstract.py
+++ b/src/writer/abstract.py
@@ -1,0 +1,15 @@
+"""
+
+Abstract templates.
+
+They're used to register new component templates, based on existing frontend templates and a backend-provided component definition. 
+
+"""
+
+from typing import Dict
+from writer.ss_types import AbstractTemplate
+
+templates:Dict[str, AbstractTemplate]  = {}
+
+def register_abstract_template(type: str, abstract_template: AbstractTemplate):
+    templates[type] = abstract_template

--- a/src/writer/abstract.py
+++ b/src/writer/abstract.py
@@ -7,6 +7,7 @@ They're used to register new component templates, based on existing frontend tem
 """
 
 from typing import Dict
+
 from writer.ss_types import AbstractTemplate
 
 templates:Dict[str, AbstractTemplate]  = {}

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -20,7 +20,7 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import ValidationError
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
-from writer import VERSION
+from writer import VERSION, abstract
 from writer.app_runner import AppRunner
 from writer.ss_types import (
     AppProcessServerResponse,
@@ -149,7 +149,8 @@ def get_asgi_app(
             mail=payload.mail,
             components=payload.components,
             userFunctions=payload.userFunctions,
-            extensionPaths=cached_extension_paths
+            extensionPaths=cached_extension_paths,
+            abstractTemplates=abstract.templates
         )
 
     def _get_edit_starter_pack(payload: InitSessionResponsePayload):
@@ -163,7 +164,8 @@ def get_asgi_app(
             components=payload.components,
             userFunctions=payload.userFunctions,
             runCode=run_code,
-            extensionPaths=cached_extension_paths
+            extensionPaths=cached_extension_paths,
+            abstractTemplates=abstract.templates
         )
 
     @app.get("/api/health")

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -150,7 +150,7 @@ def get_asgi_app(
             components=payload.components,
             userFunctions=payload.userFunctions,
             extensionPaths=cached_extension_paths,
-            featureFlags=payload.featureFlags
+            featureFlags=payload.featureFlags,
             abstractTemplates=abstract.templates
         )
 
@@ -166,7 +166,7 @@ def get_asgi_app(
             userFunctions=payload.userFunctions,
             runCode=run_code,
             extensionPaths=cached_extension_paths,
-            featureFlags=payload.featureFlags
+            featureFlags=payload.featureFlags,
             abstractTemplates=abstract.templates
         )
 

--- a/src/writer/ss_types.py
+++ b/src/writer/ss_types.py
@@ -28,6 +28,11 @@ MessageType = Literal["sessionInit", "componentUpdate",
                       "event", "codeUpdate", "codeSave", "checkSession",
                       "keepAlive", "stateEnquiry", "setUserinfo", "stateContent"]
 
+
+class AbstractTemplate(BaseModel):
+    baseType: str
+    writer: Dict
+
 # Web server models
 
 
@@ -43,6 +48,7 @@ class InitResponseBody(BaseModel):
     components: Dict
     userFunctions: List[Dict]
     extensionPaths: List
+    abstractTemplates: Dict[str, AbstractTemplate]
 
 
 class InitResponseBodyRun(InitResponseBody):

--- a/tests/backend/test_serve.py
+++ b/tests/backend/test_serve.py
@@ -3,6 +3,7 @@ import mimetypes
 import fastapi
 import fastapi.testclient
 import pytest
+import writer.abstract
 import writer.serve
 from fastapi import FastAPI
 
@@ -169,3 +170,32 @@ class TestServe:
         with fastapi.testclient.TestClient(asgi_app) as client:
             res = client.get("/probes/healthcheck")
             assert res.status_code == 404
+
+    def test_abstract_components(self):
+        writer.abstract.register_abstract_template("sectiona", {
+            "baseType": "section",
+            "writer": {
+                "name": "Section A"
+            }
+        })
+        writer.abstract.register_abstract_template("columnb", {
+            "baseType": "column",
+            "writer": {
+                "description": "Cloned Column component"
+            }
+        })
+
+        asgi_app: fastapi.FastAPI = writer.serve.get_asgi_app(
+            test_app_dir, "run")
+
+        with fastapi.testclient.TestClient(asgi_app) as client:
+            res = client.post("/api/init", json={
+                "proposedSessionId": None
+            }, headers={
+                "Content-Type": "application/json"
+            })
+            abstract_templates = res.json().get("abstractTemplates")
+            section_a = abstract_templates.get("sectiona")
+            column_b = abstract_templates.get("columnb")
+            assert section_a.get("writer").get("name") == "Section A"
+            assert column_b.get("writer").get("description") == "Cloned Column component"

--- a/tests/backend/test_serve.py
+++ b/tests/backend/test_serve.py
@@ -193,11 +193,11 @@ class TestServe:
             }, headers={
                 "Content-Type": "application/json"
             })
-        abstract_templates = res.json().get("abstractTemplates")
-        section_a = abstract_templates.get("sectiona")
-        column_b = abstract_templates.get("columnb")
-        assert section_a.get("writer").get("name") == "Section A"
-        assert column_b.get("writer").get("description") == "Cloned Column component"
+            abstract_templates = res.json().get("abstractTemplates")
+            section_a = abstract_templates.get("sectiona")
+            column_b = abstract_templates.get("columnb")
+            assert section_a.get("writer").get("name") == "Section A"
+            assert column_b.get("writer").get("description") == "Cloned Column component"
           
     def test_feature_flags(self):
         """
@@ -212,5 +212,5 @@ class TestServe:
             }, headers={
                 "Content-Type": "application/json"
             })
-        feature_flags = res.json().get("featureFlags")
-        assert feature_flags == ["flag_one", "flag_two"]
+            feature_flags = res.json().get("featureFlags")
+            assert feature_flags == ["flag_one", "flag_two"]

--- a/tests/backend/test_serve.py
+++ b/tests/backend/test_serve.py
@@ -187,6 +187,12 @@ class TestServe:
 
         asgi_app: fastapi.FastAPI = writer.serve.get_asgi_app(
             test_app_dir, "run")
+        with fastapi.testclient.TestClient(asgi_app) as client:
+            res = client.post("/api/init", json={
+                "proposedSessionId": None
+            }, headers={
+                "Content-Type": "application/json"
+            })
         abstract_templates = res.json().get("abstractTemplates")
         section_a = abstract_templates.get("sectiona")
         column_b = abstract_templates.get("columnb")


### PR DESCRIPTION
As discussed, Abstract Templates allow users to specify a combination of `baseType` and `writer` (`WriterComponentDefintion`), to create a new component type that merges an existing Vue template with a new, backend-defined component definition.

The goal is to use this for Workflows, where "workflow node" will be a generic template and, for example, "Set state" will be defined from the backend, using "workflow node" as the base type.