### PR TITLE
feat(ui): add an option `hideRoot` for `CoreJsonViewer` - WF-104

### DIFF
--- a/src/ui/src/components/core/content/CoreJsonViewer.vue
+++ b/src/ui/src/components/core/content/CoreJsonViewer.vue
@@ -4,6 +4,7 @@
 			:data="data ?? {}"
 			:initial-depth="initialDepth"
 			:enable-copy-to-json="fields.copy.value === 'yes'"
+			:hide-root="fields.hideRoot.value === 'yes'"
 		/>
 	</div>
 </template>
@@ -53,6 +54,17 @@ const definition: WriterComponentDefinition = {
 			desc: "Sets the initial viewing depth of the JSON tree hierarchy. Use -1 to display the full hierarchy.",
 			type: FieldType.Number,
 			init: "0",
+		},
+		hideRoot: {
+			name: "Hide root",
+			desc: "Don't show the type of the root node when it's an Object or an Array.",
+			type: FieldType.Text,
+			options: {
+				yes: "yes",
+				no: "no",
+			},
+			default: "no",
+			category: FieldCategory.Style,
 		},
 		copy: {
 			name: "Copy",

--- a/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewer.vue
+++ b/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewer.vue
@@ -65,6 +65,10 @@ const props = defineProps({
 		type: Array as PropType<JsonPath>,
 		default: () => [],
 	},
+	hideRoot: {
+		type: Boolean,
+		required: false,
+	},
 	initialDepth: { type: Number, default: 0 },
 	enableCopyToJson: { type: Boolean, required: false },
 });
@@ -73,7 +77,7 @@ defineEmits({
 	toggle: jsonViewerToggleEmitDefinition,
 });
 
-const isRoot = computed(() => props.path.length === 0);
+const isRoot = computed(() => props.path.length === 0 && !props.hideRoot);
 const isRootOpen = computed(
 	() => props.initialDepth === -1 || props.initialDepth > 0,
 );


### PR DESCRIPTION
Add an option to not show the type of the root node when it's an Object or an Array.

https://github.com/user-attachments/assets/830ce2e2-abad-42f5-bed2-a3b29e8f898b

