### PR TITLE
fix(ui): handle long text in `BuilderSelect`

### DIFF
--- a/src/ui/src/builder/BuilderSelect.vue
+++ b/src/ui/src/builder/BuilderSelect.vue
@@ -3,13 +3,18 @@
 		<button
 			class="BuilderSelect__trigger"
 			role="button"
-			:data-writer-tooltip="currentLabel"
 			@click="isOpen = !isOpen"
 		>
 			<i v-if="!hideIcons" class="material-symbols-outlined">{{
 				currentIcon
 			}}</i>
-			<div class="BuilderSelect__trigger__label">{{ currentLabel }}</div>
+			<div
+				class="BuilderSelect__trigger__label"
+				data-writer-tooltip-strategy="overflow"
+				:data-writer-tooltip="currentLabel"
+			>
+				{{ currentLabel }}
+			</div>
 			<div class="BuilderSelect__trigger__arrow">
 				<i class="material-symbols-outlined">{{ expandIcon }}</i>
 			</div>

--- a/src/ui/src/builder/BuilderSelect.vue
+++ b/src/ui/src/builder/BuilderSelect.vue
@@ -3,6 +3,7 @@
 		<button
 			class="BuilderSelect__trigger"
 			role="button"
+			:data-writer-tooltip="currentLabel"
 			@click="isOpen = !isOpen"
 		>
 			<i v-if="!hideIcons" class="material-symbols-outlined">{{
@@ -141,6 +142,7 @@ function onSelect(value: string) {
 	overflow: hidden;
 	flex-grow: 1;
 	text-align: left;
+	white-space: nowrap;
 }
 .BuilderSelect__trigger__arrow {
 	border: none;

--- a/src/ui/src/builder/BuilderTooltip.vue
+++ b/src/ui/src/builder/BuilderTooltip.vue
@@ -131,6 +131,7 @@ onUnmounted(() => {
 	display: content;
 	max-width: 260px;
 	filter: drop-shadow(0px 0px 12px rgba(0, 0, 0, 0.16));
+	word-break: break-all;
 }
 
 .arrow {

--- a/src/ui/src/builder/BuilderTooltip.vue
+++ b/src/ui/src/builder/BuilderTooltip.vue
@@ -43,7 +43,8 @@ async function setUpAndShowTooltip() {
 	const gapPx = trackedElement.dataset.writerTooltipGap
 		? parseInt(trackedElement.dataset.writerTooltipGap)
 		: DEFAULT_GAP_PX;
-	isActive.value = true;
+	isActive.value = canBeActive(trackedElement);
+	if (!isActive.value) return;
 	await nextTick();
 	const { x, y, width, height } = trackedElement.getBoundingClientRect();
 	const { width: tooltipWidth, height: tooltipHeight } =
@@ -67,6 +68,12 @@ async function setUpAndShowTooltip() {
 			position.value.left = x + width / 2 - tooltipWidth / 2;
 			break;
 	}
+}
+
+function canBeActive(el: HTMLElement) {
+	const strategy = el.getAttribute("data-writer-tooltip-strategy");
+	if (strategy === "overflow") return el.scrollWidth > el.clientWidth;
+	return true;
 }
 
 function handleMouseover(ev: MouseEvent) {
@@ -98,6 +105,7 @@ async function confirmTooltip(el: HTMLElement) {
 		attributeFilter: [
 			"data-writer-tooltip",
 			"data-writer-tooltip-placement",
+			"data-writer-tooltip-strategy",
 		],
 	});
 	setUpAndShowTooltip();

--- a/src/ui/src/wds/WdsDropdownMenu.vue
+++ b/src/ui/src/wds/WdsDropdownMenu.vue
@@ -138,6 +138,7 @@ watch(searchTerm, () => emits("search", searchTerm.value));
 }
 .WdsDropdownMenu__item__label {
 	text-overflow: ellipsis;
+	white-space: nowrap;
 	overflow: hidden;
 	text-align: left;
 }

--- a/src/ui/src/wds/WdsDropdownMenu.vue
+++ b/src/ui/src/wds/WdsDropdownMenu.vue
@@ -25,7 +25,11 @@
 			<i v-if="!hideIcons" class="material-symbols-outlined">{{
 				getOptionIcon(option)
 			}}</i>
-			<div class="WdsDropdownMenu__item__label">
+			<div
+				class="WdsDropdownMenu__item__label"
+				:data-writer-tooltip="option.label"
+				data-writer-tooltip-strategy="overflow"
+			>
 				{{ option.label }}
 			</div>
 			<i


### PR DESCRIPTION
The `BuilderSelect` trigger has overflow issues with long text containing breakable content. The trick was just a missing `white-space: nowrap` rule.

I also took the opportunity to add a tooltip to the `BuilderSelect`'s trigger.

![Screenshot 2024-12-18 at 19 15 29](https://github.com/user-attachments/assets/44d83828-de9d-48ca-b996-82ab66613378)
