### PR TITLE
chore: serialize tool calls messages with non-empty content

### DIFF
--- a/src/writer/ai.py
+++ b/src/writer/ai.py
@@ -1817,7 +1817,8 @@ class Conversation:
         """
         Function to verify whether the message should be serializable.
 
-        :return: Boolean that indicates
+        :return: Boolean indicating if the message meets 
+        the criteria for serialization.
         """
         if message["role"] in ["system", "tool"]:
             # Prevent serialization of messages

--- a/src/writer/ai.py
+++ b/src/writer/ai.py
@@ -1824,7 +1824,18 @@ class Conversation:
         elif message.get("tool_call_id") is not None:
             return False
         tool_calls = message.get("tool_calls")
-        if tool_calls is not None and tool_calls != []:
+        if (
+            (
+                tool_calls is not None
+                and
+                tool_calls != []
+            )
+            and
+            not message.get("content")
+        ):
+            # If tool call request message
+            # doesn't have meaningful content,
+            # we don't serialize it
             return False
 
         return True

--- a/src/writer/ai.py
+++ b/src/writer/ai.py
@@ -1824,7 +1824,7 @@ class Conversation:
             # Prevent serialization of messages
             # not intended for user display
             return False
-        elif message.get("content") is None:
+        elif not message.get("content"):
             # Prevent serialization for messages
             # without meaningful content
             return False

--- a/src/writer/ai.py
+++ b/src/writer/ai.py
@@ -1820,22 +1820,12 @@ class Conversation:
         :return: Boolean that indicates
         """
         if message["role"] in ["system", "tool"]:
+            # Prevent serialization of messages
+            # not intended for user display
             return False
-        elif message.get("tool_call_id") is not None:
-            return False
-        tool_calls = message.get("tool_calls")
-        if (
-            (
-                tool_calls is not None
-                and
-                tool_calls != []
-            )
-            and
-            not message.get("content")
-        ):
-            # If tool call request message
-            # doesn't have meaningful content,
-            # we don't serialize it
+        elif message.get("content") is None:
+            # Prevent serialization for messages
+            # without meaningful content
             return False
 
         return True


### PR DESCRIPTION
Enable serialization for messages that contain `tool_calls` but have non-empty `content` – in cases when model generates both `content` and `tool_calls` without separation.