### PR TITLE
fix(ui): force auto with inside `CoreHorizontalStack` - WF-58

### DIFF
--- a/src/ui/src/components/core/layout/CoreHorizontalStack.vue
+++ b/src/ui/src/components/core/layout/CoreHorizontalStack.vue
@@ -54,4 +54,8 @@ const fields = inject(injectionKeys.evaluatedFields);
 	width: 100%;
 	flex-wrap: wrap;
 }
+.CoreHorizontalStack > ::v-deep(*) {
+	/* override `width: 100%` of child elements to force horizontal stack */
+	width: auto !important;
+}
 </style>


### PR DESCRIPTION
Some components are using `width: 100%` which make them not stackable in horizontal mode. I just force them to `width: auto` when they are direct child of `CoreHorizontalStack`.

Closes #382