### PR TITLE
fix(ui): improve design of collapse button

### DIFF
--- a/src/ui/src/components/core/base/BaseCollapseButton.vue
+++ b/src/ui/src/components/core/base/BaseCollapseButton.vue
@@ -9,21 +9,37 @@
 	</button>
 </template>
 
+<script lang="ts">
+export type Direction =
+	| "left-right"
+	| "top-bottom"
+	| "bottom-top"
+	| "right-left";
+</script>
+
 <script setup lang="ts">
 import { computed, PropType } from "vue";
 
 const props = defineProps({
-	direction: {
-		type: String as PropType<"left-right" | "top-bottom">,
-		required: true,
-	},
+	direction: { type: String as PropType<Direction>, required: true },
 });
 
 const isCollapsed = defineModel({ type: Boolean, required: true });
 
-const icon = computed(() =>
-	props.direction === "left-right" ? "chevron_left" : "keyboard_arrow_up",
-);
+const icon = computed(() => {
+	switch (props.direction) {
+		case "left-right":
+			return "chevron_left";
+		case "top-bottom":
+			return "keyboard_arrow_up";
+		case "right-left":
+			return "chevron_right";
+		case "bottom-top":
+			return "keyboard_arrow_down";
+		default:
+			return "keyboard_arrow_up";
+	}
+});
 </script>
 
 <style scoped>

--- a/src/ui/src/components/core/layout/CoreColumn.vue
+++ b/src/ui/src/components/core/layout/CoreColumn.vue
@@ -17,7 +17,7 @@
 				v-if="isCollapsible"
 				v-model="isCollapsed"
 				class="collapser"
-				direction="left-right"
+				direction="top-bottom"
 			/>
 		</div>
 		<div v-if="isCollapsed && fields.title.value" class="collapsedTitle">
@@ -210,25 +210,6 @@ watch(
 .CoreColumn > .header > .collapser {
 	order: 2;
 	flex: 0 0 32px;
-}
-
-.CoreColumn > .header > .collapser > .collapserArrow {
-	transition: all 0.5s ease-in-out;
-	transform: rotate(0deg);
-}
-
-.CoreColumn:not(.collapsibleToRight).collapsed
-	> .header
-	> .collapser
-	> .collapserArrow {
-	transform: rotate(180deg);
-}
-
-.CoreColumn.collapsibleToRight:not(.collapsed)
-	> .header
-	> .collapser
-	> .collapserArrow {
-	transform: rotate(180deg);
 }
 
 .CoreColumn.collapsibleToRight > .header {

--- a/src/ui/src/components/core/layout/CoreColumn.vue
+++ b/src/ui/src/components/core/layout/CoreColumn.vue
@@ -17,7 +17,7 @@
 				v-if="isCollapsible"
 				v-model="isCollapsed"
 				class="collapser"
-				direction="top-bottom"
+				:direction="collapseDirection"
 			/>
 		</div>
 		<div v-if="isCollapsed && fields.title.value" class="collapsedTitle">
@@ -48,7 +48,6 @@ import {
 	startCollapsed,
 	isCollapsible as isCollapsibleField,
 } from "@/renderer/sharedStyleFields";
-import BaseCollapseButton from "../base/BaseCollapseButton.vue";
 
 const description =
 	"A layout component that organizes its child components in columns. Must be inside a Column Container component.";
@@ -100,7 +99,10 @@ export default {
 <script setup lang="ts">
 import { computed, ComputedRef, inject, Ref, ref, watch } from "vue";
 import injectionKeys from "@/injectionKeys";
-import BaseContainer from "../base/BaseContainer.vue";
+import BaseContainer from "@/components/core/base/BaseContainer.vue";
+import BaseCollapseButton from "@/components/core/base/BaseCollapseButton.vue";
+import type { Direction } from "@/components/core/base/BaseCollapseButton.vue";
+
 const instancePath = inject(injectionKeys.instancePath);
 const instanceData = inject(injectionKeys.instanceData);
 const wf = inject(injectionKeys.core);
@@ -136,6 +138,10 @@ const isCollapsibleToRight = computed(
 	() =>
 		position.value >=
 		columnsData.value?.value?.minimumNonCollapsiblePosition,
+);
+
+const collapseDirection = computed<Direction>(() =>
+	isCollapsibleToRight.value ? "right-left" : "left-right",
 );
 
 const columnsData: ComputedRef<Ref> = computed(() => {

--- a/src/ui/src/components/core/layout/CoreSection.vue
+++ b/src/ui/src/components/core/layout/CoreSection.vue
@@ -112,6 +112,7 @@ const isCollapsed = ref<boolean>(
 	margin: 16px 16px 0 16px;
 	display: grid;
 	grid-template-columns: 1fr auto;
+	align-items: center;
 }
 .CoreSection__title--collapsed {
 	margin: 16px;

--- a/src/ui/src/components/core/layout/CoreSidebar.vue
+++ b/src/ui/src/components/core/layout/CoreSidebar.vue
@@ -137,23 +137,6 @@ onMounted(() => {
 	margin-bottom: 16px;
 }
 
-.collapserContainer > .collapser {
-	flex: 0 0 32px;
-}
-
-.collapserContainer .collapserArrow {
-	transition: all 0.5s ease-in-out;
-	transform: rotate(0deg);
-}
-
-.CoreSidebar.collapsed .collapserArrow {
-	transform: rotate(180deg);
-}
-
-.collapserContainer > .collapser:hover {
-	background: var(--separatorColor);
-}
-
 @media only screen and (max-width: 768px) {
 	.CoreSidebar {
 		min-width: 100%;
@@ -163,10 +146,6 @@ onMounted(() => {
 
 	.CoreSidebar.collapsed > .collapserContainer {
 		margin-bottom: 0;
-	}
-
-	.collapserContainer > .collapser {
-		transform: rotate(90deg);
 	}
 }
 </style>


### PR DESCRIPTION
- The `CoreColumn` displayed the collapse arrow in the wrong direction
- The `CoreSection` title wasn't vertical aligned with the button
- Remove dead CSS code