### PR TITLE
chore(ui): improve icon fetching. WF-141

### DIFF
--- a/src/ui/src/components/core/content/CoreChatbot.vue
+++ b/src/ui/src/components/core/content/CoreChatbot.vue
@@ -401,7 +401,7 @@ function scrollToBottom() {
 }
 
 const encodeFile = async (file: File) => {
-	var reader = new FileReader();
+	const reader = new FileReader();
 	reader.readAsDataURL(file);
 
 	return new Promise((resolve, reject) => {

--- a/src/ui/src/components/shared/SharedImgWithFallback.spec.ts
+++ b/src/ui/src/components/shared/SharedImgWithFallback.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
+import SharedImgWithFallback from "./SharedImgWithFallback.vue";
+import { flushPromises, shallowMount } from "@vue/test-utils";
+
+describe("SharedImgWithFallback", () => {
+	let fetch: Mock;
+
+	beforeEach(() => {
+		fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			headers: new Map([["Content-Type", "image/png"]]),
+		});
+		global.fetch = fetch;
+	});
+
+	it("should use the last image because the first two are not valid", async () => {
+		fetch
+			.mockRejectedValueOnce(new Error())
+			.mockResolvedValueOnce({
+				ok: true,
+				headers: new Map([["Content-Type", "text/html"]]),
+			})
+			.mockResolvedValue({
+				ok: true,
+				headers: new Map([["Content-Type", "image/png"]]),
+			});
+
+		const wrapper = shallowMount(SharedImgWithFallback, {
+			props: { urls: ["/img1.svg", "/img2.svg", "/img3.svg"] },
+		});
+		expect(wrapper.get("img").attributes().src).toBe("");
+
+		await flushPromises();
+
+		expect(wrapper.get("img").attributes().src).toBe("/img3.svg");
+	});
+});

--- a/src/ui/src/components/shared/SharedImgWithFallback.vue
+++ b/src/ui/src/components/shared/SharedImgWithFallback.vue
@@ -1,0 +1,31 @@
+<template>
+	<img :src="src" />
+</template>
+
+<script lang="ts" setup>
+import { useAssetContentType } from "@/composables/useAssetContentType";
+import { PropType, ref, toRef, watch } from "vue";
+
+const props = defineProps({
+	urls: { type: Array as PropType<string[]>, required: true },
+});
+
+const src = ref("");
+
+const { fetchAssetContentType } = useAssetContentType();
+
+watch(
+	toRef(props, "urls"),
+	async (urls) => {
+		src.value = "";
+
+		for (const url of urls) {
+			const contentType = await fetchAssetContentType(url);
+			// ensure that the content type is valid and not HTML (the server can responds with a default HTML page)
+			if (!contentType || contentType === "text/html") continue;
+			return (src.value = url);
+		}
+	},
+	{ immediate: true },
+);
+</script>

--- a/src/ui/src/composables/useAssetContentType.spec.ts
+++ b/src/ui/src/composables/useAssetContentType.spec.ts
@@ -1,0 +1,65 @@
+import { useAssetContentType } from "./useAssetContentType";
+import { beforeEach, describe, it, expect, Mock, vi } from "vitest";
+
+describe(useAssetContentType.name, () => {
+	let fetch: Mock;
+
+	beforeEach(() => {
+		fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			headers: new Map([["Content-Type", "image/png"]]),
+		});
+		global.fetch = fetch;
+
+		useAssetContentType().clearCache();
+	});
+
+	it("should handle error ", async () => {
+		fetch.mockRejectedValue(new Error());
+		const { fetchAssetContentType } = useAssetContentType();
+
+		expect(await fetchAssetContentType("https://test.com")).toBeUndefined();
+		expect(fetch).toHaveBeenCalledOnce();
+	});
+
+	it("should cache fetch call in sequential calls", async () => {
+		const { fetchAssetContentType } = useAssetContentType();
+
+		expect(await fetchAssetContentType("https://test.com")).toBe(
+			"image/png",
+		);
+		expect(await fetchAssetContentType("https://test.com")).toBe(
+			"image/png",
+		);
+		expect(fetch).toHaveBeenCalledOnce();
+	});
+
+	it("should cache fetch call in parrallel call", async () => {
+		vi.useFakeTimers();
+
+		fetch.mockResolvedValue(
+			new Promise((res) =>
+				setTimeout(
+					() =>
+						res({
+							ok: true,
+							headers: new Map([["Content-Type", "image/png"]]),
+						}),
+					3_000,
+				),
+			),
+		);
+
+		const { fetchAssetContentType } = useAssetContentType();
+
+		const res1 = fetchAssetContentType("https://test.com");
+		const res2 = fetchAssetContentType("https://test.com");
+
+		vi.advanceTimersByTime(3_000);
+
+		expect(await res1).toBe("image/png");
+		expect(await res2).toBe("image/png");
+
+		expect(fetch).toHaveBeenCalledOnce();
+	});
+});

