### PR TITLE
fix(ui): re-introduce fields unit in Builder - WF-127

### DIFF
--- a/src/ui/src/builder/settings/BuilderSettingsProperties.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsProperties.vue
@@ -28,7 +28,7 @@
 							: fieldValue.name ?? fieldKey
 					"
 					:hint="fieldValue.desc"
-					:type="fieldValue.type"
+					:unit="fieldValue.type"
 				>
 					<BuilderFieldsColor
 						v-if="fieldValue.type == FieldType.Color"

--- a/src/ui/src/wds/WdsFieldWrapper.vue
+++ b/src/ui/src/wds/WdsFieldWrapper.vue
@@ -1,9 +1,12 @@
 <template>
 	<div class="WdsFieldWrapper colorTransformer">
 		<div v-if="label || helpButton" class="WdsFieldWrapper__title">
-			<label v-if="label" class="WdsFieldWrapper__title__label">{{
-				label
-			}}</label>
+			<label v-if="label" class="WdsFieldWrapper__title__label"
+				>{{ label
+				}}<span v-if="unit" class="WdsFieldWrapper__title__label__unit"
+					>&nbsp;:&nbsp;{{ unit }}</span
+				>
+			</label>
 			<button
 				v-if="helpButton"
 				class="WdsFieldWrapper__title__help"
@@ -22,6 +25,7 @@
 <script setup lang="ts">
 defineProps({
 	label: { type: String, required: false, default: undefined },
+	unit: { type: String, required: false, default: undefined },
 	hint: { type: String, required: false, default: undefined },
 	helpButton: {
 		type: [String, Boolean],
@@ -69,6 +73,9 @@ defineEmits({
 	font-size: 14px;
 	font-weight: 400;
 	line-height: 20px;
+}
+.WdsFieldWrapper__title__label__unit {
+	color: var(--secondaryTextColor);
 }
 
 .WdsFieldWrapper__hint {


### PR DESCRIPTION
Restore the field unit removed in https://github.com/writer/writer-framework/pull/657

| before | after |
|---|---|
| ![image](https://github.com/user-attachments/assets/a0a5dfde-8b6b-4e74-a234-72ddbfcb73a6) | ![image](https://github.com/user-attachments/assets/3ba0728b-b013-42b0-8e8e-7309776f379b) |
