### PR TITLE
chore(ui): bump Vue.js to 3.5 - WF-163

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24169,7 +24169,7 @@
 				"vega": "^5.22.1",
 				"vega-embed": "^6.22.1",
 				"vega-lite": "^5.7.1",
-				"vue": "^3.3.0",
+				"vue": "^3.4.0",
 				"vue-dompurify-html": "^5.0.1"
 			},
 			"devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24169,7 +24169,7 @@
 				"vega": "^5.22.1",
 				"vega-embed": "^6.22.1",
 				"vega-lite": "^5.7.1",
-				"vue": "^3.2.47",
+				"vue": "^3.3.0",
 				"vue-dompurify-html": "^5.0.1"
 			},
 			"devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -549,16 +549,18 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.23.4",
-			"dev": true,
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+			"integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.20",
-			"dev": true,
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+			"integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -612,8 +614,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.24.0",
+			"version": "7.26.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
+			"integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
 			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.26.3"
+			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -2050,13 +2057,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.24.0",
-			"dev": true,
+			"version": "7.26.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+			"integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.23.4",
-				"@babel/helper-validator-identifier": "^7.22.20",
-				"to-fast-properties": "^2.0.0"
+				"@babel/helper-string-parser": "^7.25.9",
+				"@babel/helper-validator-identifier": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -7878,45 +7885,53 @@
 			"license": "MIT"
 		},
 		"node_modules/@vue/compiler-core": {
-			"version": "3.4.21",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+			"integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.23.9",
-				"@vue/shared": "3.4.21",
+				"@babel/parser": "^7.25.3",
+				"@vue/shared": "3.5.13",
 				"entities": "^4.5.0",
 				"estree-walker": "^2.0.2",
-				"source-map-js": "^1.0.2"
+				"source-map-js": "^1.2.0"
 			}
 		},
 		"node_modules/@vue/compiler-dom": {
-			"version": "3.4.21",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
+			"integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-core": "3.4.21",
-				"@vue/shared": "3.4.21"
+				"@vue/compiler-core": "3.5.13",
+				"@vue/shared": "3.5.13"
 			}
 		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "3.4.21",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
+			"integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.23.9",
-				"@vue/compiler-core": "3.4.21",
-				"@vue/compiler-dom": "3.4.21",
-				"@vue/compiler-ssr": "3.4.21",
-				"@vue/shared": "3.4.21",
+				"@babel/parser": "^7.25.3",
+				"@vue/compiler-core": "3.5.13",
+				"@vue/compiler-dom": "3.5.13",
+				"@vue/compiler-ssr": "3.5.13",
+				"@vue/shared": "3.5.13",
 				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.7",
