### PR TITLE
docs: Fix image URLs in Intro and Builder Basics

### DIFF
--- a/docs/framework/builder-basics.mdx
+++ b/docs/framework/builder-basics.mdx
@@ -10,13 +10,13 @@ You can switch modes between _User Interface_, _Code_ and _Preview_ using the bu
 
 ### User Interface
 
-![Framework Builder - Mode: User Interface](/framework/images/builder-basics.ui.png#framework)
+![Framework Builder - Mode: User Interface](/framework/images/builder-basics.ui.png)
 
 The default mode. Allows you to focus on building the interface.
 
 ### Code
 
-![Framework Builder - Mode: Code](/framework/images/builder-basics.code.png#framework)
+![Framework Builder - Mode: Code](/framework/images/builder-basics.code.png)
 
 This mode displays the **code editor** and the **application log**, while still allowing you to access the _Component Tree_ and _Settings_.
 
@@ -35,7 +35,7 @@ This mode displays the **code editor** and the **application log**, while still 
 
 ### Preview
 
-![Framework Builder - Mode: Preview](/framework/images/builder-basics.preview.png#framework)
+![Framework Builder - Mode: Preview](/framework/images/builder-basics.preview.png)
 
 The _Preview_ mode shows the application exactly like the user will see it. It allocates the whole width of the viewport to the app.
 

--- a/docs/framework/introduction.mdx
+++ b/docs/framework/introduction.mdx
@@ -4,7 +4,7 @@ title: "Introduction"
 
 The Writer Framework lets you build feature-rich apps by using a drag-and-drop visual editor called **the Builder** and writing the back-end code in Python. It's fast and flexible, with clean, easy-to-test syntax. It provides separation of concerns between UI and business logic, enabling more complex apps.
 
-![Framework Builder screenshot](/framework/public/builder.png#framework) 
+![Framework Builder screenshot](/framework/public/builder.png) 
 
 Build AI apps with the Writer Framework when:
 


### PR DESCRIPTION
This PR removes the `#` from image URLs in the Introduction and Builder Basics docs.