### PR TITLE
fix: custom stylesheet and js are not loaded after OIDC authentication

### DIFF
--- a/docs/framework/authentication.mdx
+++ b/docs/framework/authentication.mdx
@@ -9,6 +9,10 @@ The Writer Framework authentication module allows you to restrict access to your
   trigger authentication for certain pages exclusively.
 </Warning>
 
+<Warning>
+  Static assets from Writer Framework exposed through `/static` and `/extensions` endpoints are not protected behind Authentication.
+</Warning>
+
 ## Use Basic Auth
 
 Basic Auth is a simple authentication method that uses a username and password. Authentication configuration is done in the [server_setup.py module](/framework/custom-server).
@@ -133,6 +137,21 @@ writer.serve.register_auth(oidc)
 ### Authentication workflow
 
 <img src="/framework/images/authentication_oidc.png" />
+
+### App static assets
+
+Static assets in your application are inaccessible. You can use the `app_static_public` parameter to allow their usage.
+When `app_static_public` is set to `True`, the static assets in your application are accessible without authentication.
+
+```python
+oidc = writer.auth.Auth0(
+	client_id="xxxxxxx",
+	client_secret="xxxxxxxxxxxxx",
+	domain="xxx-xxxxx.eu.auth0.com",
+	host_url=os.getenv('HOST_URL', "http://localhost:5000"),
+	app_static_public=True
+)
+```
 
 ## User information in event handler
 

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -9,7 +9,7 @@ import textwrap
 import typing
 from contextlib import asynccontextmanager
 from importlib.machinery import ModuleSpec
-from typing import Any, Callable, Dict, List, Optional, Set, Union, cast
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Union, cast
 from urllib.parse import urlsplit
 
 import uvicorn
@@ -593,7 +593,7 @@ def _mount_server_static_path(app: FastAPI, server_static_path: pathlib.Path) ->
     Writer Framework routes remain priority. A developer cannot come and overload them.
     """
     app.get('/')(lambda: FileResponse(server_static_path.joinpath('index.html')))
-    for f in server_static_path.glob('*'):
+    for f in wf_root_static_assets():
         if f.is_file():
             app.get(f"/{f.name}")(lambda: FileResponse(f))
         if f.is_dir():
@@ -613,3 +613,22 @@ def _execute_server_setup_hook(user_app_path: str) -> None:
 
 def app_runner(asgi_app: WriterFastAPI) -> AppRunner:
     return asgi_app.state.app_runner
+
+
+def wf_root_static_assets() -> List[pathlib.Path]:
+    """
+    Lists the root writer Framework static assets. Some of them are files, some other are directories.
+
+    >>> for f in wf_root_static_assets()
+    >>>     print(f"{f.name}")
+    >>>     # favicon.ico
+    >>>     # assets
+
+    """
+    all_static_assets: List[pathlib.Path] = []
+    server_path = pathlib.Path(__file__)
+    server_static_path = server_path.parent / "static"
+    for f in server_static_path.glob('*'):
+        all_static_assets.append(f)
+
+    return all_static_assets


### PR DESCRIPTION
fix #535 

The problem was not fully solved, and worse, has broke the OIDC authentication mechanism. The access to /static url is blocked after user authentication. I fail to diagnose this issue because I was loading those assets through browser cache in local during my test.

![image](https://github.com/user-attachments/assets/d35aaafb-8861-4e94-acf2-f29d8533f1bc)

The problem is visible on [dev review environment](https://streamsync-dev.osc-fr1.scalingo.io/auth_oidc_auth0/). It is fixed on this [PR review environment](https://streamsync-dev-pr544.osc-fr1.scalingo.io/auth_oidc_auth0/).

---
* [x] load writer framework assets
* [x] load user assets into statics
* [x] load user extensions