--- a/src/ui/src/composables/useAssetContentType.ts
+++ b/src/ui/src/composables/useAssetContentType.ts
@@ -1,0 +1,29 @@
+const cacheUrlContentType = new Map<string, Promise<undefined | string>>();
+
+/**
+ * Do an HTTP `HEAD` call to get the `Content-Type` of an URL. Handle parrallel calls and use a cache mechanism.
+ */
+export function useAssetContentType() {
+	function fetchAssetContentType(url: string) {
+		const cachedValue = cacheUrlContentType.get(url);
+		if (cachedValue !== undefined) return cachedValue;
+
+		// we store the promise instead of the result to handle concurent calls
+		const promise = fetch(url, { method: "HEAD" })
+			.then((r) => {
+				if (!r.ok) return undefined;
+				return r.headers.get("Content-Type") || undefined;
+			})
+			.catch(() => undefined);
+
+		cacheUrlContentType.set(url, promise);
+
+		return promise;
+	}
+
+	function clearCache() {
+		cacheUrlContentType.clear();
+	}
+
+	return { fetchAssetContentType, clearCache };
+}

--- a/src/ui/src/utils/url.spec.ts
+++ b/src/ui/src/utils/url.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { convertAbsolutePathtoFullURL } from "./url";
+
+describe(convertAbsolutePathtoFullURL.name, () => {
+	it("should convert the URL", () => {
+		expect(
+			convertAbsolutePathtoFullURL(
+				"/assets/image.png",
+				"http://localhost:3000/",
+			),
+		).toBe("http://localhost:3000/assets/image.png");
+	});
+
+	it("should convert the URL with a current path", () => {
+		expect(
+			convertAbsolutePathtoFullURL(
+				"/assets/image.png",
+				"http://localhost:3000/hello/?foo=bar",
+			),
+		).toBe("http://localhost:3000/hello/assets/image.png");
+	});
+});

--- a/src/ui/src/utils/url.ts
+++ b/src/ui/src/utils/url.ts
@@ -1,0 +1,14 @@
+/**
+ * Convert absoule URL to full URL in case the application is hosted on a subpath.
+ *
+ * ```js
+ * convertAbsolutePathtoFullURL("/assets/image.png", "http://localhost:3000/hello/?foo=bar")
+ * // => 'http://localhost:3000/hello/assets/image.png'
+ * ```
+ */
+export function convertAbsolutePathtoFullURL(
+	path: string,
+	base = window.location.toString(),
+) {
+	return new URL(`.${path}`, base).toString();
+}


### PR DESCRIPTION
Introduce a new component `ShareImgWithFallback` which takes an array of URLs for the image and uses the first successful URL.

This component uses a new hook `useAssetContentType` that takes care of fetching the `Content-Type` header of the asset URL, and handles the concurrency / cache. The `Content-Type` is needed because the server might serve a default `text/html` if the assets doesn't exist.

It also fix an edge case wherein the application run is an URL path like `https://streamsync-dev.osc-fr1.scalingo.io/hello/`, we are trying to import asset from the root (`https://streamsync-dev.osc-fr1.scalingo.io/`) and not the path `/hello`

I also took the opportunity to test the Vue.js component using [Vue Test Utils](https://test-utils.vuejs.org/)

This change is transparent for the user.

