### PR TITLE
chore: increase github action runner size

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     strategy:
       matrix:
         browser: [ "chromium", "firefox", "webkit" ]
-    steps: 
+    steps:
       - uses: actions/checkout@v4
 
       - name: Install poetry

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-latest-large
     strategy:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]


### PR DESCRIPTION
github actions runners sometimes failed due to lack of memory. Activation of superior runner for end 2 ends tests and for tests on macos.