### PR TITLE
fix(ui): adapt cursor of `CoreText` if attached click event - WF-59

### DIFF
--- a/src/ui/src/components/core/content/CoreText.vue
+++ b/src/ui/src/components/core/content/CoreText.vue
@@ -100,7 +100,8 @@ const shouldDisplay = computed(() => !isEmpty.value || isBeingEdited.value);
 
 const rootStyle = computed(() => {
 	const component = wf.getComponentById(componentId);
-	const isClickHandled = typeof component.handlers?.["click"] !== "undefined";
+	const isClickHandled =
+		typeof component.handlers?.["wf-click"] !== "undefined";
 
 	return {
 		cursor: isClickHandled ? "pointer" : "unset",


### PR DESCRIPTION
Very minor fix, cursor (which changes depending on whether the text is clickable) needs fixing because the event is no longer called `click` it’s called `wf-click`.