### PR TITLE
chore: docs generators run only for core components - WF-62

### DIFF
--- a/docs/codegen/generator_components_pages.mjs
+++ b/docs/codegen/generator_components_pages.mjs
@@ -27,7 +27,11 @@ export async function generate() {
 		fs.mkdirSync(componentsDirectory);
 	}
 
-	components.map((component) => {
+	components.forEach((component) => {
+		if ('toolkit' in component && component.toolkit !== 'core') {
+			return
+		}
+
 		// eslint-disable-next-line prettier/prettier
 		const componentPageTemplate = path.resolve(componentsDirectory, "component_page.mdx.tpl");
 		const page = fs.readFileSync(componentPageTemplate, "utf8");

--- a/src/ui/tools/generator_storybook.mjs
+++ b/src/ui/tools/generator_storybook.mjs
@@ -16,6 +16,7 @@ const IGNORE_COMPONENT_TYPES = [
 	"steps",
 	"html",
 	"repeater",
+	"workflowsnode",
 ];
 
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
* chore: run component generator only for core component
* chore: ignore workflowsnode into storybook