### PR TITLE
fix(ui): fix `BuilderFieldsAlign` binding

### DIFF
--- a/src/ui/src/builder/settings/BuilderFieldsAlign.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsAlign.vue
@@ -42,9 +42,9 @@
 		<div v-if="mode == 'pick' || mode == 'css'" class="main">
 			<div v-if="mode == 'pick'" class="pickerContainer">
 				<BuilderSelect
-					:value="subMode"
+					:model-value="subMode"
 					:options="selectOptions"
-					@input="handleInputSelect"
+					@update:model-value="handleInputSelect"
 				/>
 			</div>
 


### PR DESCRIPTION
Fix a small regression from https://github.com/writer/writer-framework/pull/638 , the `BuilderFieldsAlign` is not correctly binded to the `v-model` directive.


https://github.com/user-attachments/assets/7d823cfd-47d7-4c7e-860f-43b99db1f3f0


