### PR TITLE
fix: register `set_token` mark to avoid pytest warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     explicit: mark a test to be run only when explicitly specified
+    set_token: provides a Writer API token mock for the test


### PR DESCRIPTION
The warnings issued by pytest were present because `set_token` mark, used in `test_ai.py` to mock Writer API token, was not registered properly. This fix addresses that.