### PR TITLE
fix(ui): add `min-width` to `CoreTimer` - WF-130

### DIFF
--- a/src/ui/src/components/core/other/CoreTimer.vue
+++ b/src/ui/src/components/core/other/CoreTimer.vue
@@ -94,7 +94,7 @@ watch(isTickHandlerSet, async (newIsTickHandlerSet) => {
 });
 
 let animationTriggeredTime: number = 0;
-let activeTimerId: number = null;
+let activeTimerId: ReturnType<typeof setTimeout> = null;
 
 function clearActiveTimer() {
 	clearTimeout(activeTimerId);
@@ -134,6 +134,7 @@ onMounted(() => {
 <style scoped>
 .CoreTimer {
 	width: 12px;
+	min-width: 12px;
 	height: 12px;
 	background: var(--accentColor);
 	border-radius: 50%;


### PR DESCRIPTION
The `CoreTimer` component has no minimum width, which makes it indivisibles inside a `CoreHortizontalStack` component because these components force child components to have `width: auto` (see #600).

I double-checked, and it seems `CoreTimer` the only component affected by this issue.