### PR TITLE
fix(ui): floating insertion marker overflow - WF-158

### DIFF
--- a/src/ui/src/builder/panels/BuilderPanelSwitcher.vue
+++ b/src/ui/src/builder/panels/BuilderPanelSwitcher.vue
@@ -43,6 +43,7 @@ const screenEl = ref(null);
 	background: var(--builderBackgroundColor);
 	grid-template-rows: 48px;
 	grid-template-columns: 1fr;
+	z-index: 1; /* makes sure it's on top of `.ComponentRenderer` */
 }
 
 .BuilderPanelSwitcher.openPanels {


### PR DESCRIPTION
When dragging a new component in the page, the placeholder marker is displayed on top of the open panel. I just fixed it with a `z-index` to make the `BuilderPanelSwitcher` on top of `ComponentRenderer`.