### PR TITLE
feat/implement local storage persistence - WF-93

### DIFF
--- a/docs/framework/frontend-scripts.mdx
+++ b/docs/framework/frontend-scripts.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Frontend scripts"
+title: "Frontend actions"
 ---
 
-Framework can import custom JavaScript/ES6 modules from the front-end. Module functions can be triggered from the back-end.
+Framework can interact with frontend to import custom JavaScript/ES6 modules, set data into local storage, trigger module functions, ...
 
 ## Importing an ES6 module
 
@@ -84,6 +84,44 @@ initial_state = wf.init_state({
 
 initial_state.import_script("lodash", "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.js")
 ```
+
+## Local storage
+
+Framework provides functions to interact with browser's local storage. This mechanism allows information such as user preferences to be persisted between several sessions.
+
+*  `state.local_storage_set_item(key, value)`: set a value in local storage.
+*  `state.local_storage_remove_item(key)`: remove a key from local storage.
+
+```python
+# Event handler register on root:wf-app-open
+def on_app_open(state, session):
+    state['last_visit'] = session['local_storage'].get('last_visit', "")
+    state['dark_mode'] = session['local_storage'].get('dark_mode', "False") == "True"
+    state.local_storage_set_item("last_visit", str(datetime.now()))
+
+
+def on_dark_mode_toggle(state, payload):
+    state['dark_mode'] = payload
+    state.local_storage_set_item("dark_mode", str(state['dark_mode']))
+
+
+initial_state = wf.init_state({
+    "last_visit": "",
+    "dark_mode": False
+})
+```
+
+<Warning>
+	Framework propose a binding on [Local storage API](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage). It support only raw value. Your application has to serialize the data before storing it. Framework won't do it for you.
+</Warning>
+
+<Warning>
+	Local storage is not secure and should not be used to store sensitive data without encryption. It's accessible to anyone with access to the user's device.
+</Warning>
+
+<Info>
+	Content of local storage is loaded in `session` on the init request. If a JS function change a value inside, it won't be reflected. Change from the backend are reflected.
+</Info>
 
 ## Frontend core
 

--- a/docs/framework/sessions.mdx
+++ b/docs/framework/sessions.mdx
@@ -8,7 +8,7 @@ Sessions are designed for advanced use cases, being most relevant when Framework
 
 You can access the session's unique id, HTTP headers and cookies from event handlers via the `session` argument —similarly to how `state` and `payload` are accessed. The data made available here is captured in the HTTP request that initialised the session.
 
-The `session` argument will contain a dictionary with the following keys: `id`, `cookies` and `headers`. Values for the last two are themselves dictionaries.
+The `session` argument will contain a dictionary with the following keys: `id`, `cookies`, `headers` and `local_storage`. Values for the last three are themselves dictionaries.
 
 ```py
 # The following will output a dictionary

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -60,12 +60,20 @@ export function generateCore() {
 		addMailSubscription("pageChange", (pageKey: string) => {
 			setActivePageFromKey(pageKey);
 		});
-		addMailSubscription("localStorageSetItem", (event) => {
-			localStorage.setItem("wf." + event.key, JSON.stringify(event.value));
-		});
-		addMailSubscription("localStorageRemoveItem", (event) => {
-			localStorage.removeItem("wf." + event.key);
-		});
+		addMailSubscription(
+			"localStorageSetItem",
+			(event: LocalStorageSetItemEvent) => {
+				localStorage.setItem(event.key, event.value);
+			},
+		);
+
+		addMailSubscription(
+			"localStorageRemoveItem",
+			(event: LocalStorageRemoveItemEvent) => {
+				localStorage.removeItem(event.key);
+			},
+		);
+
 		sendKeepAliveMessage();
 		if (mode.value != "edit") return;
 	}
@@ -79,10 +87,7 @@ export function generateCore() {
 		const localStorageItems = {};
 		for (let i = 0; i < localStorage.length; i++) {
 			const key = localStorage.key(i);
-			if (key.startsWith("wf.")) {
-				const value = localStorage.getItem(key);
-				localStorageItems[key.replace("wf.", "")] = JSON.parse(value);
-			}
+			localStorageItems[key] = localStorage.getItem(key);
 		}
 
 		const response = await fetch("./api/init", {

--- a/src/ui/src/writerTypes.ts
+++ b/src/ui/src/writerTypes.ts
@@ -164,3 +164,12 @@ export type AbstractTemplate = {
 };
 
 export type TemplateMap = Record<string, VueComponent>;
+
+export type LocalStorageSetItemEvent = {
+	key: string;
+	value: string;
+};
+
+export type LocalStorageRemoveItemEvent = {
+	key: string;
+};

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -177,7 +177,6 @@ class AppProcess(multiprocessing.Process):
         import traceback as tb
 
         result = session.event_handler.handle(event)
-
         mutations = {}
 
         try:

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -145,7 +145,7 @@ class AppProcess(multiprocessing.Process):
 
         session = writer.session_manager.get_session(payload.proposedSessionId, restore_initial_mail=True)
         if session is None:
-            session = writer.session_manager.get_new_session(payload.cookies, payload.headers, payload.proposedSessionId)
+            session = writer.session_manager.get_new_session(payload.cookies, payload.headers, payload.localStorage, payload.proposedSessionId)
 
         if session is None:
             raise MessageHandlingException("Session rejected.")

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -293,7 +293,8 @@ def get_asgi_app(
         app_response = await app_runner.init_session(InitSessionRequestPayload(
             cookies=dict(request.cookies),
             headers=dict(request.headers),
-            proposedSessionId=initBody.proposedSessionId
+            proposedSessionId=initBody.proposedSessionId,
+            localStorage=initBody.localStorage,
         ))
 
         status = app_response.status

--- a/src/writer/ss_types.py
+++ b/src/writer/ss_types.py
@@ -38,6 +38,7 @@ class AbstractTemplate(BaseModel):
 
 class InitRequestBody(BaseModel):
     proposedSessionId: Optional[str] = None
+    localStorage: Optional[Dict[str, Any]] = None
 
 
 class InitResponseBody(BaseModel):
@@ -83,6 +84,7 @@ class AppProcessServerRequest(BaseModel):
 class InitSessionRequestPayload(BaseModel):
     cookies: Optional[Dict[str, str]] = None
     headers: Optional[Dict[str, str]] = None
+    localStorage: Optional[Dict[str, Any]] = None
     proposedSessionId: Optional[str] = None
 
 class InitSessionRequest(AppProcessServerRequest):

--- a/tests/backend/fixtures/app_runner_fixtures.py
+++ b/tests/backend/fixtures/app_runner_fixtures.py
@@ -1,7 +1,9 @@
+import contextlib
 from typing import Optional
 
 from writer.app_runner import AppRunner
-from writer.ss_types import InitSessionRequestPayload
+from writer.core import session_manager, use_request_context
+from writer.ss_types import AppProcessServerRequest, InitSessionRequestPayload
 
 FIXED_SESSION_ID = "0000000000000000000000000000000000000000000000000000000000000000" # Compliant session number
 
@@ -32,3 +34,23 @@ async def init_app_session(app_runner: AppRunner,
     result = await app_runner.init_session(init_session_payload)
 
     return result.payload.model_dump().get("sessionId")
+
+
+@contextlib.contextmanager
+def within_message_request(session_id=FIXED_SESSION_ID, request: AppProcessServerRequest=None):
+    """
+    This fixture starts a session and emulates the context of an event message.
+
+    >>>  with within_message_request():
+    >>>    _session = core.get_session()
+    >>>    _session.local_storage['key'] = "value"
+
+    :param session_id: the session identifier
+    :param request: the request to create
+    """
+    if request is None:
+        request = AppProcessServerRequest(type="event")
+
+    session_manager.get_new_session(proposed_session_id=session_id)
+    with use_request_context(session_id=session_id, request=request):
+        yield


### PR DESCRIPTION
The application can save values ​​in local storage and retrieve them when the user reloads their page. This pattern allows you to introduce persistence beyond the current session.

implement #578
---

![Peek 2024-12-11 08-37](https://github.com/user-attachments/assets/5f649c31-450b-4504-9fc1-0641ca228ba0)
