### PR TITLE
feat(ui): use design system in builder - WF-127

### DIFF
--- a/src/ui/src/builder/BuilderModal.vue
+++ b/src/ui/src/builder/BuilderModal.vue
@@ -1,7 +1,12 @@
 <!-- eslint-disable @typescript-eslint/ban-types -->
 <template>
 	<Teleport to="#modal">
-		<div class="BuilderModal" tabindex="-1" @keydown="handleKeydown">
+		<div
+			class="BuilderModal"
+			:class="{ 'BuilderModal--overflow': allowOverflow }"
+			tabindex="-1"
+			@keydown="handleKeydown"
+		>
 			<div class="main">
 				<div class="titleContainer">
 					<i v-if="icon" class="material-symbols-outlined">{{
@@ -38,19 +43,24 @@
 
 <script setup lang="ts">
 import WdsButton from "@/wds/WdsButton.vue";
-import { toRefs } from "vue";
+import { PropType, toRefs } from "vue";
 
 export type ModalAction = {
 	desc: string;
 	fn: (..._args: unknown[]) => unknown;
 };
 
-const props = defineProps<{
-	modalTitle: string;
-	icon?: string;
-	closeAction: ModalAction;
-	menuActions?: ModalAction[];
-}>();
+const props = defineProps({
+	modalTitle: { type: String, required: true },
+	icon: { type: String, required: false, default: undefined },
+	closeAction: { type: Object as PropType<ModalAction>, required: true },
+	menuActions: {
+		type: Array as PropType<ModalAction[]>,
+		required: false,
+		default: undefined,
+	},
+	allowOverflow: { type: Boolean, required: false },
+});
 
 const { modalTitle, icon, closeAction, menuActions } = toRefs(props);
 
@@ -82,6 +92,10 @@ const handleKeydown = (ev: KeyboardEvent) => {
 	box-shadow: 0px 3px 40px 0px rgba(172, 185, 220, 0.4);
 }
 
+.BuilderModal--overflow .main {
+	overflow: unset;
+}
+
 .titleContainer {
 	border-bottom: 1px solid var(--builderSubtleSeparatorColor);
 	padding: 8px 8px 8px 16px;
@@ -99,6 +113,9 @@ const handleKeydown = (ev: KeyboardEvent) => {
 	padding: 16px;
 	max-height: 60vh;
 	overflow: auto;
+}
+.BuilderModal--overflow .slotContainer {
+	overflow: unset;
 }
 
 .actionContainer {

--- a/src/ui/src/builder/BuilderSelect.vue
+++ b/src/ui/src/builder/BuilderSelect.vue
@@ -1,9 +1,5 @@
 <template>
-	<div
-		ref="trigger"
-		class="BuilderSelect"
-		:class="{ 'BuilderSelect--embedded': variant === 'embedded' }"
-	>
+	<div ref="trigger" class="BuilderSelect">
 		<button
 			class="BuilderSelect__trigger"
 			role="button"
@@ -57,14 +53,6 @@ const props = defineProps({
 	defaultIcon: { type: String, required: false, default: undefined },
 	hideIcons: { type: Boolean, required: false },
 	enableSearch: { type: Boolean, required: false },
-	/**
-	 * Customize the appareance of the selector.
-	 * In embeded mode, we remove the padding and the border around the trigger. Usefull when the selector is embed into a field wrapper.
-	 */
-	variant: {
-		type: String as PropType<"normal" | "embedded">,
-		default: "normal",
-	},
 });
 
 const currentValue = defineModel({ type: String, required: false });
@@ -125,26 +113,23 @@ function onSelect(value: string) {
 
 .BuilderSelect__trigger {
 	display: flex;
-	height: 32px;
-	width: 100%;
-
+	align-items: center;
 	gap: 8px;
 
-	align-items: center;
-	padding: 8px;
+	height: 40px;
+	width: 100%;
+	padding: 8.5px 12px 8.5px 12px;
+
+	border: 1px solid var(--separatorColor);
+	border-radius: 8px;
+
 	font-weight: 400;
-	color: #3b3b3b;
-	background: #ffffff;
-}
+	font-size: 0.875rem;
 
-.BuilderSelect__trigger {
-	/* reset button */
-	border: none;
+	color: var(--primaryTextColor);
+	background: transparent;
+
 	cursor: pointer;
-
-	font-size: 0.75rem;
-	display: flex;
-	align-items: center;
 }
 .BuilderSelect__trigger__label {
 	text-overflow: ellipsis;
@@ -161,10 +146,5 @@ function onSelect(value: string) {
 	font-weight: 300;
 	color: #000000e6;
 	cursor: pointer;
-}
-
-.BuilderSelect--embedded .BuilderSelect__trigger {
-	padding: 0;
-	height: 18px;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderFieldsAlign.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsAlign.vue
@@ -264,12 +264,9 @@ onBeforeUnmount(() => {
 @import "../sharedStyles.css";
 
 .chipStackContainer {
-	padding: 12px;
 	margin-top: 4px;
-	padding-bottom: 12px;
 }
 .main {
-	border-top: 1px solid var(--builderSeparatorColor);
-	padding: 12px;
+	margin-top: 4px;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderFieldsAlign.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsAlign.vue
@@ -5,39 +5,11 @@
 		tabindex="-1"
 		:data-automation-key="props.fieldKey"
 	>
-		<div class="chipStackContainer">
-			<div class="chipStack">
-				<button
-					class="chip"
-					tabindex="0"
-					:class="{ active: mode == 'default' }"
-					@click="
-						() => {
-							setMode('default');
-							setContentValue(component.id, fieldKey, undefined);
-						}
-					"
-				>
-					Default
-				</button>
-				<button
-					class="chip"
-					tabindex="0"
-					:class="{ active: mode == 'css' }"
-					@click="setMode('css')"
-				>
-					CSS
-				</button>
-				<button
-					class="chip"
-					:class="{ active: mode == 'pick' }"
-					tabindex="0"
-					@click="setMode('pick')"
-				>
-					Pick
-				</button>
-			</div>
-		</div>
+		<WdsTabs
+			:tabs="tabs"
+			:model-value="mode"
+			@update:model-value="setMode"
+		/>
 
 		<div v-if="mode == 'pick' || mode == 'css'" class="main">
 			<div v-if="mode == 'pick'" class="pickerContainer">
@@ -75,6 +47,7 @@ import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "@/injectionKeys";
 import BuilderSelect from "../BuilderSelect.vue";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
+import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -85,6 +58,21 @@ const pickerEl: Ref<HTMLInputElement> = ref(null);
 const freehandInputEl: Ref<HTMLInputElement> = ref(null);
 
 type Mode = "pick" | "css" | "default";
+
+const tabs: WdsTabOptions<Mode>[] = [
+	{
+		label: "Default",
+		value: "default",
+	},
+	{
+		label: "CSS",
+		value: "css",
+	},
+	{
+		label: "Pick",
+		value: "pick",
+	},
+];
 
 enum SubMode {
 	hleft = "start",
@@ -231,6 +219,10 @@ const setMode = async (newMode: Mode) => {
 	mode.value = newMode;
 	await nextTick();
 	autofocus();
+
+	if (newMode === "default") {
+		setContentValue(component.value.id, fieldKey.value, undefined);
+	}
 };
 
 const handleInputSelect = (select: string) => {
@@ -263,9 +255,6 @@ onBeforeUnmount(() => {
 <style scoped>
 @import "../sharedStyles.css";
 
-.chipStackContainer {
-	margin-top: 4px;
-}
 .main {
 	margin-top: 4px;
 }

--- a/src/ui/src/builder/settings/BuilderFieldsAlign.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsAlign.vue
@@ -47,7 +47,11 @@ import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "@/injectionKeys";
 import BuilderSelect from "../BuilderSelect.vue";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
-import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
+import WdsTabs from "@/wds/WdsTabs.vue";
+import {
+	BuilderFieldCssMode as Mode,
+	BUILDER_FIELD_CSS_TAB_OPTIONS as tabs,
+} from "./constants/builderFieldsCssTabs";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -56,23 +60,6 @@ const { setContentValue } = useComponentActions(wf, ssbm);
 const rootEl: Ref<HTMLElement> = ref(null);
 const pickerEl: Ref<HTMLInputElement> = ref(null);
 const freehandInputEl: Ref<HTMLInputElement> = ref(null);
-
-type Mode = "pick" | "css" | "default";
-
-const tabs: WdsTabOptions<Mode>[] = [
-	{
-		label: "Default",
-		value: "default",
-	},
-	{
-		label: "CSS",
-		value: "css",
-	},
-	{
-		label: "Pick",
-		value: "pick",
-	},
-];
 
 enum SubMode {
 	hleft = "start",

--- a/src/ui/src/builder/settings/BuilderFieldsColor.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsColor.vue
@@ -45,24 +45,11 @@ import { Component } from "@/writerTypes";
 import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "../../injectionKeys";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
-import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
-
-type Mode = "pick" | "css" | "default";
-
-const tabs: WdsTabOptions<Mode>[] = [
-	{
-		label: "Default",
-		value: "default",
-	},
-	{
-		label: "CSS",
-		value: "css",
-	},
-	{
-		label: "Pick",
-		value: "pick",
-	},
-];
+import WdsTabs from "@/wds/WdsTabs.vue";
+import {
+	BuilderFieldCssMode as Mode,
+	BUILDER_FIELD_CSS_TAB_OPTIONS as tabs,
+} from "./constants/builderFieldsCssTabs";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);

--- a/src/ui/src/builder/settings/BuilderFieldsColor.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsColor.vue
@@ -145,12 +145,18 @@ onBeforeUnmount(() => {
 @import "../sharedStyles.css";
 
 .chipStackContainer {
-	padding: 12px;
 	margin-top: 4px;
-	padding-bottom: 12px;
 }
 .main {
-	border-top: 1px solid var(--builderSeparatorColor);
-	padding: 12px;
+	margin-top: 4px;
+}
+input[type="color"] {
+	width: 100%;
+	height: 34px;
+	border-radius: 8px;
+	border: 1px solid var(--separatorColor);
+
+	display: block;
+	height: 40px;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderFieldsColor.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsColor.vue
@@ -5,40 +5,11 @@
 		tabindex="-1"
 		:data-automation-key="fieldKey"
 	>
-		<div class="chipStackContainer">
-			<div class="chipStack">
-				<button
-					class="chip"
-					tabindex="0"
-					:class="{ active: mode == 'default' }"
-					@click="
-						() => {
-							setMode('default');
-							setContentValue(component.id, fieldKey, undefined);
-						}
-					"
-				>
-					Default
-				</button>
-				<button
-					class="chip"
-					tabindex="0"
-					:class="{ active: mode == 'css' }"
-					@click="setMode('css')"
-				>
-					CSS
-				</button>
-				<button
-					class="chip"
-					:class="{ active: mode == 'pick' }"
-					tabindex="0"
-					@click="setMode('pick')"
-				>
-					Pick
-				</button>
-			</div>
-		</div>
-
+		<WdsTabs
+			:tabs="tabs"
+			:model-value="mode"
+			@update:model-value="setMode"
+		/>
 		<div v-if="mode == 'pick' || mode == 'css'" class="main">
 			<div v-if="mode == 'pick'" class="pickerContainer">
 				<input
@@ -74,6 +45,24 @@ import { Component } from "@/writerTypes";
 import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "../../injectionKeys";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
+import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
+
+type Mode = "pick" | "css" | "default";
+
+const tabs: WdsTabOptions<Mode>[] = [
+	{
+		label: "Default",
+		value: "default",
+	},
+	{
+		label: "CSS",
+		value: "css",
+	},
+	{
+		label: "Pick",
+		value: "pick",
+	},
+];
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -82,8 +71,6 @@ const { setContentValue } = useComponentActions(wf, ssbm);
 const rootEl: Ref<HTMLElement> = ref(null);
 const pickerEl: Ref<HTMLInputElement> = ref(null);
 const freehandInputEl: Ref<HTMLInputElement> = ref(null);
-
-type Mode = "pick" | "css" | "default";
 
 const focusEls: Record<Mode, Ref<HTMLInputElement>> = {
 	pick: pickerEl,
@@ -123,6 +110,10 @@ const setMode = async (newMode: Mode) => {
 	mode.value = newMode;
 	await nextTick();
 	autofocus();
+
+	if (newMode === "default") {
+		setContentValue(component.value.id, fieldKey.value, undefined);
+	}
 };
 
 const handleInput = (ev: Event) =>
@@ -144,9 +135,6 @@ onBeforeUnmount(() => {
 <style scoped>
 @import "../sharedStyles.css";
 
-.chipStackContainer {
-	margin-top: 4px;
-}
 .main {
 	margin-top: 4px;
 }

--- a/src/ui/src/builder/settings/BuilderFieldsKeyValue.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsKeyValue.vue
@@ -5,26 +5,12 @@
 		tabindex="-1"
 		:data-automation-key="props.fieldKey"
 	>
-		<div class="chipStackContainer">
-			<div class="chipStack">
-				<button
-					class="chip"
-					:class="{ active: mode == 'assisted' }"
-					tabindex="0"
-					@click="setMode('assisted')"
-				>
-					Static List
-				</button>
-				<button
-					class="chip"
-					tabindex="0"
-					:class="{ active: mode == 'freehand' }"
-					@click="setMode('freehand')"
-				>
-					JSON
-				</button>
-			</div>
-		</div>
+		<WdsTabs
+			class="BuilderFieldsOptions__tabs"
+			:tabs="tabs"
+			:model-value="mode"
+			@update:model-value="setMode"
+		/>
 
 		<template v-if="mode == 'assisted'">
 			<div class="staticList">
@@ -91,6 +77,7 @@ import type { InstancePath } from "@/writerTypes";
 import BuilderFieldsObject from "./BuilderFieldsObject.vue";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
 import { useComponentActions } from "../useComponentActions";
+import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -114,6 +101,11 @@ const formAdd: Ref<{ key: string; value: string }> = ref({
 	key: "",
 	value: "",
 });
+
+const tabs: WdsTabOptions<Mode>[] = [
+	{ label: "Static List", value: "assisted" },
+	{ label: "JSON", value: "freehand" },
+];
 
 const { getEvaluatedFields } = useEvaluator(wf);
 
@@ -191,7 +183,7 @@ onMounted(async () => {
 <style scoped>
 @import "../sharedStyles.css";
 
-.chipStackContainer {
+.BuilderFieldsOptions__tabs {
 	margin-bottom: 8px;
 }
 

--- a/src/ui/src/builder/settings/BuilderFieldsKeyValue.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsKeyValue.vue
@@ -192,15 +192,13 @@ onMounted(async () => {
 @import "../sharedStyles.css";
 
 .chipStackContainer {
-	padding: 12px;
-	margin-top: 4px;
-	padding-bottom: 12px;
-	border-bottom: 1px solid var(--builderSeparatorColor);
+	margin-bottom: 8px;
 }
 
 .staticList {
-	padding: 12px;
-	border-bottom: 1px solid var(--builderSeparatorColor);
+	padding: 8.5px 12px 8.5px 12px;
+	border: 1px solid var(--builderSeparatorColor);
+	border-radius: 8px;
 }
 
 .staticList:empty::before {
@@ -227,7 +225,7 @@ onMounted(async () => {
 }
 
 .formAdd {
-	padding: 12px;
+	margin-top: 8px;
 }
 
 .BuilderTemplateInput {

--- a/src/ui/src/builder/settings/BuilderFieldsObject.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsObject.vue
@@ -46,7 +46,6 @@ const templateField = computed(() => {
 @import "../sharedStyles.css";
 
 .BuilderFieldsObject {
-	padding: 16px 12px 12px 12px;
 	font-size: inherit;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderFieldsPadding.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsPadding.vue
@@ -118,7 +118,11 @@ import injectionKeys from "@/injectionKeys";
 import BuilderSelect from "../BuilderSelect.vue";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
 import WdsTextInput from "@/wds/WdsTextInput.vue";
-import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
+import WdsTabs from "@/wds/WdsTabs.vue";
+import {
+	BuilderFieldCssMode as Mode,
+	BUILDER_FIELD_CSS_TAB_OPTIONS as tabs,
+} from "./constants/builderFieldsCssTabs";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -128,23 +132,6 @@ const rootEl: Ref<HTMLElement> = ref(null);
 const pickerEl: Ref<HTMLInputElement> = ref(null);
 const fixedEl = ref<ComponentInstance<typeof WdsTextInput>>(null);
 const freehandInputEl: Ref<HTMLInputElement> = ref(null);
-
-type Mode = "pick" | "css" | "default";
-
-const tabs: WdsTabOptions<Mode>[] = [
-	{
-		label: "Default",
-		value: "default",
-	},
-	{
-		label: "CSS",
-		value: "css",
-	},
-	{
-		label: "Pick",
-		value: "pick",
-	},
-];
 
 enum SubMode {
 	all_sides = "all_sides",

--- a/src/ui/src/builder/settings/BuilderFieldsPadding.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsPadding.vue
@@ -5,39 +5,11 @@
 		tabindex="-1"
 		:data-automation-key="props.fieldKey"
 	>
-		<div class="chipStackContainer">
-			<div class="chipStack">
-				<button
-					class="chip"
-					tabindex="0"
-					:class="{ active: mode == 'default' }"
-					@click="
-						() => {
-							setMode('default');
-							setContentValue(component.id, fieldKey, undefined);
-						}
-					"
-				>
-					Default
-				</button>
-				<button
-					class="chip"
-					tabindex="0"
-					:class="{ active: mode == 'css' }"
-					@click="setMode('css')"
-				>
-					CSS
-				</button>
-				<button
-					class="chip"
-					:class="{ active: mode == 'pick' }"
-					tabindex="0"
-					@click="setMode('pick')"
-				>
-					Pick
-				</button>
-			</div>
-		</div>
+		<WdsTabs
+			:tabs="tabs"
+			:model-value="mode"
+			@update:model-value="setMode"
+		/>
 
 		<div v-if="mode == 'pick' || mode == 'css'" class="main">
 			<div v-if="mode == 'pick'" class="pickerContainer">
@@ -146,6 +118,7 @@ import injectionKeys from "@/injectionKeys";
 import BuilderSelect from "../BuilderSelect.vue";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
 import WdsTextInput from "@/wds/WdsTextInput.vue";
+import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -157,6 +130,21 @@ const fixedEl = ref<ComponentInstance<typeof WdsTextInput>>(null);
 const freehandInputEl: Ref<HTMLInputElement> = ref(null);
 
 type Mode = "pick" | "css" | "default";
+
+const tabs: WdsTabOptions<Mode>[] = [
+	{
+		label: "Default",
+		value: "default",
+	},
+	{
+		label: "CSS",
+		value: "css",
+	},
+	{
+		label: "Pick",
+		value: "pick",
+	},
+];
 
 enum SubMode {
 	all_sides = "all_sides",
@@ -317,6 +305,10 @@ const setMode = async (newMode: Mode) => {
 	mode.value = newMode;
 	await nextTick();
 	autofocus();
+
+	if (newMode === "default") {
+		setContentValue(component.value.id, fieldKey.value, undefined);
+	}
 };
 
 const handleInputSelect = (select: string) => {
@@ -392,10 +384,6 @@ onBeforeUnmount(() => {
 <style scoped>
 @import "../sharedStyles.css";
 @import "../ico.css";
-
-.chipStackContainer {
-	margin-top: 4px;
-}
 
 .main {
 	margin-top: 4px;

--- a/src/ui/src/builder/settings/BuilderFieldsPadding.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsPadding.vue
@@ -46,75 +46,75 @@
 					:options="selectOptions"
 					@update:model-value="handleInputSelect"
 				/>
-				<div v-if="subMode == SubMode.all_sides" class="row">
-					<i>All</i>
-					<input
-						ref="fixedEl"
-						type="text"
-						:value="valuePadding[0]"
-						@input="handleInputs($event, subMode)"
-					/>
-					<div>px</div>
-				</div>
-				<div v-if="subMode == SubMode.xy_sides">
-					<div class="row">
+				<div class="BuilderFieldsPadding__options">
+					<template v-if="subMode == SubMode.all_sides">
+						<i>All</i>
+						<WdsTextInput
+							ref="fixedEl"
+							type="number"
+							:model-value="valuePadding[0]"
+							@update:model-value="handleInputs($event, subMode)"
+						/>
+						<div>px</div>
+					</template>
+					<template v-if="subMode == SubMode.xy_sides">
 						<i>X</i>
-						<input
-							ref="fixedEl"
-							type="text"
-							:value="valuePadding[0]"
-							@input="handleInputs($event, subMode, 'x')"
+						<WdsTextInput
+							type="number"
+							:model-value="valuePadding[0]"
+							@update:model-value="
+								handleInputs($event, subMode, 'x')
+							"
 						/>
 						<div>px</div>
-					</div>
-					<div class="row">
 						<i>Y</i>
-						<input
-							type="text"
-							:value="valuePadding[2]"
-							@input="handleInputs($event, subMode, 'y')"
+						<WdsTextInput
+							type="number"
+							:model-value="valuePadding[2]"
+							@update:model-value="
+								handleInputs($event, subMode, 'y')
+							"
 						/>
 						<div>px</div>
-					</div>
-				</div>
-				<div v-if="subMode == SubMode.per_side">
-					<div class="row">
+					</template>
+					<template v-if="subMode == SubMode.per_side">
 						<i>Left</i>
-						<input
-							ref="fixedEl"
-							type="text"
-							:value="valuePadding[0]"
-							@input="handleInputs($event, subMode, 'left')"
+						<WdsTextInput
+							type="number"
+							:model-value="valuePadding[0]"
+							@update:model-value="
+								handleInputs($event, subMode, 'left')
+							"
 						/>
 						<div>px</div>
-					</div>
-					<div class="row">
 						<i>Right</i>
-						<input
-							type="text"
-							:value="valuePadding[1]"
-							@input="handleInputs($event, subMode, 'right')"
+						<WdsTextInput
+							type="number"
+							:model-value="valuePadding[1]"
+							@update:model-value="
+								handleInputs($event, subMode, 'right')
+							"
 						/>
 						<div>px</div>
-					</div>
-					<div class="row">
 						<i>Top</i>
-						<input
-							type="text"
-							:value="valuePadding[2]"
-							@input="handleInputs($event, subMode, 'top')"
+						<WdsTextInput
+							type="number"
+							:model-value="valuePadding[2]"
+							@update:model-value="
+								handleInputs($event, subMode, 'top')
+							"
 						/>
 						<div>px</div>
-					</div>
-					<div class="row">
 						<i>Bottom</i>
-						<input
-							type="text"
-							:value="valuePadding[3]"
-							@input="handleInputs($event, subMode, 'bottom')"
+						<WdsTextInput
+							type="number"
+							:model-value="valuePadding[3]"
+							@update:model-value="
+								handleInputs($event, subMode, 'bottom')
+							"
 						/>
 						<div>px</div>
-					</div>
+					</template>
 				</div>
 			</div>
 
@@ -130,6 +130,7 @@
 
 <script setup lang="ts">
 import {
+	ComponentInstance,
 	computed,
 	inject,
 	nextTick,
@@ -144,6 +145,7 @@ import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "@/injectionKeys";
 import BuilderSelect from "../BuilderSelect.vue";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
+import WdsTextInput from "@/wds/WdsTextInput.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -151,7 +153,7 @@ const { setContentValue } = useComponentActions(wf, ssbm);
 
 const rootEl: Ref<HTMLElement> = ref(null);
 const pickerEl: Ref<HTMLInputElement> = ref(null);
-const fixedEl: Ref<HTMLInputElement> = ref(null);
+const fixedEl = ref<ComponentInstance<typeof WdsTextInput>>(null);
 const freehandInputEl: Ref<HTMLInputElement> = ref(null);
 
 type Mode = "pick" | "css" | "default";
@@ -327,7 +329,7 @@ const handleInputSelect = (select: string) => {
 	}
 
 	nextTick(() => {
-		fixedEl.value.focus();
+		fixedEl.value?.focus();
 	});
 };
 
@@ -339,8 +341,8 @@ const handleInputCss = (ev: Event) => {
 	);
 };
 
-const handleInputs = (ev: Event, subMode: SubMode, inputType?: string) => {
-	const value = (ev.target as HTMLInputElement).value;
+const handleInputs = (ev: string, subMode: SubMode, inputType?: string) => {
+	const value = Number(ev);
 	const cssValue = component.value.content[fieldKey.value];
 
 	if (subMode == SubMode.all_sides) {
@@ -392,26 +394,22 @@ onBeforeUnmount(() => {
 @import "../ico.css";
 
 .chipStackContainer {
-	padding: 12px;
 	margin-top: 4px;
-	padding-bottom: 12px;
 }
 
 .main {
-	border-top: 1px solid var(--builderSeparatorColor);
-	padding: 12px;
+	margin-top: 4px;
 }
 
-.row {
-	display: flex;
-	flex-direction: row;
+.BuilderFieldsPadding__options {
+	margin-top: 8px;
+	display: grid;
+	grid-template-columns: auto minmax(0, 100%) auto;
 	gap: 8px;
-	padding: 8px;
 	align-items: baseline;
+	width: 100%;
 }
-
-.row input {
-	width: calc(100% - 32px) !important;
+.BuilderFieldsPadding__options input {
 	text-align: right;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderFieldsShadow.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsShadow.vue
@@ -237,24 +237,21 @@ onBeforeUnmount(() => {
 @import "../sharedStyles.css";
 
 .chipStackContainer {
-	padding: 12px;
 	margin-top: 4px;
-	padding-bottom: 12px;
 }
 .main {
-	border-top: 1px solid var(--builderSeparatorColor);
-	padding: 12px;
+	margin-top: 4px;
 }
 
 .pickerContainer {
 	display: flex;
-	gap: 8px;
+	gap: 4px;
 	flex-direction: column;
 }
 
 .param > .header {
 	display: flex;
-	margin-bottom: 8px;
+	margin-bottom: 4px;
 }
 
 .param > .header > .name {
@@ -263,5 +260,18 @@ onBeforeUnmount(() => {
 
 .param > .header > .value {
 	margin-left: auto;
+}
+.param input[type="range"] {
+	width: 100%;
+}
+
+input[type="color"] {
+	width: 100%;
+	height: 34px;
+	border-radius: 8px;
+	border: 1px solid var(--separatorColor);
+
+	display: block;
+	height: 40px;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderFieldsShadow.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsShadow.vue
@@ -114,7 +114,11 @@ import { Component } from "@/writerTypes";
 import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "../../injectionKeys";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
-import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
+import WdsTabs from "@/wds/WdsTabs.vue";
+import {
+	BuilderFieldCssMode as Mode,
+	BUILDER_FIELD_CSS_TAB_OPTIONS as tabs,
+} from "./constants/builderFieldsCssTabs";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -127,23 +131,6 @@ const paramOffsetYEl: Ref<HTMLInputElement> = ref(null);
 const paramBlurRadiusEl: Ref<HTMLInputElement> = ref(null);
 const paramSpreadRadiusEl: Ref<HTMLInputElement> = ref(null);
 const paramColorEl: Ref<HTMLInputElement> = ref(null);
-
-type Mode = "pick" | "css" | "default";
-
-const tabs: WdsTabOptions<Mode>[] = [
-	{
-		label: "Default",
-		value: "default",
-	},
-	{
-		label: "CSS",
-		value: "css",
-	},
-	{
-		label: "Pick",
-		value: "pick",
-	},
-];
 
 const focusEls: Record<Mode, Ref<HTMLInputElement>> = {
 	pick: paramOffsetXEl,

--- a/src/ui/src/builder/settings/BuilderFieldsShadow.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsShadow.vue
@@ -5,40 +5,11 @@
 		tabindex="-1"
 		:data-automation-key="props.fieldKey"
 	>
-		<div class="chipStackContainer">
-			<div class="chipStack">
-				<button
-					class="chip"
-					tabindex="0"
-					:class="{ active: mode == 'default' }"
-					@click="
-						() => {
-							setMode('default');
-							setContentValue(component.id, fieldKey, undefined);
-						}
-					"
-				>
-					Default
-				</button>
-				<button
-					class="chip"
-					tabindex="0"
-					:class="{ active: mode == 'css' }"
-					@click="setMode('css')"
-				>
-					CSS
-				</button>
-				<button
-					class="chip"
-					:class="{ active: mode == 'pick' }"
-					tabindex="0"
-					@click="setMode('pick')"
-				>
-					Pick
-				</button>
-			</div>
-		</div>
-
+		<WdsTabs
+			:tabs="tabs"
+			:model-value="mode"
+			@update:model-value="setMode"
+		/>
 		<div v-if="mode == 'pick' || mode == 'css'" class="main">
 			<div v-if="mode == 'pick'" class="pickerContainer">
 				<div class="param">
@@ -143,6 +114,7 @@ import { Component } from "@/writerTypes";
 import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "../../injectionKeys";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
+import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -157,6 +129,21 @@ const paramSpreadRadiusEl: Ref<HTMLInputElement> = ref(null);
 const paramColorEl: Ref<HTMLInputElement> = ref(null);
 
 type Mode = "pick" | "css" | "default";
+
+const tabs: WdsTabOptions<Mode>[] = [
+	{
+		label: "Default",
+		value: "default",
+	},
+	{
+		label: "CSS",
+		value: "css",
+	},
+	{
+		label: "Pick",
+		value: "pick",
+	},
+];
 
 const focusEls: Record<Mode, Ref<HTMLInputElement>> = {
 	pick: paramOffsetXEl,
@@ -198,6 +185,10 @@ const setMode = async (newMode: Mode) => {
 	mode.value = newMode;
 	await nextTick();
 	autofocus();
+
+	if (newMode === "default") {
+		setContentValue(component.value.id, fieldKey.value, undefined);
+	}
 };
 
 const handleInput = () => {
@@ -236,9 +227,6 @@ onBeforeUnmount(() => {
 <style scoped>
 @import "../sharedStyles.css";
 
-.chipStackContainer {
-	margin-top: 4px;
-}
 .main {
 	margin-top: 4px;
 }

--- a/src/ui/src/builder/settings/BuilderFieldsText.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsText.vue
@@ -75,7 +75,6 @@ const handleInput = (ev: Event) => {
 
 <style>
 .BuilderFieldsText .content {
-	padding: 16px 12px 12px 12px;
 	width: 100%;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderFieldsWidth.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsWidth.vue
@@ -47,11 +47,11 @@
 					@update:model-value="handleInputSelect"
 				/>
 				<div v-if="subMode == SubMode.fixed" class="fixedContainer">
-					<input
+					<WdsTextInput
 						ref="fixedEl"
-						type="text"
-						:value="valuePickFixed"
-						@input="handleInputFixed"
+						type="number"
+						:model-value="valuePickFixed"
+						@update:model-value="handleInputFixed"
 					/>
 					<div>px</div>
 				</div>
@@ -69,6 +69,7 @@
 
 <script setup lang="ts">
 import {
+	ComponentInstance,
 	computed,
 	inject,
 	nextTick,
@@ -83,6 +84,7 @@ import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "../../injectionKeys";
 import BuilderSelect from "../BuilderSelect.vue";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
+import WdsTextInput from "@/wds/WdsTextInput.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -90,7 +92,7 @@ const { setContentValue } = useComponentActions(wf, ssbm);
 
 const rootEl: Ref<HTMLElement> = ref(null);
 const pickerEl: Ref<HTMLInputElement> = ref(null);
-const fixedEl: Ref<HTMLInputElement> = ref(null);
+const fixedEl = ref<ComponentInstance<typeof WdsTextInput>>(null);
 const freehandInputEl: Ref<HTMLInputElement> = ref(null);
 
 type Mode = "pick" | "css" | "default";
@@ -239,12 +241,8 @@ const handleInputCss = (ev: Event) => {
 	);
 };
 
-const handleInputFixed = (ev: Event) => {
-	setContentValue(
-		component.value.id,
-		fieldKey.value,
-		(ev.target as HTMLInputElement).value + "px",
-	);
+const handleInputFixed = (ev: string) => {
+	setContentValue(component.value.id, fieldKey.value, `${ev}px`);
 };
 
 onMounted(() => {
@@ -260,19 +258,17 @@ onBeforeUnmount(() => {
 @import "../sharedStyles.css";
 
 .chipStackContainer {
-	padding: 12px;
 	margin-top: 4px;
-	padding-bottom: 12px;
 }
 .main {
-	border-top: 1px solid var(--builderSeparatorColor);
-	padding: 12px;
+	margin-top: 4px;
 }
 
 .fixedContainer {
+	margin-top: 8px;
 	display: flex;
 	flex-direction: row;
+	align-items: center;
 	gap: 8px;
-	padding: 8px;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderFieldsWidth.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsWidth.vue
@@ -57,7 +57,11 @@ import injectionKeys from "../../injectionKeys";
 import BuilderSelect from "../BuilderSelect.vue";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
 import WdsTextInput from "@/wds/WdsTextInput.vue";
-import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
+import WdsTabs from "@/wds/WdsTabs.vue";
+import {
+	BuilderFieldCssMode as Mode,
+	BUILDER_FIELD_CSS_TAB_OPTIONS as tabs,
+} from "./constants/builderFieldsCssTabs";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -67,23 +71,6 @@ const rootEl: Ref<HTMLElement> = ref(null);
 const pickerEl: Ref<HTMLInputElement> = ref(null);
 const fixedEl = ref<ComponentInstance<typeof WdsTextInput>>(null);
 const freehandInputEl: Ref<HTMLInputElement> = ref(null);
-
-type Mode = "pick" | "css" | "default";
-
-const tabs: WdsTabOptions<Mode>[] = [
-	{
-		label: "Default",
-		value: "default",
-	},
-	{
-		label: "CSS",
-		value: "css",
-	},
-	{
-		label: "Pick",
-		value: "pick",
-	},
-];
 
 enum SubMode {
 	fixed = "fixed",

--- a/src/ui/src/builder/settings/BuilderFieldsWidth.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsWidth.vue
@@ -5,39 +5,11 @@
 		tabindex="-1"
 		:data-automation-key="props.fieldKey"
 	>
-		<div class="chipStackContainer">
-			<div class="chipStack">
-				<button
-					class="chip"
-					tabindex="0"
-					:class="{ active: mode == 'default' }"
-					@click="
-						() => {
-							setMode('default');
-							setContentValue(component.id, fieldKey, undefined);
-						}
-					"
-				>
-					Default
-				</button>
-				<button
-					class="chip"
-					tabindex="0"
-					:class="{ active: mode == 'css' }"
-					@click="setMode('css')"
-				>
-					CSS
-				</button>
-				<button
-					class="chip"
-					:class="{ active: mode == 'pick' }"
-					tabindex="0"
-					@click="setMode('pick')"
-				>
-					Pick
-				</button>
-			</div>
-		</div>
+		<WdsTabs
+			:tabs="tabs"
+			:model-value="mode"
+			@update:model-value="setMode"
+		/>
 
 		<div v-if="mode == 'pick' || mode == 'css'" class="main">
 			<div v-if="mode == 'pick'" class="pickerContainer">
@@ -85,6 +57,7 @@ import injectionKeys from "../../injectionKeys";
 import BuilderSelect from "../BuilderSelect.vue";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
 import WdsTextInput from "@/wds/WdsTextInput.vue";
+import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -96,6 +69,21 @@ const fixedEl = ref<ComponentInstance<typeof WdsTextInput>>(null);
 const freehandInputEl: Ref<HTMLInputElement> = ref(null);
 
 type Mode = "pick" | "css" | "default";
+
+const tabs: WdsTabOptions<Mode>[] = [
+	{
+		label: "Default",
+		value: "default",
+	},
+	{
+		label: "CSS",
+		value: "css",
+	},
+	{
+		label: "Pick",
+		value: "pick",
+	},
+];
 
 enum SubMode {
 	fixed = "fixed",
@@ -215,6 +203,10 @@ const setMode = async (newMode: Mode) => {
 	mode.value = newMode;
 	await nextTick();
 	autofocus();
+
+	if (newMode === "default") {
+		setContentValue(component.value.id, fieldKey.value, undefined);
+	}
 };
 
 const handleInputSelect = (select: string) => {
@@ -257,9 +249,6 @@ onBeforeUnmount(() => {
 <style scoped>
 @import "../sharedStyles.css";
 
-.chipStackContainer {
-	margin-top: 4px;
-}
 .main {
 	margin-top: 4px;
 }

--- a/src/ui/src/builder/settings/BuilderSectionTitle.vue
+++ b/src/ui/src/builder/settings/BuilderSectionTitle.vue
@@ -1,0 +1,23 @@
+<template>
+	<div class="BuilderSectionTitle">
+		<i class="material-symbols-outlined">{{ icon }}</i>
+		<h3>{{ label }}</h3>
+	</div>
+</template>
+
+<script setup lang="ts">
+defineProps({
+	icon: { type: String, required: true },
+	label: { type: String, required: true },
+});
+</script>
+
+<style lang="css" scoped>
+@import "../sharedStyles.css";
+.BuilderSectionTitle {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	font-size: 1rem;
+}
+</style>

--- a/src/ui/src/builder/settings/BuilderSettingsBinding.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsBinding.vue
@@ -1,15 +1,10 @@
 <template>
 	<div v-if="ssbm.isSelectionActive()" class="BuilderSettingsBinding">
-		<div class="sectionTitle">
-			<i class="material-symbols-outlined">link</i>
-			<h3>Binding</h3>
-		</div>
+		<BuilderSectionTitle icon="link" label="Binding" />
 		<div class="main">
-			<div class="fieldWrapper">
-				<span class="name">State element</span>
+			<WdsFieldWrapper label="State element" :hint="hint">
 				<BuilderTemplateInput
 					type="state"
-					class="content"
 					:value="component.binding?.stateRef"
 					placeholder="my_var"
 					@input="
@@ -20,12 +15,7 @@
 							)
 					"
 				/>
-				<div class="desc">
-					Links this component to a state element, in a two-way
-					fashion. Reference the state element directly, i.e. use
-					"my_var" instead of "@{my_var}".
-				</div>
-			</div>
+			</WdsFieldWrapper>
 		</div>
 	</div>
 </template>
@@ -35,6 +25,10 @@ import { computed, inject } from "vue";
 import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "../../injectionKeys";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
+import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
+
+const hint =
+	'Links this component to a state element, in a two-way fashion. Reference the state element directly, i.e. use "my_var" instead of "@{my_var}".';
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);

--- a/src/ui/src/builder/settings/BuilderSettingsHandlers.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsHandlers.vue
@@ -1,45 +1,34 @@
 <template>
 	<div v-if="ssbm.isSelectionActive()" class="BuilderSettingsHandlers">
-		<div class="sectionTitle">
+		<div class="BuilderSettingsHandlers__title">
 			<i class="material-symbols-outlined">bolt</i>
 			<h3>Events</h3>
 		</div>
-		<div class="list">
+		<div class="BuilderSettingsHandlers__list">
 			<div
 				v-for="(eventInfo, eventType) in recognisedEvents"
 				:key="eventType"
-				class="fieldWrapper"
 			>
 				<div class="columns">
-					<div class="fieldWrapperMain">
-						<span class="name">{{ eventType }}</span>
-						<div class="content">
-							<BuilderSelect
-								:model-value="
-									component.handlers?.[eventType] ?? ''
-								"
-								:options="getOptions(eventType)"
-								variant="embedded"
-								enable-search
-								@update:model-value="
-									handleHandlerChange($event, eventType)
-								"
-							/>
-						</div>
-					</div>
-					<div class="fieldActions">
-						<button
-							v-if="getStubCode(eventType)"
-							variant="subtle"
-							title="Show event handler stub"
-							@click="showStub(eventType)"
-						>
-							<i class="material-symbols-outlined">help</i>
-						</button>
-					</div>
-				</div>
-				<div v-if="eventInfo?.desc" class="desc">
-					{{ eventInfo.desc }}
+					<WdsFieldWrapper
+						:label="eventType"
+						:hint="eventInfo?.desc"
+						:help-button="
+							getStubCode(eventType)
+								? 'Show event handler stub'
+								: false
+						"
+						@help-click="showStub(eventType)"
+					>
+						<BuilderSelect
+							:model-value="component.handlers?.[eventType] ?? ''"
+							:options="getOptions(eventType)"
+							enable-search
+							@update:model-value="
+								handleHandlerChange($event, eventType)
+							"
+						/>
+					</WdsFieldWrapper>
 				</div>
 			</div>
 		</div>
@@ -73,63 +62,38 @@
 				:close-action="customHandlerModalCloseAction"
 				icon="bolt"
 				modal-title="Add Custom Event Handler"
+				allow-overflow
 			>
 				<div class="customHandlerModalForm">
-					<div class="fieldWrapper">
-						<div class="fieldWrapperMain">
-							<span class="name">Event type</span>
-							<input
-								v-model="customHandlerModal.eventType"
-								class="content"
-								type="text"
-								list="commonEventTypes"
-							/>
-							<datalist id="commonEventTypes">
-								<option
-									v-for="commonEventType in commonEventTypes"
-									:key="commonEventType"
-									:value="commonEventType"
-								>
-									{{ commonEventType }}
-								</option>
-							</datalist>
-						</div>
-						<span class="desc">Can be any event type.</span>
-					</div>
-					<div class="fieldWrapper">
-						<div class="fieldWrapperMain">
-							<span class="name">Handler function</span>
-						</div>
-						<select
+					<WdsFieldWrapper
+						label="Event type"
+						hint="Can be any event type."
+					>
+						<WdsTextInput
+							v-model="customHandlerModal.eventType"
+							type="text"
+							list="commonEventTypes"
+						/>
+						<datalist id="commonEventTypes">
+							<option
+								v-for="commonEventType in commonEventTypes"
+								:key="commonEventType"
+								:value="commonEventType"
+							>
+								{{ commonEventType }}
+							</option>
+						</datalist>
+					</WdsFieldWrapper>
+					<WdsFieldWrapper
+						label="Handler function"
+						hint="The function that will handle the event."
+					>
+						<BuilderSelect
 							v-model="customHandlerModal.handlerFunctionName"
-							class="content"
-						>
-							<option
-								v-for="userFunction in userFunctions"
-								:key="userFunction.name"
-								:value="userFunction.name"
-							>
-								{{ userFunction.name }}
-							</option>
-							<option
-								v-for="pageKey in pageKeys"
-								:key="`$goToPage_${pageKey}`"
-								:value="`$goToPage_${pageKey}`"
-							>
-								Go to page "{{ pageKey }}"
-							</option>
-							<option
-								v-for="workflowKey in workflowKeys"
-								:key="`$runWorkflow_${workflowKey}`"
-								:value="`$runWorkflow_${workflowKey}`"
-							>
-								Run workflow "{{ workflowKey }}"
-							</option>
-						</select>
-						<span class="desc"
-							>The function that will handle the event.</span
-						>
-					</div>
+							:options="options"
+							enable-search
+						/>
+					</WdsFieldWrapper>
 				</div>
 
 				<button @click="addCustomEventHandler()">
@@ -150,6 +114,8 @@ import BuilderModal, { ModalAction } from "../BuilderModal.vue";
 import { WriterComponentDefinition } from "@/writerTypes";
 import BuilderSelect from "../BuilderSelect.vue";
 import type { Option } from "../BuilderSelect.vue";
+import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
+import WdsTextInput from "@/wds/WdsTextInput.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -182,7 +148,7 @@ const options = computed<Option[]>(() => {
 	];
 });
 
-function getOptions(eventType: string): Option[] {
+function getOptions(eventType?: string): Option[] {
 	if (!isHandlerInvalid(eventType)) return options.value;
 
 	const handler = component.value.handlers?.[eventType];
@@ -359,34 +325,22 @@ const copyToClipboard = (text: string) => {
 <style scoped>
 @import "../sharedStyles.css";
 
-.list {
-	border-radius: 4px;
+.BuilderSettingsHandlers {
+	padding: 24px;
 }
 
-.fieldWrapper .columns {
-	display: grid;
-	grid-template-columns: minmax(0, 100%) auto;
-	gap: 12px;
+.BuilderSettingsHandlers__title {
+	padding-bottom: 24px;
+	display: flex;
+	gap: 8px;
 	align-items: center;
-	max-width: 100%;
+	font-size: 1rem;
 }
 
-.fieldWrapperMain {
-	width: 100%;
-}
-
-.fieldWrapper .content {
-	padding: 16px 8px 12px 8px;
-	width: 100%;
-}
-.fieldWrapper .content .select {
-	padding: 0;
-	height: auto;
-}
-
-.fieldActions > button {
-	border-radius: 16px;
-	font-size: 0.875rem;
+.BuilderSettingsHandlers__list {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
 }
 
 .customHandler {
@@ -421,14 +375,10 @@ const copyToClipboard = (text: string) => {
 }
 
 .customHandlerModalForm {
-	display: flex;
+	display: grid;
+	grid-template-columns: 1fr 1fr;
 	align-items: center;
 	gap: 16px;
 	margin-bottom: 16px;
-}
-
-.customHandlerModalForm .fieldWrapper {
-	flex: 1 1 auto;
-	margin-top: 0;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderSettingsProperties.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsProperties.vue
@@ -4,44 +4,46 @@
 		class="BuilderSettingsProperties"
 	>
 		<div
-			v-for="propertyCategory in fieldCategories.filter(
-				(fc) => fieldsByCategory[fc].length > 0,
-			)"
+			v-for="propertyCategory in fieldCategories"
 			:key="propertyCategory"
-			class="propertyCategory"
+			class="BuilderSettingsProperties__category"
 		>
-			<div class="title">
-				<h4>{{ propertyCategory }}</h4>
-			</div>
+			<h4
+				v-if="fieldsByCategory[propertyCategory].length > 0"
+				class="BuilderSettingsProperties__category__title"
+			>
+				{{ propertyCategory }}
+			</h4>
 			<div
 				v-for="[fieldKey, fieldValue] in fieldsByCategory[
 					propertyCategory
 				]"
 				:key="fieldKey"
+				class="BuilderSettingsProperties__category__field"
 			>
-				<div class="fieldWrapper">
-					<div v-if="propertyCategory != 'Tools'" class="name">
-						{{ fieldValue.name ?? fieldKey
-						}}<span class="type"> : {{ fieldValue.type }}</span>
-					</div>
-
+				<WdsFieldWrapper
+					:label="
+						propertyCategory === 'Tools'
+							? undefined
+							: fieldValue.name ?? fieldKey
+					"
+					:hint="fieldValue.desc"
+					:type="fieldValue.type"
+				>
 					<BuilderFieldsColor
 						v-if="fieldValue.type == FieldType.Color"
-						class="content"
 						:field-key="fieldKey"
 						:component-id="selectedComponent.id"
 					></BuilderFieldsColor>
 
 					<BuilderFieldsShadow
 						v-if="fieldValue.type == FieldType.Shadow"
-						class="content"
 						:field-key="fieldKey"
 						:component-id="selectedComponent.id"
 					></BuilderFieldsShadow>
 
 					<BuilderFieldsKeyValue
 						v-if="fieldValue.type == FieldType.KeyValue"
-						class="content"
 						:field-key="fieldKey"
 						:component-id="selectedComponent.id"
 						:instance-path="selectedInstancePath"
@@ -67,21 +69,18 @@
 
 					<BuilderFieldsObject
 						v-if="fieldValue.type == FieldType.Object"
-						class="content"
 						:field-key="fieldKey"
 						:component-id="selectedComponent.id"
 					></BuilderFieldsObject>
 
 					<BuilderFieldsWidth
 						v-if="fieldValue.type == FieldType.Width"
-						class="content"
 						:field-key="fieldKey"
 						:component-id="selectedComponent.id"
 					></BuilderFieldsWidth>
 
 					<BuilderFieldsAlign
 						v-if="fieldValue.type == FieldType.HAlign"
-						class="content"
 						direction="horizontal"
 						:field-key="fieldKey"
 						:component-id="selectedComponent.id"
@@ -89,7 +88,6 @@
 
 					<BuilderFieldsAlign
 						v-if="fieldValue.type == FieldType.VAlign"
-						class="content"
 						direction="vertical"
 						:field-key="fieldKey"
 						:component-id="selectedComponent.id"
@@ -97,7 +95,6 @@
 
 					<BuilderFieldsPadding
 						v-if="fieldValue.type == FieldType.Padding"
-						class="content"
 						:field-key="fieldKey"
 						:component-id="selectedComponent.id"
 					></BuilderFieldsPadding>
@@ -108,11 +105,7 @@
 						:component-id="selectedComponent.id"
 					>
 					</BuilderFieldsTools>
-
-					<div v-if="fieldValue.desc" class="desc">
-						{{ fieldValue.desc }}
-					</div>
-				</div>
+				</WdsFieldWrapper>
 			</div>
 		</div>
 	</div>
@@ -132,6 +125,7 @@ import BuilderFieldsShadow from "./BuilderFieldsShadow.vue";
 import BuilderFieldsText from "./BuilderFieldsText.vue";
 import BuilderFieldsWidth from "./BuilderFieldsWidth.vue";
 import BuilderFieldsTools from "./BuilderFieldsTools.vue";
+import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -179,17 +173,22 @@ const fieldsByCategory = computed(() => {
 @import "../sharedStyles.css";
 
 .BuilderSettingsProperties {
+	padding: 24px;
+
 	display: flex;
 	flex-direction: column;
-	gap: 24px;
+	gap: 16px;
 }
 
-textarea.content {
-	resize: vertical;
-	height: 8em;
+.BuilderSettingsProperties__category {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
 }
 
-input[type="color"].content {
-	height: 48px;
+.BuilderSettingsProperties__category__title {
+	color: var(--builderSecondaryTextColor);
+	font-weight: 500;
+	font-size: 12px;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderSettingsVisibility.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsVisibility.vue
@@ -1,9 +1,6 @@
 <template>
 	<div v-if="ssbm.isSelectionActive()" class="BuilderSettingsVisibility">
-		<div class="sectionTitle">
-			<i class="material-symbols-outlined"> visibility </i>
-			<h3>Visibility</h3>
-		</div>
+		<BuilderSectionTitle icon="visibility" label="Visibility" />
 		<div class="main">
 			<div class="chipStack">
 				<div
@@ -42,18 +39,16 @@
 					Custom
 				</div>
 			</div>
-			<div
+			<WdsFieldWrapper
 				v-if="
 					typeof component.visible != 'undefined' &&
 					component.visible.expression === 'custom'
 				"
-				class="fieldWrapper"
+				:hint="hint"
 			>
-				<span class="name">Visibility value</span>
 				<BuilderTemplateInput
 					:value="component.visible.binding"
 					type="state"
-					class="content"
 					placeholder="my_visibility_state_value"
 					@input="
 						(ev: Event) =>
@@ -80,12 +75,7 @@
 						"
 					/><span>Reverse</span>
 				</div>
-				<div class="desc">
-					Reference a state or context element that will evaluate to
-					true or false. Reference the element directly, i.e. use
-					"my_var" instead of "@{my_var}".
-				</div>
-			</div>
+			</WdsFieldWrapper>
 		</div>
 	</div>
 </template>
@@ -95,12 +85,17 @@ import { computed, inject } from "vue";
 import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "../../injectionKeys";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
+import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
+import BuilderSectionTitle from "./BuilderSectionTitle.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
 const { setVisibleValue } = useComponentActions(wf, ssbm);
 
 const component = computed(() => wf.getComponentById(ssbm.getSelectedId()));
+
+const hint =
+	'Reference a state or context element that will evaluate to true or false. Reference the element directly, i.e. use "my_var" instead of "@{my_var}".';
 </script>
 
 <style scoped>
@@ -110,11 +105,8 @@ const component = computed(() => wf.getComponentById(ssbm.getSelectedId()));
 	margin-top: 16px;
 }
 
-.content {
-	padding: 16px 12px 12px 12px;
-}
-
 .flexRow {
+	margin-top: 4px;
 	display: flex;
 	flex-direction: row;
 	gap: 8px;

--- a/src/ui/src/builder/settings/BuilderSettingsVisibility.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsVisibility.vue
@@ -2,43 +2,7 @@
 	<div v-if="ssbm.isSelectionActive()" class="BuilderSettingsVisibility">
 		<BuilderSectionTitle icon="visibility" label="Visibility" />
 		<div class="main">
-			<div class="chipStack">
-				<div
-					class="chip"
-					:class="{
-						active:
-							typeof component.visible == 'undefined' ||
-							component.visible.expression === true,
-					}"
-					@click="() => setVisibleValue(component.id, true)"
-				>
-					Yes
-				</div>
-				<div
-					class="chip"
-					:class="{ active: component.visible?.expression === false }"
-					@click="() => setVisibleValue(component.id, false)"
-				>
-					No
-				</div>
-				<div
-					class="chip"
-					:class="{
-						active: component.visible?.expression === 'custom',
-					}"
-					@click="
-						() =>
-							setVisibleValue(
-								component.id,
-								'custom',
-								component.visible?.binding,
-								component.visible?.reversed,
-							)
-					"
-				>
-					Custom
-				</div>
-			</div>
+			<WdsTabs v-model="tab" :tabs="tabs" />
 			<WdsFieldWrapper
 				v-if="
 					typeof component.visible != 'undefined' &&
@@ -87,6 +51,38 @@ import injectionKeys from "../../injectionKeys";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
 import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
 import BuilderSectionTitle from "./BuilderSectionTitle.vue";
+import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
+
+type Mode = "yes" | "no" | "custom";
+
+const tabs: WdsTabOptions<Mode>[] = [
+	{ label: "Yes", value: "yes" },
+	{ label: "No", value: "no" },
+	{ label: "Custom", value: "custom" },
+];
+
+const tab = computed<Mode>({
+	get() {
+		const visible = component.value.visible;
+		if (visible?.expression === "custom") return "custom";
+
+		return visible === undefined || visible.expression === true
+			? "yes"
+			: "no";
+	},
+	set(value: Mode) {
+		if (value === "custom") {
+			setVisibleValue(
+				component.value.id,
+				"custom",
+				component.value.visible?.binding,
+				component.value.visible?.reversed,
+			);
+		} else {
+			setVisibleValue(component.value.id, value === "yes");
+		}
+	},
+});
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -103,6 +99,9 @@ const hint =
 
 .main {
 	margin-top: 16px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
 }
 
 .flexRow {

--- a/src/ui/src/builder/settings/constants/builderFieldsCssTabs.ts
+++ b/src/ui/src/builder/settings/constants/builderFieldsCssTabs.ts
@@ -1,0 +1,20 @@
+import type { WdsTabOptions } from "@/wds/WdsTabs.vue";
+
+export type BuilderFieldCssMode = "pick" | "css" | "default";
+
+export const BUILDER_FIELD_CSS_TAB_OPTIONS = Object.freeze<
+	WdsTabOptions<BuilderFieldCssMode>[]
+>([
+	{
+		label: "Default",
+		value: "default",
+	},
+	{
+		label: "CSS",
+		value: "css",
+	},
+	{
+		label: "Pick",
+		value: "pick",
+	},
+]);

--- a/src/ui/src/builder/sharedStyles.css
+++ b/src/ui/src/builder/sharedStyles.css
@@ -119,61 +119,6 @@ code {
 	padding: 2px;
 }
 
-.sectionTitle {
-	display: flex;
-	gap: 8px;
-	align-items: center;
-	font-size: 1rem;
-}
-
-.fieldWrapper {
-	position: relative;
-	width: 100%;
-	margin-top: 16px;
-}
-
-:is(.fieldWrapper, .fieldWrapperMain) > .name {
-	position: absolute;
-	top: 0;
-	left: 8px;
-	background: var(--builderBackgroundColor);
-	padding: 0 4px 4px 4px;
-	font-size: 0.7rem;
-	z-index: 1;
-}
-
-:is(.fieldWrapper, .fieldWrapperMain) .name .type {
-	color: var(--builderSecondaryTextColor);
-}
-
-:is(.fieldWrapper, .fieldWrapperMain) .content {
-	position: relative;
-	top: 6px;
-	margin-bottom: 14px;
-	width: 100%;
-	border-radius: 4px;
-	border: 1px solid var(--builderSeparatorColor);
-	font-size: 0.75rem;
-	background: var(--builderBackgroundColor);
-	outline: none;
-}
-
-:is(.fieldWrapper, .fieldWrapperMain) .content:focus-within {
-	border: 1px solid var(--builderPrimaryTextColor);
-}
-
-:is(.fieldWrapper, .fieldWrapperMain) .content textarea,
-:is(.fieldWrapper, .fieldWrapperMain) .content input {
-	border: 0;
-	outline: none;
-	width: 100%;
-}
-
-.fieldWrapper > .desc {
-	color: var(--builderSecondaryTextColor);
-	font-size: 0.7rem;
-}
-
 .chipStack {
 	display: flex;
 	flex-direction: row;
@@ -200,19 +145,4 @@ code {
 
 .chip.active {
 	background: var(--builderSubtleSeparatorColor);
-}
-
-.countLabel {
-	background: var(--builderIntenseSelectedColor);
-	display: inline-flex;
-	color: var(--builderBackgroundColor);
-	align-items: center;
-	justify-content: center;
-	padding-left: 4px;
-	padding-right: 4px;
-	min-width: 20px;
-	height: 20px;
-	border-radius: 10px;
-	margin-left: 8px;
-	font-size: 0.7rem;
 }

--- a/src/ui/src/builder/sharedStyles.css
+++ b/src/ui/src/builder/sharedStyles.css
@@ -118,31 +118,3 @@ code {
 	background-color: var(--builderSubtleSeparatorColor);
 	padding: 2px;
 }
-
-.chipStack {
-	display: flex;
-	flex-direction: row;
-	flex-wrap: wrap;
-	gap: 4px;
-}
-
-.chip {
-	font-size: 0.75rem;
-	border-radius: 16px;
-	padding: 8px 12px 8px 12px;
-	cursor: pointer;
-	outline: none;
-	background: var(--builderBackgroundColor);
-}
-
-.chip:focus,
-.chip.active:focus,
-.chip:hover,
-.chip.active:hover {
-	color: var(--builderBackgroundColor);
-	background: var(--builderActionOngoingColor);
-}
-
-.chip.active {
-	background: var(--builderSubtleSeparatorColor);
-}

--- a/src/ui/src/wds/WdsFieldWrapper.vue
+++ b/src/ui/src/wds/WdsFieldWrapper.vue
@@ -1,17 +1,38 @@
 <template>
 	<div class="WdsFieldWrapper colorTransformer">
-		<label>{{ label }}</label>
-		<div class="slotContainer" :class="{ frameSlot }"><slot></slot></div>
-		<div v-if="hint" class="hint">{{ hint }}</div>
+		<div v-if="label || helpButton" class="WdsFieldWrapper__title">
+			<label v-if="label" class="WdsFieldWrapper__title__label">{{
+				label
+			}}</label>
+			<button
+				v-if="helpButton"
+				class="WdsFieldWrapper__title__help"
+				variant="subtle"
+				:title="typeof helpButton === 'string' ? helpButton : undefined"
+				@click="$emit('helpClick')"
+			>
+				<i class="material-symbols-outlined">help</i>
+			</button>
+		</div>
+		<div class="WdsFieldWrapper__slot"><slot></slot></div>
+		<div v-if="hint" class="WdsFieldWrapper__hint">{{ hint }}</div>
 	</div>
 </template>
 
 <script setup lang="ts">
-defineProps<{
-	label: string;
-	hint?: string;
-	frameSlot?: boolean;
-}>();
+defineProps({
+	label: { type: String, required: false, default: undefined },
+	hint: { type: String, required: false, default: undefined },
+	helpButton: {
+		type: [String, Boolean],
+		required: false,
+		default: undefined,
+	},
+});
+
+defineEmits({
+	helpClick: () => true,
+});
 </script>
 
 <style scoped>
@@ -23,26 +44,34 @@ defineProps<{
 	gap: 4px;
 }
 
-label {
+.WdsFieldWrapper__title {
 	color: var(--primaryTextColor);
+	display: grid;
+	grid-template-columns: 1fr auto;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.WdsFieldWrapper__title__help {
+	background-color: transparent;
+	border: none;
+	border-radius: 50%;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+}
+.WdsFieldWrapper__title__help:hover {
+	color: var(--primaryColor);
+}
+
+.WdsFieldWrapper__title__label {
 	font-size: 14px;
 	font-weight: 400;
 	line-height: 20px;
 }
 
-.slotContainer.frameSlot {
-	border-radius: 8px;
-	padding: 8.5px 12px 8.5px 12px;
-	font-size: 0.875rem;
-	border: 1px solid var(--separatorColor);
-}
-
-.slotContainer.frameSlot:focus-within {
-	border: 1px solid var(--softenedAccentColor);
-	box-shadow: 0px 0px 0px 3px rgba(81, 31, 255, 0.05);
-}
-
-.hint {
+.WdsFieldWrapper__hint {
 	color: var(--secondaryTextColor);
 	margin-top: 4px;
 	font-family: Poppins;

--- a/src/ui/src/wds/WdsTab.vue
+++ b/src/ui/src/wds/WdsTab.vue
@@ -1,0 +1,48 @@
+<template>
+	<button
+		class="WdsTab"
+		:class="{ 'WdsTab--disabled': disabled, 'WdsTab--selected': selected }"
+		type="button"
+		@click="$emit('click')"
+	>
+		<slot />
+	</button>
+</template>
+
+<script setup lang="ts">
+defineProps({
+	disabled: { type: Boolean },
+	selected: { type: Boolean },
+});
+
+defineEmits({
+	click: () => true,
+});
+</script>
+
+<style scoped>
+.WdsTab {
+	/* reset button */
+	border: none;
+	background-color: transparent;
+	cursor: pointer;
+
+	padding: 4px 20px 4px 20px;
+	gap: 10px;
+	border-radius: 8px;
+}
+
+/* TODO: use color tokens */
+
+.WdsTab:hover {
+	background-color: #f3f5ff;
+}
+
+.WdsTab--disabled {
+	color: #828282;
+}
+
+.WdsTab--selected {
+	background-color: #e4e9ff;
+}
+</style>

--- a/src/ui/src/wds/WdsTabs.vue
+++ b/src/ui/src/wds/WdsTabs.vue
@@ -1,0 +1,39 @@
+<template>
+	<div class="WdsTabs">
+		<WdsTab
+			v-for="tab of tabs"
+			:key="tab.value"
+			:disabled="tab.disabled"
+			:selected="tab.value === selected"
+			@click="selected = tab.value"
+			>{{ tab.label }}</WdsTab
+		>
+	</div>
+</template>
+
+<script lang="ts">
+export interface WdsTabOptions<Value extends string = string> {
+	label: string;
+	value: Value;
+	disabled?: boolean;
+}
+</script>
+
+<script setup lang="ts">
+import { PropType } from "vue";
+import WdsTab from "./WdsTab.vue";
+
+defineProps({
+	tabs: { type: Array as PropType<WdsTabOptions[]>, required: true },
+});
+
+const selected = defineModel({ type: String });
+</script>
+
+<style scoped>
+.WdsTabs {
+	display: flex;
+	gap: 16px;
+	flex-wrap: wrap;
+}
+</style>

--- a/src/ui/src/wds/WdsTextInput.vue
+++ b/src/ui/src/wds/WdsTextInput.vue
@@ -2,20 +2,17 @@
 	<div
 		v-if="leftIcon"
 		class="WdsTextInput WdsTextInput--leftIcon colorTransformer"
+		v-bind="$attrs"
 		@click="input.focus()"
 	>
 		<i class="material-symbols-outlined">{{ leftIcon }}</i>
-		<input
-			ref="input"
-			v-model="model"
-			type="text"
-			:placeholder="placeholder"
-		/>
+		<input ref="input" v-model="model" v-bind="$attrs" />
 	</div>
 	<input
 		v-else
+		v-bind="$attrs"
+		ref="input"
 		v-model="model"
-		type="text"
 		class="WdsTextInput colorTransformer"
 	/>
 </template>
@@ -25,12 +22,40 @@ import { ref } from "vue";
 
 const model = defineModel({ type: String });
 
+// disable attributes inheritance to apply attr to nested input
+defineOptions({ inheritAttrs: false });
+
 defineProps({
 	leftIcon: { type: String, required: false, default: undefined },
-	placeholder: { type: String, required: false, default: undefined },
 });
 
-const input = ref();
+defineExpose({
+	focus,
+	getSelection,
+	value: model,
+	setSelectionEnd,
+	setSelectionStart,
+});
+
+const input = ref<HTMLInputElement>();
+
+function setSelectionStart(value: number) {
+	if (input.value) input.value.selectionStart = value;
+}
+function setSelectionEnd(value: number) {
+	if (input.value) input.value.selectionEnd = value;
+}
+
+function getSelection() {
+	return {
+		selectionStart: input.value?.selectionStart,
+		selectionEnd: input.value?.selectionEnd,
+	};
+}
+
+function focus() {
+	input.value?.focus();
+}
 </script>
 
 <style scoped>

--- a/src/ui/src/wds/WdsTextareaInput.vue
+++ b/src/ui/src/wds/WdsTextareaInput.vue
@@ -1,9 +1,39 @@
 <template>
-	<textarea v-model="model"></textarea>
+	<textarea ref="input" v-model="model"></textarea>
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
+
 const model = defineModel<string>();
+
+defineExpose({
+	focus,
+	getSelection,
+	value: model,
+	setSelectionEnd,
+	setSelectionStart,
+});
+
+const input = ref<HTMLTextAreaElement>();
+
+function setSelectionStart(value: number) {
+	if (input.value) input.value.selectionStart = value;
+}
+function setSelectionEnd(value: number) {
+	if (input.value) input.value.selectionEnd = value;
+}
+
+function getSelection() {
+	return {
+		selectionStart: input.value?.selectionStart,
+		selectionEnd: input.value?.selectionEnd,
+	};
+}
+
+function focus() {
+	input.value?.focus();
+}
 </script>
 
 <style scoped>

--- a/tests/e2e/tests/state.spec.ts
+++ b/tests/e2e/tests/state.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from "@playwright/test";
 const setTextField = async (page, text) => {
 	await page.locator('div.CoreText.component').click();
 	await page
-		.locator('.BuilderFieldsText[data-automation-key="text"] .templateInput')
+		.locator('.BuilderFieldsText[data-automation-key="text"] textarea')
 		.fill(text);
 }
 

--- a/tests/e2e/tests/stateAutocompletion.spec.ts
+++ b/tests/e2e/tests/stateAutocompletion.spec.ts
@@ -71,7 +71,7 @@ test.describe("state autocompletion", () => {
 
 			await page.locator('div.CoreRadioInput.component > label').click();
 			await page
-				.locator(`${FIELD} button.chip:text-matches("Static List")`)
+				.locator(`${FIELD} button.WdsTab:text-matches("Static List")`)
 				.click();
 			await page
 				.locator(`${FIELD} .inputKey input`)
@@ -102,7 +102,7 @@ test.describe("state autocompletion", () => {
 
 			await page.locator('div.CoreRadioInput.component > label').click();
 			await page
-				.locator(`${FIELD} button.chip:text-matches("JSON")`)
+				.locator(`${FIELD} button.WdsTab:text-matches("JSON")`)
 				.click();
 			await page
 				.locator(`${FIELD} textarea`)
@@ -122,7 +122,7 @@ test.describe("state autocompletion", () => {
 			const FIELD = `.${type}[data-automation-key="${key}"]`; 
 			await page.locator(componentSelector).click();
 			await page
-				.locator(`${FIELD} button.chip:text-matches("CSS")`)
+				.locator(`${FIELD} button.WdsTab:text-matches("CSS")`)
 				.click();
 			await page
 				.locator(`${FIELD} .BuilderTemplateInput input`)

--- a/tests/e2e/tests/stateAutocompletion.spec.ts
+++ b/tests/e2e/tests/stateAutocompletion.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from "@playwright/test";
 const setTextField = async (page, text) => {
 	await page.locator('div.CoreText.component').click();
 	await page
-		.locator('.BuilderFieldsText[data-automation-key="text"] .templateInput')
+		.locator('.BuilderFieldsText[data-automation-key="text"] textarea')
 		.fill(text);
 }
 
@@ -29,7 +29,7 @@ test.describe("state autocompletion", () => {
 			await setTextField(page, "@{types.");
 			page.locator('.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.prop:text-matches("string")').click();
 			await expect(page
-				.locator('.BuilderFieldsText[data-automation-key="text"] .templateInput'))
+				.locator('.BuilderFieldsText[data-automation-key="text"] textarea'))
 				.toHaveValue("@{types.string");
 		});
 		test("counter", async ({ page }) => {
@@ -55,7 +55,7 @@ test.describe("state autocompletion", () => {
 		test("options should show on focus", async ({ page }) => {
 			await page.locator('div.CoreText.component').click();
 			await page
-				.locator('.BuilderFieldsText[data-automation-key="useMarkdown"] .templateInput')
+				.locator('.BuilderFieldsText[data-automation-key="useMarkdown"] input')
 				.focus();
 			await expect(page.locator('.BuilderFieldsText[data-automation-key="useMarkdown"] datalist option[value="yes"]')).toHaveCount(1);
 			await expect(page.locator('.BuilderFieldsText[data-automation-key="useMarkdown"] datalist option[value="no"]')).toHaveCount(1);
@@ -74,22 +74,22 @@ test.describe("state autocompletion", () => {
 				.locator(`${FIELD} button.chip:text-matches("Static List")`)
 				.click();
 			await page
-				.locator(`${FIELD} .inputKey .templateInput`)
+				.locator(`${FIELD} .inputKey input`)
 				.fill("@{types.");
 			await expect(page.locator(`${FIELD} .inputKey .fieldStateAutocomplete span.prop`)).toHaveText(["none", "string", "integer", "float"]);
 			await expect(page.locator(`${FIELD} .inputKey .fieldStateAutocomplete span.type`)).toHaveText(["null", "string", "number", "number"]);
 			page.locator(`${FIELD} .inputKey .fieldStateAutocomplete span.prop:text-matches("string")`).click();
 			await expect(page
-				.locator(`${FIELD} .inputKey .templateInput`))
+				.locator(`${FIELD} .inputKey input`))
 				.toHaveValue("@{types.string");
 			await page
-				.locator(`${FIELD} .inputValue .templateInput`)
+				.locator(`${FIELD} .inputValue input`)
 				.fill("@{types.");
 			await expect(page.locator(`${FIELD} .inputValue .fieldStateAutocomplete span.prop`)).toHaveText(["none", "string", "integer", "float"]);
 			await expect(page.locator(`${FIELD} .inputValue .fieldStateAutocomplete span.type`)).toHaveText(["null", "string", "number", "number"]);
 			page.locator(`${FIELD} .inputValue .fieldStateAutocomplete span.prop:text-matches("string")`).click();
 			await expect(page
-				.locator(`${FIELD} .inputValue .templateInput`))
+				.locator(`${FIELD} .inputValue input`))
 				.toHaveValue("@{types.string");
 			await page.locator('[data-automation-action="delete"]').click();
 		});
@@ -105,13 +105,13 @@ test.describe("state autocompletion", () => {
 				.locator(`${FIELD} button.chip:text-matches("JSON")`)
 				.click();
 			await page
-				.locator(`${FIELD} .templateInput`)
+				.locator(`${FIELD} textarea`)
 				.fill("@{types.");
 			await expect(page.locator(`${FIELD} .fieldStateAutocomplete span.prop`)).toHaveText(["none", "string", "integer", "float"]);
 			await expect(page.locator(`${FIELD} .fieldStateAutocomplete span.type`)).toHaveText(["null", "string", "number", "number"]);
 			page.locator(`${FIELD} .fieldStateAutocomplete span.prop:text-matches("string")`).click();
 			await expect(page
-				.locator(`${FIELD} .templateInput`))
+				.locator(`${FIELD} textarea`))
 				.toHaveValue("@{types.string");
 			await page.locator('[data-automation-action="delete"]').click();
 		});
@@ -125,13 +125,13 @@ test.describe("state autocompletion", () => {
 				.locator(`${FIELD} button.chip:text-matches("CSS")`)
 				.click();
 			await page
-				.locator(`${FIELD} .templateInput`)
+				.locator(`${FIELD} .BuilderTemplateInput input`)
 				.fill("@{types.");
 			await expect(page.locator(`${FIELD} .fieldStateAutocomplete span.prop`)).toHaveText(["none", "string", "integer", "float"]);
 			await expect(page.locator(`${FIELD} .fieldStateAutocomplete span.type`)).toHaveText(["null", "string", "number", "number"]);
 			page.locator(`${FIELD} .fieldStateAutocomplete span.prop:text-matches("string")`).click();
 			await expect(page
-				.locator(`${FIELD} .templateInput`))
+				.locator(`${FIELD} .BuilderTemplateInput input`))
 				.toHaveValue("@{types.string");
 		});
 	}


### PR DESCRIPTION
- Use `WdsTextField` and `WdsFieldWrapper` in the builder to respect the design system.
- Adapt the design on settings fields to make it compliant

| before | after |
|---|---|
| ![image](https://github.com/user-attachments/assets/21b99b1a-dcf2-4d03-86ae-65b379dba410) | ![image](https://github.com/user-attachments/assets/27707711-9263-4a3f-b968-52ca5d881dab) |
| ![image](https://github.com/user-attachments/assets/26abd2b2-c891-41ad-9134-723f5cc61949)  | ![image](https://github.com/user-attachments/assets/b53ffd53-7b37-455d-a41d-53947a4c7031) |
| ![image](https://github.com/user-attachments/assets/75c6afe0-4639-41ae-8cfa-42fd941cdd04) | ![image](https://github.com/user-attachments/assets/99c5aead-9d87-4b5b-acf7-9a81e2515de9) |

