### PR TITLE
fix(ui): adapt Dataframe bg color when selected - WF-131

### DIFF
--- a/src/ui/src/components/core/content/CoreDataframe.vue
+++ b/src/ui/src/components/core/content/CoreDataframe.vue
@@ -696,6 +696,11 @@ onUnmounted(() => {
 	max-height: 90vh;
 }
 
+/* remove the background if the dataframe is being selected in builder mode */
+.CoreDataframe.selected .gridContainer {
+	background: unset;
+}
+
 .grid {
 	margin-bottom: -1px;
 	position: v-bind("isRowCountMassive ? 'sticky': 'unset'");

--- a/src/ui/src/components/core/content/CoreDataframeLegacy.vue
+++ b/src/ui/src/components/core/content/CoreDataframeLegacy.vue
@@ -573,6 +573,11 @@ onUnmounted(() => {
 	max-height: 90vh;
 }
 
+/* remove the background if the dataframe is being selected in builder mode */
+.CoreDataframe.selected .gridContainer {
+	background: unset;
+}
+
 .grid {
 	margin-bottom: -1px;
 	position: v-bind("isRowCountMassive ? 'sticky': 'unset'");


### PR DESCRIPTION
The `CoreDataframe` component has a custom background color set with `dataframeBackgroundColor` variable. This custom background prevents the user to seeing that this component is being selected in Builder mode.

The workaround is to simply `unset` the background color when the component has a `.selected` class.


https://github.com/user-attachments/assets/c8431363-6013-4df0-a1ac-3fc72978a8cd

