### PR TITLE
feat: allow CLI to find a different port - WF-76

### DIFF
--- a/docs/framework/chat-assistant.mdx
+++ b/docs/framework/chat-assistant.mdx
@@ -49,7 +49,7 @@ Next, open your terminal and navigate to the directory where you want to create 
     This command sets up a new project called `chat-assistant` in the specified directory.
   </Step>
   <Step title="Edit your project">
-    To edit your project, run the below commands. This will bring up the console, where Framework-wide messages and errors will appear, including logs from the API. By default, the Writer Framework Builder is accessible at `localhost:3006`. If that port is in use, you can specify a different port. Open this address in your browser to view your default application setup.
+    To edit your project, run the below commands. This will bring up the console, where Framework-wide messages and errors will appear, including logs from the API. By default, the Writer Framework Builder is accessible at `localhost:4005`. If that port is in use, you can specify a different port. Open this address in your browser to view your default application setup.
 
     <CodeGroup>
     ```bash Standard port

--- a/docs/framework/product-description-generator.mdx
+++ b/docs/framework/product-description-generator.mdx
@@ -51,7 +51,7 @@ Next, open your terminal and navigate to the directory where you want to create 
     This command sets up a new project called `product-description-app` in the specified directory using a template designed for this tutorial.
   </Step>
   <Step title="Edit your project">
-    To edit your project, run the below commands. This will bring up the console, where Framework-wide messages and errors will appear, including logs from the API. By default, the Writer Framework Builder is accessible at `localhost:3006`. If that port is in use, you can specify a different port. Open this address in your browser to view your default application setup.
+    To edit your project, run the below commands. This will bring up the console, where Framework-wide messages and errors will appear, including logs from the API. By default, the Writer Framework Builder is accessible at `localhost:4005`. If that port is in use, you can specify a different port. Open this address in your browser to view your default application setup.
 
     <CodeGroup>
     ```bash Standard port
@@ -59,7 +59,7 @@ Next, open your terminal and navigate to the directory where you want to create 
     ```
 
     ```bash Custom port
-     writer edit product-description-app –port=3007
+     writer edit product-description-app --port=3007
     ```
     </CodeGroup>
   </Step>

--- a/docs/framework/quickstart-tutorial.mdx
+++ b/docs/framework/quickstart-tutorial.mdx
@@ -47,7 +47,7 @@ Once this is done, we can finally run the Framework editor using the command:
 writer edit .
 ```
 
-This will run our Framework instance. Runtime logs can be observed in the terminal, and the app is available at http://localhost:3006.
+This will run our Framework instance. Runtime logs can be observed in the terminal, and the app is available at http://localhost:4005.
 
 ![newly created application](./images/quickstart/new_app.png)
 

--- a/docs/framework/quickstart.mdx
+++ b/docs/framework/quickstart.mdx
@@ -61,6 +61,10 @@ It's not recommended to expose Framework to the Internet. If you need to access 
 If you need to disable this protection, use the flag `--enable-remote-edit`. 
 </Warning>
 
+<Info>
+The editor starts by default on port 4005. If you launch multiple editors in parallel and do not specify a port, Writer Framework will automatically assign the next port until reaching the limit of 4099.
+</Info>
+
 ## Run an app
 
 When your app is ready, execute the `run` command, which will allow others to run, but not edit, your Framework app.
@@ -68,6 +72,10 @@ When your app is ready, execute the `run` command, which will allow others to ru
 ```sh
 writer run my_app
 ```
+
+<Info>
+Your app starts by default on port 3005. If you launch multiple apps in parallel and do not specify a port, Writer Framework will automatically assign the next port until reaching the limit of 3099.
+</Info>
 
 You can specify a port and host. Specifying `--host 0.0.0.0` enables you to share your application in your local network.
 

