### PR TITLE
feat(ui): add allow file type for `CoreFileInput` - WF-41

### DIFF
--- a/src/ui/src/components/core/input/CoreFileInput.vue
+++ b/src/ui/src/components/core/input/CoreFileInput.vue
@@ -11,6 +11,7 @@
 					ref="fileEl"
 					type="file"
 					:multiple="allowMultipleFilesFlag"
+					:accept="allowFileTypes"
 					@change="fileChange($event as InputEvent)"
 				/>
 				<div>
@@ -80,6 +81,18 @@ export default {
 				init: "Input Label",
 				type: FieldType.Text,
 			},
+			allowFileTypes: {
+				name: "Allowed file types",
+				type: FieldType.Text,
+				init: [
+					".pdf",
+					".txt",
+					".doc",
+					"application/msword",
+					"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+				].join(", "),
+				desc: "Provides hints for browsers to select the correct file types. You can specify the extension or the MIME type, separated by comma.",
+			},
 			allowMultipleFiles: {
 				name: "Allow multiple files",
 				default: "no",
@@ -128,6 +141,8 @@ const { formValue, handleInput } = useFormValueBroker(
 const selectedFiles = computed<SavedFile[]>(() =>
 	Array.isArray(formValue.value) ? formValue.value : [],
 );
+
+const allowFileTypes = computed(() => fields.allowFileTypes?.value ?? "");
 
 const allowMultipleFilesFlag = computed(() => {
 	return fields.allowMultipleFiles.value == "yes" ? true : undefined;


### PR DESCRIPTION
Just introduce a field for the HTML attribute
[`accept`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#limiting_accepted_file_types) input file.

![image](https://github.com/user-attachments/assets/1dee5f76-f6bb-4773-951b-139b7b40e3c3)
