### PR TITLE
fix(ui): hide `CoreProgressBar` progression in indeterminate state

### DIFF
--- a/src/ui/src/components/core/content/CoreProgressBar.vue
+++ b/src/ui/src/components/core/content/CoreProgressBar.vue
@@ -18,7 +18,7 @@
 				label
 			}}</label>
 			<span
-				v-if="displayPercentage"
+				v-if="displayPercentage && progression !== undefined"
 				class="CoreProgressBar__title__progress"
 				>{{ progressionText }}</span
 			>


### PR DESCRIPTION
I forgot to hide the progression when the `CoreProgressBar`'s progression is `undefined` (which is the case in "indeterminate" state when no `value` is provided).

So it actually displays `NaN%` when the component settings are `value === undefined && displayPercentage === true`. It's better to simply not display the percentage in this situation.

![image](https://github.com/user-attachments/assets/4f9a0186-3a80-4801-8295-5c2da15461e4)