--- a/docs/framework/release-notes-generator.mdx
+++ b/docs/framework/release-notes-generator.mdx
@@ -48,7 +48,7 @@ Next, open your terminal and navigate to the directory where you want to create 
     ```
   </Step>
   <Step title="Edit your project">
-    To edit your project, run the following commands. This will bring up the console, which displays Framework-wide messages and errors, including logs from the API. By default, the Writer Framework Builder is accessible at `localhost:3006`. If this port is in use, you can specify a different port. Open this address in your browser to view your default application setup.
+    To edit your project, run the following commands. This will bring up the console, which displays Framework-wide messages and errors, including logs from the API. By default, the Writer Framework Builder is accessible at `localhost:4005`. If this port is in use, you can specify a different port. Open this address in your browser to view your default application setup.
 
     <CodeGroup>
     ```bash Standard port

--- a/docs/framework/social-post-generator.mdx
+++ b/docs/framework/social-post-generator.mdx
@@ -51,7 +51,7 @@ Next, open your terminal and navigate to the directory where you want to create 
     This command will set up a new project called `social-generator` in the specified directory using an `ai-starter` template.
   </Step>
   <Step title="Edit project">
-    To edit your project, run the below commands. This will bring up the console, where Framework-wide messages and errors will appear, including logs from the API. By default, the Writer Framework Builder is accessible at `localhost:3006`. If that port is in use, you can specify a different port. Open this address in your browser to view your default application setup.
+    To edit your project, run the below commands. This will bring up the console, where Framework-wide messages and errors will appear, including logs from the API. By default, the Writer Framework Builder is accessible at `localhost:4005`. If that port is in use, you can specify a different port. Open this address in your browser to view your default application setup.
 
     <CodeGroup>
     ```bash Standard port
@@ -59,7 +59,7 @@ Next, open your terminal and navigate to the directory where you want to create 
     ```
 
     ```bash Custom port
-    writer edit social-generator –port=3007
+    writer edit social-generator --port=3007
     ```
     </CodeGroup>
   </Step>

--- a/src/writer/command_line.py
+++ b/src/writer/command_line.py
@@ -20,9 +20,9 @@ def main():
 
 @main.command()
 @click.option('--host', default="127.0.0.1", help="Host to run the app on")
-@click.option('--port', default=3005, help="Port to run the app on")
+@click.option('--port', default=None, help="Port to run the app on")
 @click.argument('path')
-def run(path, host, port):
+def run(path: str, host: str, port: Optional[int]):
     """Run the app from PATH folder in run mode."""
 
     abs_path = os.path.abspath(path)
@@ -34,11 +34,11 @@ def run(path, host, port):
 
 @main.command()
 @click.option('--host', default="127.0.0.1", help="Host to run the app on")
-@click.option('--port', default=3006, help="Port to run the app on")
+@click.option('--port', default=None, help="Port to run the app on")
 @click.option('--enable-remote-edit', help="Set this flag to allow non-local requests in edit mode.", is_flag=True)
 @click.option('--enable-server-setup', help="Set this flag to enable server setup hook in edit mode.", is_flag=True)
 @click.argument('path')
-def edit(path, port, host, enable_remote_edit, enable_server_setup):
+def edit(path: str, port: Optional[int], host: str, enable_remote_edit: bool, enable_server_setup: bool):
     """Run the app from PATH folder in edit mode."""
 
     abs_path = os.path.abspath(path)
@@ -63,9 +63,9 @@ def create(path, template):
 
 @main.command()
 @click.option('--host', default="127.0.0.1", help="Host to run the app on")
-@click.option('--port', default=3006, help="Port to run the app on")
+@click.option('--port', default=None, help="Port to run the app on")
 @click.option('--enable-remote-edit', help="Set this flag to allow non-local requests in edit mode.", is_flag=True)
-def hello(port, host, enable_remote_edit):
+def hello(port: Optional[int], host: str, enable_remote_edit):
     """Create and run an onboarding 'Hello' app."""
     create_app("hello", template_name="hello", overwrite=True)
     writer.serve.serve("hello", mode="edit",


### PR DESCRIPTION
implement #567 

### writer run

![image](https://github.com/user-attachments/assets/00e97f1b-88c6-4a08-845a-d3374b7b604a)

### writer edit

![image](https://github.com/user-attachments/assets/6b75d1d3-2cfc-45a5-80c7-d13a1dd05f06)

### does not look for the next port when port is set manually

![image](https://github.com/user-attachments/assets/d46bc96d-3f76-4a16-8f7b-a5734ee9f91d)
