### PR TITLE
fix: patch with fake_generate_content instead of replacing the original

### DIFF
--- a/tests/backend/blocks/test_writernocodeapp.py
+++ b/tests/backend/blocks/test_writernocodeapp.py
@@ -1,9 +1,9 @@
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import writer.ai
 from writer.blocks.writernocodeapp import WriterNoCodeApp
-from unittest.mock import AsyncMock, MagicMock, patch
 
 
 @pytest.fixture


### PR DESCRIPTION
Replacing the original functions led to fails on consecutive tests. This avoids it, patching the function in the context of the test.