-				"postcss": "^8.4.35",
-				"source-map-js": "^1.0.2"
+				"magic-string": "^0.30.11",
+				"postcss": "^8.4.48",
+				"source-map-js": "^1.2.0"
 			}
 		},
 		"node_modules/@vue/compiler-ssr": {
-			"version": "3.4.21",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
+			"integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.4.21",
-				"@vue/shared": "3.4.21"
+				"@vue/compiler-dom": "3.5.13",
+				"@vue/shared": "3.5.13"
 			}
 		},
 		"node_modules/@vue/eslint-config-prettier": {
@@ -7956,42 +7971,53 @@
 			}
 		},
 		"node_modules/@vue/reactivity": {
-			"version": "3.4.21",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
+			"integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/shared": "3.4.21"
+				"@vue/shared": "3.5.13"
 			}
 		},
 		"node_modules/@vue/runtime-core": {
-			"version": "3.4.21",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
+			"integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/reactivity": "3.4.21",
-				"@vue/shared": "3.4.21"
+				"@vue/reactivity": "3.5.13",
+				"@vue/shared": "3.5.13"
 			}
 		},
 		"node_modules/@vue/runtime-dom": {
-			"version": "3.4.21",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
+			"integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/runtime-core": "3.4.21",
-				"@vue/shared": "3.4.21",
+				"@vue/reactivity": "3.5.13",
+				"@vue/runtime-core": "3.5.13",
+				"@vue/shared": "3.5.13",
 				"csstype": "^3.1.3"
 			}
 		},
 		"node_modules/@vue/server-renderer": {
-			"version": "3.4.21",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
+			"integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-ssr": "3.4.21",
-				"@vue/shared": "3.4.21"
+				"@vue/compiler-ssr": "3.5.13",
+				"@vue/shared": "3.5.13"
 			},
 			"peerDependencies": {
-				"vue": "3.4.21"
+				"vue": "3.5.13"
 			}
 		},
 		"node_modules/@vue/shared": {
-			"version": "3.4.21",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
+			"integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
 			"license": "MIT"
 		},
 		"node_modules/@vue/test-utils": {
@@ -21762,14 +21788,6 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/to-fast-properties": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"license": "MIT",
@@ -23534,14 +23552,16 @@
 			}
 		},
 		"node_modules/vue": {
-			"version": "3.4.21",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
+			"integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.4.21",
-				"@vue/compiler-sfc": "3.4.21",
-				"@vue/runtime-dom": "3.4.21",
-				"@vue/server-renderer": "3.4.21",
-				"@vue/shared": "3.4.21"
+				"@vue/compiler-dom": "3.5.13",
+				"@vue/compiler-sfc": "3.5.13",
+				"@vue/runtime-dom": "3.5.13",
+				"@vue/server-renderer": "3.5.13",
+				"@vue/shared": "3.5.13"
 			},
 			"peerDependencies": {
 				"typescript": "*"
@@ -24169,7 +24189,7 @@
 				"vega": "^5.22.1",
 				"vega-embed": "^6.22.1",
 				"vega-lite": "^5.7.1",
-				"vue": "^3.4.0",
+				"vue": "^3.5.0",
 				"vue-dompurify-html": "^5.0.1"
 			},
 			"devDependencies": {

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -38,7 +38,7 @@
 		"vega": "^5.22.1",
 		"vega-embed": "^6.22.1",
 		"vega-lite": "^5.7.1",
-		"vue": "^3.3.0",
+		"vue": "^3.4.0",
 		"vue-dompurify-html": "^5.0.1"
 	},
 	"devDependencies": {

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -38,7 +38,7 @@
 		"vega": "^5.22.1",
 		"vega-embed": "^6.22.1",
 		"vega-lite": "^5.7.1",
-		"vue": "^3.4.0",
+		"vue": "^3.5.0",
 		"vue-dompurify-html": "^5.0.1"
 	},
 	"devDependencies": {

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -38,7 +38,7 @@
 		"vega": "^5.22.1",
 		"vega-embed": "^6.22.1",
 		"vega-lite": "^5.7.1",
-		"vue": "^3.2.47",
+		"vue": "^3.3.0",
 		"vue-dompurify-html": "^5.0.1"
 	},
 	"devDependencies": {

--- a/src/ui/src/builder/BuilderEmbeddedCodeEditor.vue
+++ b/src/ui/src/builder/BuilderEmbeddedCodeEditor.vue
@@ -7,10 +7,10 @@
 <script setup lang="ts">
 import * as monaco from "monaco-editor";
 import "./builderEditorWorker";
-import { onMounted, onUnmounted, ref, toRefs, watch } from "vue";
+import { onMounted, onUnmounted, toRefs, useTemplateRef, watch } from "vue";
 
-const rootEl = ref<HTMLElement>(null);
-const editorContainerEl = ref<HTMLElement>(null);
+const rootEl = useTemplateRef("rootEl");
+const editorContainerEl = useTemplateRef("editorContainerEl");
 const resizeObserver = new ResizeObserver(updateDimensions);
 let editor: monaco.editor.IStandaloneCodeEditor = null;
 

--- a/src/ui/src/builder/BuilderHeader.vue
+++ b/src/ui/src/builder/BuilderHeader.vue
@@ -52,8 +52,7 @@
 			:class="wf.syncHealth.value"
 			:title="syncHealthStatus()"
 		>
-			<i ref="syncHealthIcon" class="material-symbols-outlined icon"
-				>sync</i
+			<i class="material-symbols-outlined icon">sync</i
 			><span v-if="wf.syncHealth.value == 'offline'">Offline</span>
 		</div>
 	</div>
@@ -67,7 +66,6 @@ import BuilderModal, { ModalAction } from "./BuilderModal.vue";
 import injectionKeys from "@/injectionKeys";
 import BuilderStateExplorer from "./BuilderStateExplorer.vue";
 
-const syncHealthIcon = ref(null);
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
 const { undo, redo, getUndoRedoSnapshot } = useComponentActions(wf, ssbm);

--- a/src/ui/src/builder/BuilderInstanceTracker.vue
+++ b/src/ui/src/builder/BuilderInstanceTracker.vue
@@ -4,7 +4,15 @@
 	</div>
 </template>
 <script setup lang="ts">
-import { nextTick, onMounted, onUnmounted, Ref, ref, toRefs } from "vue";
+import {
+	nextTick,
+	onMounted,
+	onUnmounted,
+	Ref,
+	ref,
+	toRefs,
+	useTemplateRef,
+} from "vue";
 
 const REFRESH_INTERVAL_MS = 200;
 
@@ -33,7 +41,7 @@ type RootStyle = {
 
 const rootStyle: Ref<RootStyle> = ref(null);
 const timerId = ref(0);
-const rootEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
 const MIN_TOP_PX = 36;
 
 const trackElement = (el: HTMLElement) => {

--- a/src/ui/src/builder/BuilderMoreDropdown.vue
+++ b/src/ui/src/builder/BuilderMoreDropdown.vue
@@ -24,7 +24,14 @@ export type { WdsDropdownMenuOption as Option } from "@/wds/WdsDropdownMenu.vue"
 </script>
 
 <script setup lang="ts">
-import { defineAsyncComponent, nextTick, PropType, ref, watch } from "vue";
+import {
+	defineAsyncComponent,
+	nextTick,
+	PropType,
+	ref,
+	useTemplateRef,
+	watch,
+} from "vue";
 import { useFloating, autoPlacement } from "@floating-ui/vue";
 import type { WdsDropdownMenuOption } from "@/wds/WdsDropdownMenu.vue";
 import { useFocusWithin } from "@/composables/useFocusWithin";
@@ -46,8 +53,8 @@ const emits = defineEmits({
 });
 
 const isOpen = ref(false);
-const trigger = ref<HTMLElement>();
-const dropdown = ref<HTMLElement>();
+const trigger = useTemplateRef("trigger");
+const dropdown = useTemplateRef("dropdown");
 
 const { floatingStyles } = useFloating(trigger, dropdown, {
 	placement: "bottom-end",

--- a/src/ui/src/builder/BuilderSelect.vue
+++ b/src/ui/src/builder/BuilderSelect.vue
@@ -43,6 +43,7 @@ import {
 	nextTick,
 	PropType,
 	ref,
+	useTemplateRef,
 	watch,
 } from "vue";
 import { useFloating, autoPlacement } from "@floating-ui/vue";
@@ -63,8 +64,8 @@ const props = defineProps({
 
 const currentValue = defineModel({ type: String, required: false });
 const isOpen = ref(false);
-const trigger = ref<HTMLElement>();
-const dropdown = ref<HTMLElement>();
+const trigger = useTemplateRef("trigger");
+const dropdown = useTemplateRef("dropdown");
 
 const { floatingStyles, update: updateFloatingStyle } = useFloating(
 	trigger,

--- a/src/ui/src/builder/BuilderTooltip.vue
+++ b/src/ui/src/builder/BuilderTooltip.vue
@@ -20,12 +20,13 @@ import {
 	onMounted,
 	onUnmounted,
 	ref,
+	useTemplateRef,
 } from "vue";
 
 const DELAY_MS = 200;
 const DEFAULT_GAP_PX = 4;
 
-const rootEl = ref(null);
+const rootEl = useTemplateRef("rootEl");
 const isActive = ref(false);
 const tooltipText = ref<ComputedRef | string | null>(null);
 let trackedElement: HTMLElement | null = null;

--- a/src/ui/src/builder/panels/BuilderCodePanel.vue
+++ b/src/ui/src/builder/panels/BuilderCodePanel.vue
@@ -75,6 +75,7 @@ import {
 	onMounted,
 	onUnmounted,
 	ref,
+	useTemplateRef,
 	watch,
 } from "vue";
 import BuilderPanel from "./BuilderPanel.vue";
@@ -139,7 +140,7 @@ function useKeydownCmdS(callback: () => void | Promise<void>) {
 }
 useKeydownCmdS(handleSave);
 
-const filenameEl = ref<HTMLInputElement>();
+const filenameEl = useTemplateRef("filenameEl");
 const filename = ref("");
 const isDisabled = ref(false);
 

--- a/src/ui/src/builder/panels/BuilderPanelSwitcher.vue
+++ b/src/ui/src/builder/panels/BuilderPanelSwitcher.vue
@@ -28,13 +28,13 @@ export type BuilderPanelAction = {
 
 <script setup lang="ts">
 import injectionKeys from "@/injectionKeys";
-import { inject, ref } from "vue";
+import { inject, useTemplateRef } from "vue";
 import BuilderCodePanel from "./BuilderCodePanel.vue";
 import BuilderLogPanel from "./BuilderLogPanel.vue";
 
 const wfbm = inject(injectionKeys.builderManager);
 
-const screenEl = ref(null);
+const screenEl = useTemplateRef("screenEl");
 </script>
 
 <style scoped>

--- a/src/ui/src/builder/settings/BuilderFieldsAlign.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsAlign.vue
@@ -14,6 +14,7 @@
 		<div v-if="mode == 'pick' || mode == 'css'" class="main">
 			<div v-if="mode == 'pick'" class="pickerContainer">
 				<BuilderSelect
+					ref="pickerEl"
 					:model-value="subMode"
 					:options="selectOptions"
 					@update:model-value="handleInputSelect"
@@ -43,6 +44,7 @@ import {
 	Ref,
 	ref,
 	toRefs,
+	useTemplateRef,
 } from "vue";
 import { Component } from "@/writerTypes";
 import { useComponentActions } from "../useComponentActions";
@@ -59,9 +61,9 @@ const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
 const { setContentValue } = useComponentActions(wf, ssbm);
 
-const rootEl: Ref<HTMLElement> = ref(null);
-const pickerEl: Ref<HTMLInputElement> = ref(null);
-const freehandInputEl: Ref<HTMLInputElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const pickerEl = useTemplateRef("pickerEl");
+const freehandInputEl = useTemplateRef("freehandInputEl");
 
 enum SubMode {
 	hleft = "start",
@@ -131,7 +133,7 @@ const verticalSubmodes: SubModes = [
 	},
 ];
 
-const focusEls: Record<Mode, Ref<HTMLInputElement>> = {
+const focusEls = {
 	pick: pickerEl,
 	css: freehandInputEl,
 	default: null,

--- a/src/ui/src/builder/settings/BuilderFieldsColor.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsColor.vue
@@ -42,6 +42,7 @@ import {
 	ref,
 	toRefs,
 	PropType,
+	useTemplateRef,
 } from "vue";
 import { Component } from "@/writerTypes";
 import { useComponentActions } from "../useComponentActions";
@@ -57,11 +58,11 @@ const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
 const { setContentValue } = useComponentActions(wf, ssbm);
 
-const rootEl: Ref<HTMLElement> = ref(null);
-const pickerEl: Ref<HTMLInputElement> = ref(null);
-const freehandInputEl: Ref<HTMLInputElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const pickerEl = useTemplateRef("pickerEl");
+const freehandInputEl = useTemplateRef("freehandInputEl");
 
-const focusEls: Record<Mode, Ref<HTMLInputElement>> = {
+const focusEls = {
 	pick: pickerEl,
 	css: freehandInputEl,
 	default: null,

--- a/src/ui/src/builder/settings/BuilderFieldsKeyValue.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsKeyValue.vue
@@ -73,6 +73,7 @@ import {
 	onMounted,
 	ref,
 	toRefs,
+	useTemplateRef,
 	watch,
 } from "vue";
 import injectionKeys from "@/injectionKeys";
@@ -97,8 +98,8 @@ const props = defineProps({
 const { componentId, fieldKey } = toRefs(props);
 const component = computed(() => wf.getComponentById(componentId.value));
 
-const rootEl: Ref<HTMLElement> = ref(null);
-const assistedKeyEl: Ref<HTMLInputElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const assistedKeyEl = useTemplateRef("assistedKeyEl");
 type Mode = "assisted" | "freehand";
 const mode: Ref<Mode> = ref(null);
 const assistedEntries: Ref<Record<string, string | number | null>> = ref({});

--- a/src/ui/src/builder/settings/BuilderFieldsPadding.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsPadding.vue
@@ -14,6 +14,7 @@
 		<div v-if="mode == 'pick' || mode == 'css'" class="main">
 			<div v-if="mode == 'pick'" class="pickerContainer">
 				<BuilderSelect
+					ref="pickerEl"
 					:model-value="subMode"
 					:options="selectOptions"
 					@update:model-value="handleInputSelect"
@@ -103,7 +104,6 @@
 
 <script setup lang="ts">
 import {
-	ComponentInstance,
 	computed,
 	inject,
 	nextTick,
@@ -113,6 +113,7 @@ import {
 	Ref,
 	ref,
 	toRefs,
+	useTemplateRef,
 } from "vue";
 import { Component } from "@/writerTypes";
 import { useComponentActions } from "../useComponentActions";
@@ -130,10 +131,10 @@ const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
 const { setContentValue } = useComponentActions(wf, ssbm);
 
-const rootEl: Ref<HTMLElement> = ref(null);
-const pickerEl: Ref<HTMLInputElement> = ref(null);
-const fixedEl = ref<ComponentInstance<typeof WdsTextInput>>(null);
-const freehandInputEl: Ref<HTMLInputElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const pickerEl = useTemplateRef("pickerEl");
+const freehandInputEl = useTemplateRef("freehandInputEl");
+const fixedEl = useTemplateRef("fixedEl");
 
 enum SubMode {
 	all_sides = "all_sides",
@@ -179,7 +180,7 @@ const subModes: Array<{
 	},
 ];
 
-const focusEls: Record<Mode, Ref<HTMLInputElement>> = {
+const focusEls = {
 	pick: pickerEl,
 	css: freehandInputEl,
 	default: null,

--- a/src/ui/src/builder/settings/BuilderFieldsShadow.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsShadow.vue
@@ -111,6 +111,7 @@ import {
 	Ref,
 	ref,
 	toRefs,
+	useTemplateRef,
 } from "vue";
 import { Component } from "@/writerTypes";
 import { useComponentActions } from "../useComponentActions";
@@ -126,15 +127,15 @@ const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
 const { setContentValue } = useComponentActions(wf, ssbm);
 
-const rootEl: Ref<HTMLElement> = ref(null);
-const freehandInputEl: Ref<HTMLInputElement> = ref(null);
-const paramOffsetXEl: Ref<HTMLInputElement> = ref(null);
-const paramOffsetYEl: Ref<HTMLInputElement> = ref(null);
-const paramBlurRadiusEl: Ref<HTMLInputElement> = ref(null);
-const paramSpreadRadiusEl: Ref<HTMLInputElement> = ref(null);
-const paramColorEl: Ref<HTMLInputElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const freehandInputEl = useTemplateRef("freehandInputEl");
+const paramOffsetXEl = useTemplateRef("paramOffsetXEl");
+const paramOffsetYEl = useTemplateRef("paramOffsetYEl");
+const paramBlurRadiusEl = useTemplateRef("paramBlurRadiusEl");
+const paramSpreadRadiusEl = useTemplateRef("paramSpreadRadiusEl");
+const paramColorEl = useTemplateRef("paramColorEl");
 
-const focusEls: Record<Mode, Ref<HTMLInputElement>> = {
+const focusEls = {
 	pick: paramOffsetXEl,
 	css: freehandInputEl,
 	default: null,

--- a/src/ui/src/builder/settings/BuilderFieldsWidth.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsWidth.vue
@@ -14,6 +14,7 @@
 		<div v-if="mode == 'pick' || mode == 'css'" class="main">
 			<div v-if="mode == 'pick'" class="pickerContainer">
 				<BuilderSelect
+					ref="pickerEl"
 					:model-value="subMode"
 					:options="selectOptions"
 					@update:model-value="handleInputSelect"
@@ -42,7 +43,6 @@
 
 <script setup lang="ts">
 import {
-	ComponentInstance,
 	computed,
 	inject,
 	nextTick,
@@ -52,6 +52,7 @@ import {
 	Ref,
 	ref,
 	toRefs,
+	useTemplateRef,
 } from "vue";
 import { Component } from "@/writerTypes";
 import { useComponentActions } from "../useComponentActions";
@@ -69,10 +70,10 @@ const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
 const { setContentValue } = useComponentActions(wf, ssbm);
 
-const rootEl: Ref<HTMLElement> = ref(null);
-const pickerEl: Ref<HTMLInputElement> = ref(null);
-const fixedEl = ref<ComponentInstance<typeof WdsTextInput>>(null);
-const freehandInputEl: Ref<HTMLInputElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const pickerEl = useTemplateRef("pickerEl");
+const freehandInputEl = useTemplateRef("freehandInputEl");
+const fixedEl = useTemplateRef("fixedEl");
 
 enum SubMode {
 	fixed = "fixed",
@@ -107,7 +108,7 @@ const subModes: Array<{
 	},
 ];
 
-const focusEls: Record<Mode, Ref<HTMLInputElement>> = {
+const focusEls = {
 	pick: pickerEl,
 	css: freehandInputEl,
 	default: null,

--- a/src/ui/src/components/core/base/BaseDropdown.vue
+++ b/src/ui/src/components/core/base/BaseDropdown.vue
@@ -1,7 +1,14 @@
 <script setup lang="ts">
 // TODO(WF-154): to be move in shared
 import { useFocusWithin } from "@/composables/useFocusWithin";
-import { onMounted, onUnmounted, PropType, ref, watch } from "vue";
+import {
+	onMounted,
+	onUnmounted,
+	PropType,
+	ref,
+	useTemplateRef,
+	watch,
+} from "vue";
 
 defineProps({
 	options: {
@@ -14,8 +21,8 @@ const emits = defineEmits({
 	selected: (key: string) => typeof key === "string",
 });
 
-const root = ref<HTMLDivElement>();
-const trigger = ref<HTMLDivElement>();
+const root = useTemplateRef("root");
+const trigger = useTemplateRef("trigger");
 const isOpen = ref(false);
 
 const popoverTop = ref("unset");
@@ -31,6 +38,7 @@ function closePopover() {
 }
 
 function openPopover() {
+	if (!trigger.value) return;
 	const boundingRect = trigger.value.getBoundingClientRect();
 	popoverTop.value = `${boundingRect.top + boundingRect.height + 4 + window.pageYOffset}px`;
 	popoverLeft.value = `${boundingRect.left + window.pageXOffset}px`;

--- a/src/ui/src/components/core/base/BaseInputColor.vue
+++ b/src/ui/src/components/core/base/BaseInputColor.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script setup lang="ts">
-import { PropType, computed, inject, ref } from "vue";
+import { PropType, computed, inject, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 
 const props = defineProps({
@@ -27,7 +27,7 @@ const emit = defineEmits({
 	change: (value: string) => typeof value === "string",
 });
 
-const pickerEl = ref<HTMLInputElement | undefined>();
+const pickerEl = useTemplateRef("pickerEl");
 
 const flattenedInstancePath = inject(injectionKeys.flattenedInstancePath);
 

--- a/src/ui/src/components/core/base/BaseInputSlider.vue
+++ b/src/ui/src/components/core/base/BaseInputSlider.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, PropType, ref, ComponentInstance, toRef, watch } from "vue";
+import { computed, PropType, toRef, watch, useTemplateRef } from "vue";
 import BaseInputRangeThumb from "./BaseInputSliderThumb.vue";
 import BaseInputSliderLayout from "./BaseInputSliderLayout.vue";
 import { useBoundingClientRect } from "@/composables/useBoundingClientRect";
@@ -50,8 +50,8 @@ const props = defineProps({
 
 const model = defineModel("value", { type: Number, default: 50 });
 
-const slider = ref<HTMLElement>();
-const thumb = ref<ComponentInstance<typeof BaseInputRangeThumb>>();
+const slider = useTemplateRef("slider");
+const thumb = useTemplateRef("thumb");
 
 const displayValue = useNumberFormatByStep(model, toRef(props, "step"));
 

--- a/src/ui/src/components/core/base/BaseInputSliderRange.vue
+++ b/src/ui/src/components/core/base/BaseInputSliderRange.vue
@@ -35,7 +35,7 @@
 </template>
 
 <script setup lang="ts">
-import { ComponentInstance, computed, PropType, ref, toRef, watch } from "vue";
+import { computed, PropType, toRef, useTemplateRef, watch } from "vue";
 import BaseInputRangeThumb from "./BaseInputSliderThumb.vue";
 import { useBoundingClientRect } from "@/composables/useBoundingClientRect";
 import BaseInputSliderLayout from "./BaseInputSliderLayout.vue";
@@ -64,8 +64,8 @@ function onUpdate(key: 0 | 1, value: number) {
 	model.value = copy.sort((a, b) => a - b);
 }
 
-const slider = ref<HTMLElement>();
-const thumbs = ref<ComponentInstance<typeof BaseInputRangeThumb>[]>();
+const slider = useTemplateRef("slider");
+const thumbs = useTemplateRef("thumbs");
 
 function handleMouseDown(e: MouseEvent) {
 	const thumb1 = thumbs.value[0];

--- a/src/ui/src/components/core/base/BaseInputSliderThumb.vue
+++ b/src/ui/src/components/core/base/BaseInputSliderThumb.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, PropType, ref, toRef, watch } from "vue";
+import { computed, PropType, ref, toRef, useTemplateRef, watch } from "vue";
 import { useNumberFormatByStep } from "./BaseInputSlider.utils";
 
 const props = defineProps({
@@ -44,7 +44,7 @@ defineExpose({ handleMouseDown, getOffsetLeft });
 
 const model = defineModel("value", { type: Number, default: 50 });
 
-const thumb = ref<HTMLElement>();
+const thumb = useTemplateRef("thumb");
 
 const displayValue = useNumberFormatByStep(model, toRef(props, "step"));
 

--- a/src/ui/src/components/core/base/BaseSelect.vue
+++ b/src/ui/src/components/core/base/BaseSelect.vue
@@ -93,7 +93,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, PropType, Ref, ref, toRefs, watch } from "vue";
+import {
+	computed,
+	nextTick,
+	PropType,
+	Ref,
+	ref,
+	toRefs,
+	useTemplateRef,
+	watch,
+} from "vue";
 
 const emit = defineEmits(["change"]);
 
@@ -121,10 +130,10 @@ const activeValue = computed<string[]>(() =>
 );
 
 const LIST_MAX_HEIGHT_PX = 200;
-const rootEl: Ref<HTMLElement | null> = ref(null);
-const inputEl: Ref<HTMLElement | null> = ref(null);
-const selectedOptionsEl: Ref<HTMLElement | null> = ref(null);
-const listEl: Ref<HTMLElement | null> = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const inputEl = useTemplateRef("inputEl");
+const selectedOptionsEl = useTemplateRef("selectedOptionsEl");
+const listEl = useTemplateRef("listEl");
 const activeText: Ref<string> = ref("");
 const highlightedOffset: Ref<number | null> = ref(null);
 const selectedOptions: Ref<string[]> = ref([]);

--- a/src/ui/src/components/core/content/CoreAvatar.vue
+++ b/src/ui/src/components/core/content/CoreAvatar.vue
@@ -97,10 +97,10 @@ export default {
 };
 </script>
 <script setup lang="ts">
-import { CSSProperties, Ref, computed, inject, ref } from "vue";
+import { CSSProperties, computed, inject, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 
-const rootEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
 const fields = inject(injectionKeys.evaluatedFields);
 const componentId = inject(injectionKeys.componentId);
 const wf = inject(injectionKeys.core);

--- a/src/ui/src/components/core/content/CoreAvatar.vue
+++ b/src/ui/src/components/core/content/CoreAvatar.vue
@@ -4,7 +4,7 @@
 		class="CoreAvatar"
 		:class="[fields.size.value, fields.orientation.value]"
 	>
-		<div class="image" @click="handleClick">
+		<div class="image" :style="imageStyle" @click="handleClick">
 			<i v-if="!fields.imageSrc.value" class="material-symbols-outlined">
 				account_circle
 			</i>
@@ -97,7 +97,7 @@ export default {
 };
 </script>
 <script setup lang="ts">
-import { Ref, computed, inject, ref } from "vue";
+import { CSSProperties, Ref, computed, inject, ref } from "vue";
 import injectionKeys from "@/injectionKeys";
 
 const rootEl: Ref<HTMLElement> = ref(null);
@@ -109,6 +109,13 @@ const isClickable = computed(() => {
 	const component = wf.getComponentById(componentId);
 	return typeof component.handlers?.["wf-click"] !== "undefined";
 });
+
+const imageStyle = computed<CSSProperties>(() => ({
+	backgroundImage: fields.imageSrc.value
+		? `url(${fields.imageSrc.value})`
+		: "none",
+	cursor: isClickable.value ? "pointer" : "auto",
+}));
 
 function handleClick(ev: MouseEvent) {
 	const ssEv = getClick(ev);
@@ -151,11 +158,7 @@ function handleClick(ev: MouseEvent) {
 	background-color: var(--separatorColor);
 	background-position: center;
 	background-size: cover;
-	background-image: v-bind(
-		"fields.imageSrc.value ? `url(\"${fields.imageSrc.value}\")` : 'none'"
-	);
 	color: var(--primaryTextColor);
-	cursor: v-bind("isClickable ? 'pointer' : 'auto'");
 }
 
 .info {

--- a/src/ui/src/components/core/content/CoreChatbot.vue
+++ b/src/ui/src/components/core/content/CoreChatbot.vue
@@ -305,15 +305,16 @@ import {
 	ref,
 	computed,
 	ComputedRef,
+	useTemplateRef,
 } from "vue";
 import injectionKeys from "@/injectionKeys";
 import CoreChatbotSentMessageIcon from "./CoreChatBot/CoreChatbotSentMessageIcon.vue";
 import CoreChatbotMessage from "./CoreChatBot/CoreChatbotMessage.vue";
 import type { Message } from "./CoreChatBot/CoreChatbotMessage.vue";
 
-const rootEl: Ref<HTMLElement> = ref(null);
-const messageAreaEl: Ref<HTMLElement> = ref(null);
-const messagesEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const messageAreaEl = useTemplateRef("messageAreaEl");
+const messagesEl = useTemplateRef("messagesEl");
 const messageIndexLoading: Ref<number | undefined> = ref(undefined);
 const fields = inject(injectionKeys.evaluatedFields);
 const files: Ref<File[]> = shallowRef([]);

--- a/src/ui/src/components/core/content/CoreDataframe.vue
+++ b/src/ui/src/components/core/content/CoreDataframe.vue
@@ -110,7 +110,7 @@
 </template>
 
 <script lang="ts">
-import { computed, inject, ref, shallowRef } from "vue";
+import { computed, inject, ref, shallowRef, useTemplateRef } from "vue";
 import { FieldCategory, FieldType } from "@/writerTypes";
 import CoreDataframeRow from "./CoreDataframe/CoreDataframeRow.vue";
 import {
@@ -327,9 +327,9 @@ type OrderSetting = {
 };
 
 const fields = inject(injectionKeys.evaluatedFields);
-const rootEl = ref<HTMLElement>();
-const toolsEl = ref<HTMLElement>();
-const gridContainerEl = ref<HTMLElement>();
+const rootEl = useTemplateRef("rootEl");
+const toolsEl = useTemplateRef("toolsEl");
+const gridContainerEl = useTemplateRef("gridContainerEl");
 let baseTable: aq.internal.ColumnTable = null;
 const table = shallowRef<aq.internal.ColumnTable | null>(null);
 const tableIndex = shallowRef([]);

--- a/src/ui/src/components/core/content/CoreDataframe/CoreDataframeCellNumber.vue
+++ b/src/ui/src/components/core/content/CoreDataframe/CoreDataframeCellNumber.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, ref } from "vue";
+import { nextTick, ref, useTemplateRef } from "vue";
 
 const props = defineProps({
 	value: {
@@ -13,8 +13,8 @@ const emits = defineEmits({
 	change: (value: string) => typeof value === "string",
 });
 
-const wrapper = ref<HTMLDivElement | undefined>();
-const input = ref<HTMLTextAreaElement | undefined>();
+const wrapper = useTemplateRef("wrapper");
+const input = useTemplateRef("input");
 const isEditing = ref(false);
 
 async function startEditing() {

--- a/src/ui/src/components/core/content/CoreDataframe/CoreDataframeCellText.vue
+++ b/src/ui/src/components/core/content/CoreDataframe/CoreDataframeCellText.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, ref } from "vue";
+import { nextTick, ref, useTemplateRef } from "vue";
 import BaseMarkdown from "../../base/BaseMarkdown.vue";
 
 const props = defineProps({
@@ -12,8 +12,8 @@ const emits = defineEmits({
 	change: (value: string) => typeof value === "string",
 });
 
-const wrapper = ref<HTMLDivElement | undefined>();
-const textarea = ref<HTMLTextAreaElement | undefined>();
+const wrapper = useTemplateRef("wrapper");
+const textarea = useTemplateRef("textarea");
 const isEditing = ref(false);
 const height = ref<number | undefined>();
 

--- a/src/ui/src/components/core/content/CoreDataframeLegacy.vue
+++ b/src/ui/src/components/core/content/CoreDataframeLegacy.vue
@@ -109,7 +109,7 @@
 </template>
 
 <script lang="ts">
-import { Ref, computed, inject, ref } from "vue";
+import { Ref, computed, inject, ref, useTemplateRef } from "vue";
 import { FieldCategory, FieldType } from "@/writerTypes";
 import {
 	cssClasses,
@@ -248,9 +248,9 @@ type OrderSetting = {
 };
 
 const fields = inject(injectionKeys.evaluatedFields);
-const rootEl: Ref<HTMLElement> = ref();
-const toolsEl: Ref<HTMLElement> = ref();
-const gridContainerEl: Ref<HTMLElement> = ref();
+const rootEl = useTemplateRef("rootEl");
+const toolsEl = useTemplateRef("toolsEl");
+const gridContainerEl = useTemplateRef("gridContainerEl");
 let baseTable: aq.internal.ColumnTable = null;
 const table: Ref<aq.internal.ColumnTable> = ref(null);
 const tableIndex = ref([]);

--- a/src/ui/src/components/core/content/CoreImage.vue
+++ b/src/ui/src/components/core/content/CoreImage.vue
@@ -89,10 +89,10 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { Ref, computed, inject, ref } from "vue";
+import { computed, inject, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 
-const rootEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
 const wf = inject(injectionKeys.core);
 const fields = inject(injectionKeys.evaluatedFields);
 const componentId = inject(injectionKeys.componentId);

--- a/src/ui/src/components/core/content/CorePlotlyGraph.vue
+++ b/src/ui/src/components/core/content/CorePlotlyGraph.vue
@@ -56,11 +56,11 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { computed, inject, onMounted, Ref, ref, watch } from "vue";
+import { computed, inject, onMounted, useTemplateRef, watch } from "vue";
 import injectionKeys from "@/injectionKeys";
 
-const rootEl: Ref<HTMLElement> = ref(null);
-const chartTargetEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const chartTargetEl = useTemplateRef("chartTargetEl");
 const fields = inject(injectionKeys.evaluatedFields);
 const spec = computed(() => fields.spec.value);
 

--- a/src/ui/src/components/core/content/CoreProgressBar.vue
+++ b/src/ui/src/components/core/content/CoreProgressBar.vue
@@ -107,13 +107,13 @@ export default { writer: definition };
 </script>
 
 <script setup lang="ts">
-import { CSSProperties, computed, inject, ref } from "vue";
+import { CSSProperties, computed, inject, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 import { useFieldValueAsYesNo } from "@/composables/useFieldValue";
 import { getClick } from "@/renderer/syntheticEvents";
 import { usePercentageFormatter } from "@/composables/useFormatter";
 
-const rootEl = ref<HTMLElement>();
+const rootEl = useTemplateRef("rootEl");
 const fields = inject(injectionKeys.evaluatedFields);
 const componentId = inject(injectionKeys.componentId);
 const wf = inject(injectionKeys.core);

--- a/src/ui/src/components/core/content/CoreTags.vue
+++ b/src/ui/src/components/core/content/CoreTags.vue
@@ -85,7 +85,7 @@ export default {
 };
 </script>
 <script setup lang="ts">
-import { Ref, computed, inject, ref } from "vue";
+import { computed, inject, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 import chroma from "chroma-js";
 
@@ -101,7 +101,7 @@ const COLOR_STEPS = [
 	{ h: 69, s: 0, l: 25 },
 	{ h: 70, s: 0, l: 29 },
 ];
-const rootEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
 const fields = inject(injectionKeys.evaluatedFields);
 const componentId = inject(injectionKeys.componentId);
 const wf = inject(injectionKeys.core);

--- a/src/ui/src/components/core/content/CoreText.vue
+++ b/src/ui/src/components/core/content/CoreText.vue
@@ -84,12 +84,12 @@ export default {
 };
 </script>
 <script setup lang="ts">
-import { Ref, computed, inject, ref } from "vue";
+import { computed, inject, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 import BaseEmptiness from "../base/BaseEmptiness.vue";
 import BaseMarkdown from "../base/BaseMarkdown.vue";
 
-const rootEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
 const fields = inject(injectionKeys.evaluatedFields);
 const componentId = inject(injectionKeys.componentId);
 const wf = inject(injectionKeys.core);

--- a/src/ui/src/components/core/content/CoreVegaLiteChart.vue
+++ b/src/ui/src/components/core/content/CoreVegaLiteChart.vue
@@ -57,11 +57,11 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { inject, onMounted, Ref, ref, watch } from "vue";
+import { inject, onMounted, useTemplateRef, watch } from "vue";
 import injectionKeys from "@/injectionKeys";
 
-const rootEl: Ref<HTMLElement> = ref(null);
-const chartTargetEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const chartTargetEl = useTemplateRef("chartTargetEl");
 const fields = inject(injectionKeys.evaluatedFields);
 
 const renderChart = async () => {

--- a/src/ui/src/components/core/embed/CoreGoogleMaps.vue
+++ b/src/ui/src/components/core/embed/CoreGoogleMaps.vue
@@ -95,11 +95,11 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { Ref, inject, ref, onMounted, watch, computed } from "vue";
+import { inject, onMounted, watch, computed, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 
-const rootEl: Ref<HTMLElement> = ref(null);
-const mapEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const mapEl = useTemplateRef("mapEl");
 const fields = inject(injectionKeys.evaluatedFields);
 let map: google.maps.Map | null = null;
 let markers = [];

--- a/src/ui/src/components/core/embed/CoreIFrame.vue
+++ b/src/ui/src/components/core/embed/CoreIFrame.vue
@@ -54,10 +54,10 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { Ref, inject, ref } from "vue";
+import { inject, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 
-const rootEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
 const fields = inject(injectionKeys.evaluatedFields);
 
 function handleLoad() {

--- a/src/ui/src/components/core/embed/CoreMapbox.vue
+++ b/src/ui/src/components/core/embed/CoreMapbox.vue
@@ -93,12 +93,12 @@ export default {
 
 <script setup lang="ts">
 import "mapbox-gl/dist/mapbox-gl.css";
-import { inject, ref, watch, computed } from "vue";
+import { inject, ref, watch, computed, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 import type * as mapboxgl from "mapbox-gl";
 const fields = inject(injectionKeys.evaluatedFields);
-const rootEl = ref(null);
-const mapEl = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const mapEl = useTemplateRef("mapEl");
 const center = computed<mapboxgl.LngLatLike>(() => [
 	fields.lng.value,
 	fields.lat.value,

--- a/src/ui/src/components/core/embed/CorePDF.vue
+++ b/src/ui/src/components/core/embed/CorePDF.vue
@@ -106,7 +106,7 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { inject, ref, watch, computed, onMounted } from "vue";
+import { inject, ref, watch, computed, onMounted, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 import "@tato30/vue-pdf/style.css";
 
@@ -131,8 +131,8 @@ const scale = ref(1);
 const page = ref(1);
 const matches = ref<MatchType[]>([]);
 const currentMatch = ref(0);
-const rootEl = ref(null);
-const viewerEl = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const viewerEl = useTemplateRef("viewerEl");
 const loading = ref(false);
 
 const pagesLoaded = ref(0);

--- a/src/ui/src/components/core/input/CoreFileInput.vue
+++ b/src/ui/src/components/core/input/CoreFileInput.vue
@@ -116,7 +116,7 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { computed, inject, Ref, ref, watch } from "vue";
+import { computed, inject, Ref, ref, useTemplateRef, watch } from "vue";
 import injectionKeys from "@/injectionKeys";
 import LoadingSymbol from "@/renderer/LoadingSymbol.vue";
 import { useFormValueBroker } from "@/renderer/useFormValueBroker";
@@ -126,7 +126,7 @@ type SavedFile = { name: string; type: string; data: unknown };
 
 const fields = inject(injectionKeys.evaluatedFields);
 const rootInstance = ref<ComponentPublicInstance | null>(null);
-const fileEl: Ref<HTMLInputElement> = ref(null);
+const fileEl = useTemplateRef("fileEl");
 const message: Ref<string> = ref(null);
 const wf = inject(injectionKeys.core);
 const instancePath = inject(injectionKeys.instancePath);

--- a/src/ui/src/components/core/input/CoreNumberInput.vue
+++ b/src/ui/src/components/core/input/CoreNumberInput.vue
@@ -34,7 +34,6 @@
 import { FieldType } from "@/writerTypes";
 import { cssClasses } from "@/renderer/sharedStyleFields";
 import BaseInputWrapper from "../base/BaseInputWrapper.vue";
-import { ComponentPublicInstance } from "vue";
 
 const description =
 	"A user input component that allows users to enter numeric values.";

--- a/src/ui/src/components/core/input/CoreNumberInput.vue
+++ b/src/ui/src/components/core/input/CoreNumberInput.vue
@@ -94,13 +94,13 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { inject, ref } from "vue";
+import { inject, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 import { useFormValueBroker } from "@/renderer/useFormValueBroker";
 
 const fields = inject(injectionKeys.evaluatedFields);
-const rootInstance = ref<ComponentPublicInstance | null>(null);
-const inputEl = ref(null);
+const rootInstance = useTemplateRef("rootInstance");
+const inputEl = useTemplateRef("inputEl");
 const wf = inject(injectionKeys.core);
 const instancePath = inject(injectionKeys.instancePath);
 

--- a/src/ui/src/components/core/input/CoreRatingInput.vue
+++ b/src/ui/src/components/core/input/CoreRatingInput.vue
@@ -57,7 +57,6 @@ import {
 	primaryTextColor,
 } from "@/renderer/sharedStyleFields";
 import BaseInputWrapper from "../base/BaseInputWrapper.vue";
-import { ComponentPublicInstance } from "vue";
 import { buildJsonSchemaForNumberBetween } from "@/constants/validators";
 
 const description =
@@ -127,13 +126,13 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { Ref, computed, inject, ref } from "vue";
+import { Ref, computed, inject, ref, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 import { useFormValueBroker } from "@/renderer/useFormValueBroker";
 
 const fields = inject(injectionKeys.evaluatedFields);
-const rootInstance = ref<ComponentPublicInstance | null>(null);
-const unitsEl: Ref<HTMLElement> = ref(null);
+const rootInstance = useTemplateRef("rootInstance");
+const unitsEl = useTemplateRef("unitsEl");
 const wf = inject(injectionKeys.core);
 const instancePath = inject(injectionKeys.instancePath);
 const provisionalValue: Ref<number> = ref(null);

--- a/src/ui/src/components/core/input/__snapshots__/CoreCheckboxInput.spec.ts.snap
+++ b/src/ui/src/components/core/input/__snapshots__/CoreCheckboxInput.spec.ts.snap
@@ -38,6 +38,7 @@ exports[`CoreCheckboxInput > should render value from the state and forward emit
       data-v-7a72f1be=""
     >
       <input
+        checked=""
         data-v-7a72f1be=""
         type="checkbox"
         value="b"

--- a/src/ui/src/components/core/input/__snapshots__/CoreDateInput.spec.ts.snap
+++ b/src/ui/src/components/core/input/__snapshots__/CoreDateInput.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`CoreDateInput > should render value from the state and forward emit 1`]
   <input
     data-v-acf95c76=""
     type="date"
+    value="2024-12-14"
   />
   
 </div>

--- a/src/ui/src/components/core/input/__snapshots__/CoreRadioInput.spec.ts.snap
+++ b/src/ui/src/components/core/input/__snapshots__/CoreRadioInput.spec.ts.snap
@@ -22,6 +22,7 @@ exports[`CoreRadioInput > should render value from the state and forward emit 1`
       data-v-d075b11d=""
     >
       <input
+        checked=""
         data-v-d075b11d=""
         id="component-id-test:0-option-a"
         name="component-id-test:0-options"

--- a/src/ui/src/components/core/other/CorePagination.vue
+++ b/src/ui/src/components/core/other/CorePagination.vue
@@ -178,13 +178,20 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { inject, ref, computed, watch, onUnmounted, onMounted, Ref } from "vue";
+import {
+	inject,
+	computed,
+	watch,
+	onUnmounted,
+	onMounted,
+	useTemplateRef,
+} from "vue";
 import injectionKeys from "@/injectionKeys";
 import { useFormValueBroker } from "@/renderer/useFormValueBroker";
 
 const fields = inject(injectionKeys.evaluatedFields);
 const wf = inject(injectionKeys.core);
-const rootEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
 const instancePath = inject(injectionKeys.instancePath);
 
 const { handleInput: handlePageInput } = useFormValueBroker(

--- a/src/ui/src/components/core/other/CoreTimer.vue
+++ b/src/ui/src/components/core/other/CoreTimer.vue
@@ -58,14 +58,22 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { computed, inject, nextTick, onMounted, Ref, ref, watch } from "vue";
+import {
+	computed,
+	inject,
+	nextTick,
+	onMounted,
+	ref,
+	useTemplateRef,
+	watch,
+} from "vue";
 import injectionKeys from "@/injectionKeys";
 
 const MIN_ANIMATION_RESET_MS = 500;
 const MIN_ANIMATION_DURATION_MS = 1000;
 const fields = inject(injectionKeys.evaluatedFields);
 const wf = inject(injectionKeys.core);
-const rootEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
 
 const intervalMs = computed(() => fields.intervalMs.value);
 const isActive = computed(() => fields.isActive.value == "yes");

--- a/src/ui/src/components/core/other/CoreWebcamCapture.vue
+++ b/src/ui/src/components/core/other/CoreWebcamCapture.vue
@@ -97,14 +97,15 @@ import {
 	onMounted,
 	Ref,
 	ref,
+	useTemplateRef,
 	watch,
 } from "vue";
 import injectionKeys from "@/injectionKeys";
 
 const isActive = ref(false);
-const rootEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
 const canvasEl = document.createElement("canvas");
-const videoEl: Ref<HTMLVideoElement> = ref(null);
+const videoEl = useTemplateRef("videoEl");
 const fields = inject(injectionKeys.evaluatedFields);
 const videoDevices: Ref<MediaDeviceInfo[]> = ref(null);
 const preferredDeviceId: Ref<MediaDeviceInfo["deviceId"]> = ref(null);

--- a/src/ui/src/components/core/root/CorePage.vue
+++ b/src/ui/src/components/core/root/CorePage.vue
@@ -119,10 +119,10 @@ export default {
 };
 </script>
 <script setup lang="ts">
-import { Ref, inject, ref } from "vue";
+import { inject, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 
-const rootEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
 const fields = inject(injectionKeys.evaluatedFields);
 
 function handleKeydown(ev: KeyboardEvent) {

--- a/src/ui/src/components/core/root/CoreRoot.vue
+++ b/src/ui/src/components/core/root/CoreRoot.vue
@@ -94,6 +94,7 @@ import {
 	watch,
 	nextTick,
 	onBeforeMount,
+	useTemplateRef,
 } from "vue";
 import injectionKeys from "@/injectionKeys";
 import { changePageInHash, serializeParsedHash } from "@/core/navigation";
@@ -101,7 +102,7 @@ import { changePageInHash, serializeParsedHash } from "@/core/navigation";
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
 const getChildrenVNodes = inject(injectionKeys.getChildrenVNodes);
-const rootEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
 const { isComponentVisible } = useEvaluator(wf);
 
 const displayedPageId = computed(() => {

--- a/src/ui/src/components/custom/BubbleMessageAdvanced.vue
+++ b/src/ui/src/components/custom/BubbleMessageAdvanced.vue
@@ -116,7 +116,7 @@ import {
 	WriterComponentDefinition,
 } from "@/writerTypes";
 import injectionKeys from "@/injectionKeys";
-import { inject, computed, ref, Ref } from "vue";
+import { inject, computed, useTemplateRef } from "vue";
 
 /* Standard style fields can be imported from "sharedStyleFields" 
 to avoid repetition. */
@@ -128,7 +128,7 @@ import {
 	containerBackgroundColor,
 } from "@/renderer/sharedStyleFields";
 
-const rootEl: Ref<HTMLElement> = ref(null); // Root element is used to fire events
+const rootEl = useTemplateRef("rootEl"); // Root element is used to fire events
 
 /*
 The values for the fields defined earlier in the custom option

--- a/src/ui/src/components/shared/ShareHorizontalResize.vue
+++ b/src/ui/src/components/shared/ShareHorizontalResize.vue
@@ -14,12 +14,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, CSSProperties, ref } from "vue";
+import { computed, CSSProperties, ref, useTemplateRef } from "vue";
 
 const props = defineProps({
 	initialLeftSize: { type: Number, required: true },
 });
-const root = ref<HTMLElement | null>(null);
+const root = useTemplateRef("root");
 
 let leftSize = ref(props.initialLeftSize);
 const style = computed<CSSProperties>(() => ({
@@ -27,6 +27,7 @@ const style = computed<CSSProperties>(() => ({
 }));
 
 function handleMouseDown() {
+	if (!root.value) return;
 	document.addEventListener("mousemove", onMouseMove);
 	document.addEventListener("mouseup", onMouseUp);
 

--- a/src/ui/src/components/workflows/WorkflowsRoot.vue
+++ b/src/ui/src/components/workflows/WorkflowsRoot.vue
@@ -25,12 +25,12 @@ export default {
 };
 </script>
 <script setup lang="ts">
-import { computed, inject, ref, Ref } from "vue";
+import { computed, inject, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 
 const wf = inject(injectionKeys.core);
 const getChildrenVNodes = inject(injectionKeys.getChildrenVNodes);
-const rootEl: Ref<HTMLElement> = ref(null);
+const rootEl = useTemplateRef("rootEl");
 
 const displayedWorkflowId = computed(() => {
 	const activePageId = wf.activePageId.value;

--- a/src/ui/src/components/workflows/WorkflowsWorkflow.vue
+++ b/src/ui/src/components/workflows/WorkflowsWorkflow.vue
@@ -138,6 +138,7 @@ import {
 	onUnmounted,
 	ref,
 	shallowRef,
+	useTemplateRef,
 } from "vue";
 import { useComponentActions } from "@/builder/useComponentActions";
 import { useDragDropComponent } from "@/builder/useDragDropComponent";
@@ -146,8 +147,8 @@ import injectionKeys from "@/injectionKeys";
 const renderProxiedComponent = inject(injectionKeys.renderProxiedComponent);
 const workflowComponentId = inject(injectionKeys.componentId);
 
-const rootEl: Ref<HTMLElement | null> = ref(null);
-const nodeContainerEl: Ref<HTMLElement | null> = ref(null);
+const rootEl = useTemplateRef("rootEl");
+const nodeContainerEl = useTemplateRef("nodeContainerEl");
 const wf = inject(injectionKeys.core);
 const wfbm = inject(injectionKeys.builderManager);
 const arrows: Ref<WorkflowArrowData[]> = ref([]);

--- a/src/ui/src/components/workflows/base/WorkflowMiniMap.vue
+++ b/src/ui/src/components/workflows/base/WorkflowMiniMap.vue
@@ -42,10 +42,17 @@
 
 <script setup lang="ts">
 import injectionKeys from "@/injectionKeys";
-import { inject, nextTick, onMounted, onUnmounted, ref } from "vue";
+import {
+	inject,
+	nextTick,
+	onMounted,
+	onUnmounted,
+	ref,
+	useTemplateRef,
+} from "vue";
 
 const wfbm = inject(injectionKeys.builderManager);
-const rootEl = ref(null);
+const rootEl = useTemplateRef("rootEl");
 const emit = defineEmits(["changeRenderOffset"]);
 const resizeObserver = new ResizeObserver(render);
 const mutationObserver = new MutationObserver(render);

--- a/src/ui/src/components/workflows/base/WorkflowNavigator.vue
+++ b/src/ui/src/components/workflows/base/WorkflowNavigator.vue
@@ -86,7 +86,14 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, toRefs, watch } from "vue";
+import {
+	onMounted,
+	onUnmounted,
+	ref,
+	toRefs,
+	useTemplateRef,
+	watch,
+} from "vue";
 import WorkflowMiniMap from "./WorkflowMiniMap.vue";
 import WdsButton from "@/wds/WdsButton.vue";
 import WdsTextInput from "@/wds/WdsTextInput.vue";
@@ -105,7 +112,7 @@ const props = defineProps<{
 
 const { zoomLevel } = toRefs(props);
 
-const rootEl = ref(null);
+const rootEl = useTemplateRef("rootEl");
 const emit = defineEmits([
 	"changeRenderOffset",
 	"changeZoomLevel",

--- a/src/ui/src/components/workflows/base/WorkflowsNodeNamer.vue
+++ b/src/ui/src/components/workflows/base/WorkflowsNodeNamer.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, nextTick, ref } from "vue";
+import { computed, inject, nextTick, ref, useTemplateRef } from "vue";
 import { useComponentActions } from "@/builder/useComponentActions";
 import { Component } from "@/writerTypes";
 import injectionKeys from "@/injectionKeys";
@@ -47,7 +47,7 @@ const aliasFieldValue = computed(
 	() => wf.getComponentById(props.componentId)?.content["alias"],
 );
 const isAliased = computed(() => Boolean(aliasFieldValue.value));
-const aliasEditorEl = ref<HTMLInputElement>(null);
+const aliasEditorEl = useTemplateRef("aliasEditorEl");
 const isAliasBeingEdited = ref(false);
 
 async function enableEditor() {

--- a/src/ui/src/renderer/RendererNotifications.vue
+++ b/src/ui/src/renderer/RendererNotifications.vue
@@ -39,14 +39,14 @@
 </template>
 
 <script setup lang="ts">
-import { inject, onMounted, reactive, Ref, ref } from "vue";
+import { inject, onMounted, reactive, ref, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 import WdsButton from "@/wds/WdsButton.vue";
 
 const MAX_ITEMS_IN_LIST = 100;
 const wf = inject(injectionKeys.core);
 const isActive = ref(false);
-const balloon: Ref<HTMLElement> = ref(null);
+const balloon = useTemplateRef("balloon");
 
 const notifications: {
 	type: string;

--- a/src/ui/src/wds/WdsDropdownMenu.vue
+++ b/src/ui/src/wds/WdsDropdownMenu.vue
@@ -52,7 +52,7 @@ export type WdsDropdownMenuOption = {
 
 <script setup lang="ts">
 // from https://www.figma.com/design/jgLDtwVwg3hReC1t4Vw20D/.WDS-Writer-Design-System?node-id=128-396&t=9Gy9MYDycjVV8C2Y-1
-import { computed, PropType, ref, watch } from "vue";
+import { computed, PropType, ref, useTemplateRef, watch } from "vue";
 
 const props = defineProps({
 	options: {
@@ -69,7 +69,7 @@ const emits = defineEmits({
 	search: (value: string) => typeof value === "string",
 });
 
-const searchInput = ref<HTMLElement>();
+const searchInput = useTemplateRef("searchInput");
 const searchTerm = ref("");
 
 function getOptionIcon(option: WdsDropdownMenuOption) {

--- a/src/ui/src/wds/WdsTabs.vue
+++ b/src/ui/src/wds/WdsTabs.vue
@@ -24,7 +24,10 @@ import { PropType } from "vue";
 import WdsTab from "./WdsTab.vue";
 
 defineProps({
-	tabs: { type: Array as PropType<WdsTabOptions[]>, required: true },
+	tabs: {
+		type: Array as PropType<WdsTabOptions[] | Readonly<WdsTabOptions[]>>,
+		required: true,
+	},
 });
 
 const selected = defineModel({ type: String });

--- a/src/ui/src/wds/WdsTextInput.vue
+++ b/src/ui/src/wds/WdsTextInput.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import { PropType, ref } from "vue";
+import { PropType, useTemplateRef } from "vue";
 
 const model = defineModel({ type: String });
 
@@ -43,7 +43,7 @@ defineExpose({
 	setSelectionStart,
 });
 
-const input = ref<HTMLInputElement>();
+const input = useTemplateRef("input");
 
 function setSelectionStart(value: number) {
 	if (input.value) input.value.selectionStart = value;

--- a/src/ui/src/wds/WdsTextareaInput.vue
+++ b/src/ui/src/wds/WdsTextareaInput.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { useTemplateRef } from "vue";
 
 const model = defineModel<string>();
 
@@ -19,7 +19,7 @@ defineExpose({
 	setSelectionStart,
 });
 
-const input = ref<HTMLTextAreaElement>();
+const input = useTemplateRef("input");
 
 function setSelectionStart(value: number) {
 	if (input.value) input.value.selectionStart = value;


### PR DESCRIPTION
We are currently on Vue.js 3.2 (08/2021), the latest is 3.5 (11/2024).

So I bumped the version, here is the changelog

- [changelog 3.3](https://blog.vuejs.org/posts/vue-3-3), improves DevX
- [changelog 3.4](https://blog.vuejs.org/posts/vue-3-4), perf improvements (SFC + reactivity)
- [changelog 3.5](https://blog.vuejs.org/posts/vue-3-5), perf improvements (reactivity)

The main changes I did was to:

- use new `useId`
- use the `useTemplateRef('xyz')` instead of `const xyz = ref<HTMLElement>()`