### PR TITLE
fix(ui): make `CoreSwitchInput` reactive to state change - WF-81

### DIFF
--- a/src/ui/src/components/core/input/CoreSwitchInput.vue
+++ b/src/ui/src/components/core/input/CoreSwitchInput.vue
@@ -7,10 +7,10 @@
 	>
 		<div
 			class="switch"
-			:class="{ on: toggleValue }"
+			:class="{ on: !!formValue }"
 			tabindex="0"
 			role="switch"
-			:aria-checked="toggleValue"
+			:aria-checked="!!formValue"
 			@click="handleToggle"
 			@keydown.enter.space.prevent="handleToggle"
 		>
@@ -29,7 +29,6 @@ import {
 	separatorColor,
 	cssClasses,
 } from "@/renderer/sharedStyleFields";
-import { onMounted } from "vue";
 import BaseInputWrapper from "../base/BaseInputWrapper.vue";
 import { ComponentPublicInstance } from "vue";
 
@@ -82,24 +81,15 @@ const { formValue, handleInput } = useFormValueBroker(
 	instancePath,
 	rootInstance,
 );
-const toggleValue = ref(false);
 
 function handleToggle() {
-	toggleValue.value = !toggleValue.value;
-	handleInput(toggleValue.value, "wf-toggle");
+	handleInput(!formValue.value, "wf-toggle");
 }
-
-onMounted(() => {
-	toggleValue.value = !!formValue.value;
-});
 </script>
 
 <style scoped>
 @import "@/renderer/sharedStyles.css";
 @import "@/renderer/colorTransformations.css";
-
-.CoreSwitchInput {
-}
 
 .switch {
 	background: var(--separatorColor);


### PR DESCRIPTION
We used a `ref` to store the state of the input and try to synchronize with `useFormValueBroker`. But in fact, there is no reason to do it since this method already use an optimistic update.

https://github.com/writer/writer-framework/blob/9f4af7b7f5c5bc247bc8174a900d6c98456ef529/src/ui/src/renderer/useFormValueBroker.ts#L47-L52

https://github.com/user-attachments/assets/9c19a653-708d-463d-a82c-4ac7d220925c

