### PR TITLE
feat: implement multi-file code editor - WF-100

### DIFF
--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -68,6 +68,7 @@
 		<!-- TOOLTIP -->
 
 		<BuilderTooltip id="tooltip"></BuilderTooltip>
+		<BuilderToasts />
 	</div>
 </template>
 
@@ -83,6 +84,7 @@ import BuilderAsyncLoader from "./BuilderAsyncLoader.vue";
 import BuilderPanelSwitcher from "./panels/BuilderPanelSwitcher.vue";
 import { WDS_CSS_PROPERTIES } from "@/wds/tokens";
 import { SelectionStatus } from "./builderManager";
+import BuilderToasts from "./BuilderToasts.vue";
 
 const BuilderSettings = defineAsyncComponent({
 	loader: () => import("./settings/BuilderSettings.vue"),

--- a/src/ui/src/builder/BuilderEmbeddedCodeEditor.vue
+++ b/src/ui/src/builder/BuilderEmbeddedCodeEditor.vue
@@ -21,7 +21,7 @@ const props = defineProps<{
 	disabled?: boolean;
 }>();
 
-const { modelValue, disabled } = toRefs(props);
+const { modelValue, disabled, language } = toRefs(props);
 const emit = defineEmits(["update:modelValue"]);
 
 const VARIANTS_SETTINGS: Record<
@@ -53,6 +53,10 @@ watch(disabled, (isNewDisabled) => {
 watch(modelValue, (newCode) => {
 	if (editor.getValue() == newCode) return;
 	editor.getModel().setValue(newCode);
+});
+
+watch(language, () => {
+	monaco.editor.setModelLanguage(editor.getModel(), language.value);
 });
 
 onMounted(() => {

--- a/src/ui/src/builder/BuilderMoreDropdown.vue
+++ b/src/ui/src/builder/BuilderMoreDropdown.vue
@@ -1,0 +1,83 @@
+<template>
+	<div ref="trigger" class="BuilderMoreDropdown">
+		<WdsButton
+			variant="neutral"
+			size="smallIcon"
+			:disabled="disabled"
+			@click="isOpen = !isOpen"
+		>
+			<i class="material-symbols-outlined">more_horiz</i>
+		</WdsButton>
+		<WdsMenu
+			v-if="isOpen"
+			ref="dropdown"
+			class="BuilderMoreDropdown__dropdown"
+			:options="options"
+			:style="floatingStyles"
+			@select="onSelect"
+		/>
+	</div>
+</template>
+
+<script lang="ts">
+export type { WdsDropdownMenuOption as Option } from "@/wds/WdsDropdownMenu.vue";
+</script>
+
+<script setup lang="ts">
+import { defineAsyncComponent, nextTick, PropType, ref, watch } from "vue";
+import { useFloating, autoPlacement } from "@floating-ui/vue";
+import type { WdsDropdownMenuOption } from "@/wds/WdsDropdownMenu.vue";
+import { useFocusWithin } from "@/composables/useFocusWithin";
+import WdsButton from "@/wds/WdsButton.vue";
+
+const WdsMenu = defineAsyncComponent(() => import("@/wds/WdsDropdownMenu.vue"));
+
+defineProps({
+	options: {
+		type: Array as PropType<WdsDropdownMenuOption[]>,
+		default: () => [],
+	},
+	disabled: { type: Boolean },
+	hideIcons: { type: Boolean, required: false },
+});
+
+const emits = defineEmits({
+	select: (value: string) => typeof value === "string",
+});
+
+const isOpen = ref(false);
+const trigger = ref<HTMLElement>();
+const dropdown = ref<HTMLElement>();
+
+const { floatingStyles } = useFloating(trigger, dropdown, {
+	placement: "bottom-end",
+	middleware: [autoPlacement({ allowedPlacements: ["bottom", "top"] })],
+});
+
+// close the dropdown when clicking outside
+const hasFocus = useFocusWithin(trigger);
+watch(
+	hasFocus,
+	() => {
+		if (!hasFocus.value) {
+			// wait next tick to let event propagate
+			nextTick().then(() => (isOpen.value = false));
+		}
+	},
+	{ immediate: true },
+);
+
+function onSelect(value: string) {
+	isOpen.value = false;
+	emits("select", value);
+}
+</script>
+
+<style scoped>
+.BuilderMoreDropdown {
+	position: relative;
+}
+.BuilderMoreDropdown__dropdown {
+	min-width: 200px;
+}
+</style>

--- a/src/ui/src/builder/BuilderToasts.vue
+++ b/src/ui/src/builder/BuilderToasts.vue
@@ -1,0 +1,45 @@
+<template>
+	<div class="BuilderToasts">
+		<TransitionGroup name="list" tag="div">
+			<WdsToast
+				v-for="toast of toasts"
+				:key="toast.id"
+				class="BuilderToasts__toast"
+				:closable="toast.closable"
+				:message="toast.message"
+				:type="toast.type"
+				@click="removeToast(toast.id)"
+			/>
+		</TransitionGroup>
+	</div>
+</template>
+
+<script setup lang="ts">
+import WdsToast from "@/wds/WdsToast.vue";
+import { useToasts } from "./useToast";
+
+const { toasts, removeToast } = useToasts();
+</script>
+
+<style scoped>
+.BuilderToasts {
+	position: fixed;
+	bottom: 12px;
+	right: 12px;
+	z-index: 1;
+}
+
+.BuilderToasts__toast {
+	margin-top: 12px;
+}
+
+.list-enter-active,
+.list-leave-active {
+	transition: all 0.5s ease;
+}
+.list-enter-from,
+.list-leave-to {
+	opacity: 0;
+	transform: translateX(30px);
+}
+</style>

--- a/src/ui/src/builder/BuilderTree.vue
+++ b/src/ui/src/builder/BuilderTree.vue
@@ -6,6 +6,8 @@
 			tabindex="0"
 			:draggable="draggable"
 			:data-automation-key="dataAutomationKey"
+			@mouseenter="isMainHovered = true"
+			@mouseleave="isMainHovered = false"
 			@click="$emit('select', $event)"
 			@keydown.enter="$emit('select', $event)"
 			@dragover="$emit('dragover', $event)"
@@ -28,6 +30,12 @@
 			<slot name="nameLeft" />
 			<span class="BuilderTree__main__name">{{ name }}</span>
 			<slot name="nameRight" />
+			<BaseDropdown
+				v-if="dropdownOptions && isMainHovered"
+				class="BuilderTree__dropdown"
+				:options="dropdownOptions"
+				@selected="$emit('dropdownSelect', $event)"
+			/>
 		</div>
 		<div
 			v-show="(!collapsed || props.query) && hasChildren"
@@ -39,8 +47,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, defineAsyncComponent, PropType, ref } from "vue";
 import WdsButton from "@/wds/WdsButton.vue";
+const BaseDropdown = defineAsyncComponent(
+	() => import("@/components/core/base/BaseDropdown.vue"),
+);
 
 const props = defineProps({
 	name: { type: String, required: true },
@@ -50,6 +61,11 @@ const props = defineProps({
 	draggable: { type: Boolean },
 	matched: { type: Boolean },
 	selected: { type: Boolean },
+	dropdownOptions: {
+		type: Object as PropType<Record<string, string>>,
+		required: false,
+		default: undefined,
+	},
 });
 
 const emit = defineEmits({
@@ -59,11 +75,13 @@ const emit = defineEmits({
 	dragstart: (ev: DragEvent) => !!ev,
 	dragend: (ev: DragEvent) => !!ev,
 	drop: (ev: DragEvent) => !!ev,
+	dropdownSelect: (key: string) => typeof key === "string",
 });
 
 defineExpose({ expand });
 
 const collapsed = ref(false);
+const isMainHovered = ref(false);
 
 const notMatched = computed(() => !props.matched);
 
@@ -132,5 +150,9 @@ function toggleCollapse() {
 
 .BuilderTree__children {
 	margin-left: 20px;
+}
+
+.BuilderTree__dropdown {
+	--containerShadow: var(--wdsShadowMenu);
 }
 </style>

--- a/src/ui/src/builder/BuilderTree.vue
+++ b/src/ui/src/builder/BuilderTree.vue
@@ -28,14 +28,22 @@
 			</WdsButton>
 
 			<slot name="nameLeft" />
-			<span class="BuilderTree__main__name">{{ name }}</span>
+			<span
+				class="BuilderTree__main__name"
+				:data-writer-tooltip="name"
+				data-writer-tooltip-strategy="overflow"
+				>{{ name }}</span
+			>
 			<slot name="nameRight" />
-			<BaseDropdown
+			<div
 				v-if="dropdownOptions && isMainHovered"
 				class="BuilderTree__dropdown"
-				:options="dropdownOptions"
-				@selected="$emit('dropdownSelect', $event)"
-			/>
+			>
+				<BaseDropdown
+					:options="dropdownOptions"
+					@selected="$emit('dropdownSelect', $event)"
+				/>
+			</div>
 		</div>
 		<div
 			v-show="(!collapsed || props.query) && hasChildren"
@@ -139,7 +147,6 @@ function toggleCollapse() {
 
 .BuilderTree__main__name {
 	color: var(--builderPrimaryTextColor);
-	flex-grow: 1;
 }
 
 .BuilderTree__main__collapser {
@@ -153,6 +160,9 @@ function toggleCollapse() {
 }
 
 .BuilderTree__dropdown {
+	flex-grow: 1;
+	display: flex;
+	justify-content: flex-end;
 	color: var(--builderPrimaryTextColor);
 	--containerShadow: var(--wdsShadowMenu);
 }

--- a/src/ui/src/builder/BuilderTree.vue
+++ b/src/ui/src/builder/BuilderTree.vue
@@ -153,6 +153,7 @@ function toggleCollapse() {
 }
 
 .BuilderTree__dropdown {
+	color: var(--builderPrimaryTextColor);
 	--containerShadow: var(--wdsShadowMenu);
 }
 </style>

--- a/src/ui/src/builder/BuilderTree.vue
+++ b/src/ui/src/builder/BuilderTree.vue
@@ -121,6 +121,7 @@ function toggleCollapse() {
 
 .BuilderTree__main__name {
 	color: var(--builderPrimaryTextColor);
+	flex-grow: 1;
 }
 
 .BuilderTree__main__collapser {

--- a/src/ui/src/builder/BuilderTree.vue
+++ b/src/ui/src/builder/BuilderTree.vue
@@ -1,0 +1,135 @@
+<template>
+	<div class="BuilderTree">
+		<div
+			class="BuilderTree__main"
+			:class="{ selected, notMatched, childless }"
+			tabindex="0"
+			:draggable="draggable"
+			:data-automation-key="dataAutomationKey"
+			@click="$emit('select', $event)"
+			@keydown.enter="$emit('select', $event)"
+			@dragover="$emit('dragover', $event)"
+			@dragstart="$emit('dragstart', $event)"
+			@dragend="$emit('dragend', $event)"
+			@drop="$emit('drop', $event)"
+		>
+			<WdsButton
+				v-if="hasChildren"
+				class="BuilderTree__main__collapser"
+				variant="neutral"
+				size="icon"
+				@click.stop="toggleCollapse"
+			>
+				<i class="material-symbols-outlined">{{
+					collapsed ? "expand_more" : "expand_less"
+				}}</i>
+			</WdsButton>
+
+			<slot name="nameLeft" />
+			<span class="BuilderTree__main__name">{{ name }}</span>
+			<slot name="nameRight" />
+		</div>
+		<div
+			v-show="(!collapsed || props.query) && hasChildren"
+			class="BuilderTree__children"
+		>
+			<slot name="children" />
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import WdsButton from "@/wds/WdsButton.vue";
+
+const props = defineProps({
+	name: { type: String, required: true },
+	query: { type: String, required: false, default: undefined },
+	dataAutomationKey: { type: String, required: false, default: undefined },
+	hasChildren: { type: Boolean },
+	draggable: { type: Boolean },
+	matched: { type: Boolean },
+	selected: { type: Boolean },
+});
+
+const emit = defineEmits({
+	expandBranch: () => true,
+	select: (ev: MouseEvent | KeyboardEvent) => !!ev,
+	dragover: (ev: DragEvent) => !!ev,
+	dragstart: (ev: DragEvent) => !!ev,
+	dragend: (ev: DragEvent) => !!ev,
+	drop: (ev: DragEvent) => !!ev,
+});
+
+defineExpose({ expand });
+
+const collapsed = ref(false);
+
+const notMatched = computed(() => !props.matched);
+
+const childless = computed(() => !props.hasChildren);
+
+function expand() {
+	collapsed.value = false;
+	emit("expandBranch");
+}
+
+function toggleCollapse() {
+	collapsed.value = !collapsed.value;
+}
+</script>
+
+<style scoped>
+.BuilderTree {
+	font-size: 12px;
+}
+
+.BuilderTree__main {
+	padding: 8px;
+	border-radius: 8px;
+	cursor: pointer;
+	display: flex;
+	flex-wrap: nowrap;
+	text-wrap: nowrap;
+	max-width: 100%;
+	overflow: hidden;
+	align-items: center;
+	outline: none;
+	gap: 4px;
+	color: var(--builderSecondaryTextColor);
+}
+
+.BuilderTree__main.childless {
+	padding-left: 12px;
+}
+
+.BuilderTree__main:focus {
+	outline: 1px solid var(--builderSelectedColor);
+}
+
+.BuilderTree__main:hover {
+	background: var(--builderSubtleSeparatorColor);
+}
+
+.BuilderTree__main.selected {
+	background: var(--builderSelectedColor);
+}
+
+.BuilderTree__main.notMatched {
+	filter: opacity(0.2);
+}
+
+.BuilderTree__main__name {
+	color: var(--builderPrimaryTextColor);
+}
+
+.BuilderTree__main__collapser {
+	margin-left: -4px;
+	width: 20px;
+	height: 20px;
+}
+
+.BuilderTree__children {
+	margin-left: 20px;
+}
+</style>

--- a/src/ui/src/builder/panels/BuilderCodePanel.vue
+++ b/src/ui/src/builder/panels/BuilderCodePanel.vue
@@ -224,6 +224,7 @@ async function handleSave() {
 	height: 100%;
 	width: 100%;
 	padding: 4px;
+	overflow-y: auto;
 }
 
 .BuilderCodePanel__tree__addFile {

--- a/src/ui/src/builder/panels/BuilderCodePanel.vue
+++ b/src/ui/src/builder/panels/BuilderCodePanel.vue
@@ -3,121 +3,259 @@
 		panel-id="code"
 		name="Code"
 		:contents-teleport-el="contentsTeleportEl"
-		:actions="actions"
+		:actions="[]"
 		:scrollable="false"
+		enable-left-panel
 		keyboard-shortcut-key="J"
 		class="BuilderCodePanel"
+		@openned="onOpenPanel"
 	>
+		<template #leftPanel>
+			<div class="BuilderCodePanel__tree">
+				<BuilderCodePanelSourceFilesTree
+					:path-active="filepathOpen"
+					:paths-unsaved="pathsUnsaved"
+					:source-files="sourceFileDraft"
+					@add-file="handleAddFile"
+					@select="openFile"
+				/>
+				<button
+					class="BuilderCodePanel__tree__addFile"
+					@click="handleAddFile"
+				>
+					<i class="material-symbols-outlined">add</i>
+					Add file
+				</button>
+			</div>
+		</template>
 		<BuilderEmbeddedCodeEditor
 			v-model="code"
 			variant="full"
-			language="python"
+			:language="openedFileLanguage"
 			:disabled="isDisabled"
-			@update:model-value="handleUpdate"
-		></BuilderEmbeddedCodeEditor>
+		/>
 		<template #actionsCompanion>
-			<div v-if="status" class="status" :class="status.type">
-				{{ status.message }}
+			<div class="BuilderCodePanel__actionsCompanion">
+				<WdsTextInput
+					ref="filenameEl"
+					v-model="filename"
+					:disabled="!isRenaminAllowed"
+					class="BuilderCodePanel__actionsCompanion__filename"
+					autofocus
+					variant="ghost"
+					@keydown.enter="handleSave"
+				/>
+				<WdsButton
+					variant="primary"
+					size="small"
+					:disabled="isDisabled || isCodeSaved"
+					class="BuilderCodePanel__actionsCompanion__saveBtn"
+					@click="handleSave"
+				>
+					<i class="material-symbols-outlined">save</i>
+					Save file
+				</WdsButton>
+				<BuilderMoreDropdown
+					:disabled="moreOptionsDisabled"
+					:options="moreOptions"
+					@select="handleMoreSelect"
+				/>
 			</div>
 		</template>
 	</BuilderPanel>
 </template>
 
 <script setup lang="ts">
-import { computed, defineAsyncComponent, inject, ref, watch } from "vue";
-import BuilderPanel, { type BuilderPanelAction } from "./BuilderPanel.vue";
+import {
+	computed,
+	defineAsyncComponent,
+	inject,
+	nextTick,
+	onMounted,
+	onUnmounted,
+	ref,
+	watch,
+} from "vue";
+import BuilderPanel from "./BuilderPanel.vue";
 import BuilderAsyncLoader from "../BuilderAsyncLoader.vue";
 import injectionKeys from "@/injectionKeys";
-
-defineProps<{
-	contentsTeleportEl: HTMLElement;
-}>();
+import { useSourceFiles } from "@/core/useSourceFiles";
+import WdsTextInput from "@/wds/WdsTextInput.vue";
+import WdsButton from "@/wds/WdsButton.vue";
+import BuilderMoreDropdown, { Option } from "../BuilderMoreDropdown.vue";
+import BuilderCodePanelSourceFilesTree from "./BuilderCodePanelSourceFilesTree.vue";
+import { useToasts } from "../useToast";
+import { useLogger } from "@/composables/useLogger";
 
 const BuilderEmbeddedCodeEditor = defineAsyncComponent({
 	loader: () => import("../BuilderEmbeddedCodeEditor.vue"),
 	loadingComponent: BuilderAsyncLoader,
 });
 
+defineProps<{
+	contentsTeleportEl: HTMLElement;
+}>();
+
 const wf = inject(injectionKeys.core);
 
-const code = ref<string>(wf.runCode.value);
-const status = ref<null | {
-	type: "error" | "success" | "neutral";
-	message: string;
-}>(null);
-const isDisabled = ref<boolean>(false);
+const moreOptions: Option[] = [
+	{ label: "Rename file", value: "rename", icon: "edit" },
+	{ label: "Delete file", value: "delete", icon: "delete" },
+];
 
-const actions = computed<BuilderPanelAction[]>(() => [
-	{
-		icon: "save",
-		name: "Save and run",
-		keyboardShortcut: {
-			modifierKey: true,
-			key: "S",
-		},
-		callback: () => {
-			save();
-		},
-		isDisabled: isDisabled.value,
-	},
-]);
+const {
+	sourceFileDraft,
+	openFile,
+	openNewFile,
+	code,
+	openedFileLanguage,
+	filepathOpen,
+	pathsUnsaved,
+	save,
+} = useSourceFiles(wf);
 
-watch(wf.runCode, (newRunCode) => {
-	code.value = newRunCode;
+const { pushToast } = useToasts();
+
+const logger = useLogger();
+
+function useKeydownCmdS(callback: () => void | Promise<void>) {
+	const abortController = new AbortController();
+	onMounted(() => {
+		document.addEventListener(
+			"keydown",
+			async (event) => {
+				const isCmdOrCtrl = event.metaKey || event.ctrlKey;
+				const isSKey = event.key === "s" || event.key === "S";
+				if (!isCmdOrCtrl || !isSKey) return;
+
+				event.preventDefault(); // Prevent the default save dialog
+				await callback();
+			},
+			{ signal: abortController.signal },
+		);
+	});
+	onUnmounted(abortController.abort);
+}
+useKeydownCmdS(handleSave);
+
+const filenameEl = ref<HTMLInputElement>();
+const filename = ref("");
+const isDisabled = ref(false);
+
+const filepathOpenStr = computed(() => filepathOpen.value?.join("/") ?? "");
+const isRenaminAllowed = computed(() => filepathOpenStr.value !== "main.py");
+const isRenaming = computed(() => filepathOpenStr.value !== filename.value);
+
+const moreOptionsDisabled = computed(
+	() => isDisabled.value || filepathOpenStr.value === "main.py",
+);
+
+const isCodeSaved = computed(() => {
+	if (isRenaming.value) return false;
+	if (filepathOpen.value === undefined) return true;
+
+	return !pathsUnsaved.value
+		.map((p) => p.join("/"))
+		.includes(filepathOpenStr.value);
+});
+
+watch(filepathOpen, () => {
+	filename.value = filepathOpen.value?.join("/") ?? "";
 });
 
 watch(wf.sessionTimestamp, () => {
 	isDisabled.value = false;
-	if (isCodeSaved()) return;
-	status.value = null;
 });
 
-function handleUpdate() {
-	status.value = null;
+function onOpenPanel(open: boolean) {
+	if (!open) return;
+	if (filepathOpen.value === undefined) openFile(["main.py"]);
 }
 
-function isCodeSaved() {
-	return wf.runCode.value == code.value;
+async function openRenameMode() {
+	if (filepathOpenStr.value === "main.py") return;
+	await nextTick();
+	filenameEl.value?.focus();
 }
 
-async function save() {
-	status.value = {
-		type: "neutral",
-		message: "Processing...",
-	};
-	try {
-		isDisabled.value = true;
-		await wf.sendCodeSaveRequest(code.value);
-	} catch {
-		status.value = {
-			type: "error",
-			message: "Code hasn't been saved.",
-		};
-		isDisabled.value = false;
-		return;
+async function handleMoreSelect(key: string) {
+	switch (key) {
+		case "rename":
+			return openRenameMode();
+		case "delete":
+			await wf.sendDeleteSourceFileRequest(filepathOpen.value);
+			pushToast({ type: "success", message: "The file was deleted" });
+			return openFile(["main.py"]);
 	}
-	status.value = {
-		type: "success",
-		message: "Saved.",
-	};
+}
+
+async function handleAddFile() {
+	await openNewFile();
+	openRenameMode();
+}
+
+async function handleSave() {
+	if (filepathOpen.value === undefined) {
+		return pushToast({ type: "error", message: "There is no file open" });
+	} else if (isCodeSaved.value) {
+		return pushToast({
+			type: "info",
+			message: "There are not file changes to save",
+		});
+	}
+
+	isDisabled.value = true;
+
+	try {
+		await save(isRenaming.value ? filename.value.split("/") : undefined);
+		pushToast({ type: "success", message: "The file was saved" });
+	} catch (error) {
+		logger.error("The file hasn't been saved.", error);
+		pushToast({ type: "error", message: "The file hasn't been saved" });
+		return;
+	} finally {
+		isDisabled.value = false;
+	}
 }
 </script>
 
 <style scoped>
-.status {
-	padding: 2px 12px 2px 12px;
-	border-radius: 16px;
+.BuilderCodePanel__tree {
+	height: 100%;
+	width: 100%;
+	padding: 4px;
+}
+
+.BuilderCodePanel__tree__addFile {
+	height: 32px;
+	padding: 8px;
+
+	cursor: pointer;
+	background-color: transparent;
+	color: var(--wdsColorBlue5);
 	font-size: 12px;
+	border: none;
+
+	display: flex;
+	justify-content: center;
+	text-align: left;
+	gap: 4px;
 }
 
-.status.success,
-.status.neutral {
-	border: 1px solid var(--builderSeparatorColor);
-	background: var(--builderSubtleSeparatorColor);
+.BuilderCodePanel__actionsCompanion {
+	width: 100%;
+	display: flex;
+	gap: 12px;
+	align-items: center;
+	justify-content: right;
 }
 
-.status.error {
-	border: 1px solid var(--wdsColorOrange2);
-	background: var(--wdsColorOrange1);
+.BuilderCodePanel__actionsCompanion__filename {
+	height: 32px;
+	flex-grow: 1;
+}
+
+.BuilderCodePanel__actionsCompanion__saveBtn {
+	min-width: 120px;
 }
 </style>

--- a/src/ui/src/builder/panels/BuilderCodePanel.vue
+++ b/src/ui/src/builder/panels/BuilderCodePanel.vue
@@ -18,6 +18,7 @@
 					:source-files="sourceFileDraft"
 					@add-file="handleAddFile"
 					@select="openFile"
+					@delete="handleDeleteFile"
 				/>
 				<button
 					class="BuilderCodePanel__tree__addFile"
@@ -183,15 +184,24 @@ async function handleMoreSelect(key: string) {
 		case "rename":
 			return openRenameMode();
 		case "delete":
-			await wf.sendDeleteSourceFileRequest(filepathOpen.value);
-			pushToast({ type: "success", message: "The file was deleted" });
-			return openFile(["main.py"]);
+			await handleDeleteFile(filepathOpen.value);
 	}
 }
 
 async function handleAddFile() {
 	await openNewFile();
 	openRenameMode();
+}
+
+async function handleDeleteFile(path: string[]) {
+	await wf.sendDeleteSourceFileRequest(path);
+	pushToast({ type: "success", message: "The file was deleted" });
+
+	const currentFileDeleted = filepathOpen.value
+		.join("/")
+		.startsWith(path.join("/"));
+
+	if (currentFileDeleted) openFile(["main.py"]);
 }
 
 async function handleSave() {

--- a/src/ui/src/builder/panels/BuilderCodePanelSourceFilesTree.vue
+++ b/src/ui/src/builder/panels/BuilderCodePanelSourceFilesTree.vue
@@ -7,7 +7,12 @@
 			matched
 			:has-children="isSourceFilesDirectory(node)"
 			:selected="isSelected(key)"
+			:right-click-options="rightClickDropdownOptions"
+			:dropdown-options="
+				isSourceFilesDirectory(node) ? { delete: 'Delete' } : undefined
+			"
 			@select="handleSelect(key)"
+			@dropdown-select="handleDropdownSelect($event, key)"
 		>
 			<template v-if="isDraft(key)" #nameLeft>
 				<WdsStateDot state="newDraft" />
@@ -19,11 +24,20 @@
 					:paths-unsaved="pathsUnsaved"
 					:path="[...path, key]"
 					@select="$emit('select', $event)"
+					@delete="$emit('delete', $event)"
 				/>
 			</template>
 		</BuilderTree>
 	</div>
 </template>
+
+<script lang="ts">
+import type { WdsDropdownMenuOption } from "@/wds/WdsDropdownMenu.vue";
+
+const rightClickDropdownOptions: WdsDropdownMenuOption[] = [
+	{ label: "Delete", value: "delete" },
+];
+</script>
 
 <script setup lang="ts">
 import { SourceFiles } from "@/writerTypes";
@@ -46,6 +60,7 @@ const props = defineProps({
 
 const emits = defineEmits({
 	select: (path: string[]) => Array.isArray(path),
+	delete: (path: string[]) => Array.isArray(path),
 	addFile: () => true,
 });
 
@@ -82,6 +97,10 @@ function handleSelect(key: string) {
 	if (!isSourceFilesFile(node)) return;
 
 	emits("select", [...props.path, key]);
+}
+
+function handleDropdownSelect(action: string, key: string) {
+	if (action === "delete") emits("delete", [...props.path, key]);
 }
 </script>
 

--- a/src/ui/src/builder/panels/BuilderCodePanelSourceFilesTree.vue
+++ b/src/ui/src/builder/panels/BuilderCodePanelSourceFilesTree.vue
@@ -1,0 +1,93 @@
+<template>
+	<div>
+		<BuilderTree
+			v-for="[key, node] of sourceFilesEntries"
+			:key="key"
+			:name="key"
+			matched
+			:has-children="isSourceFilesDirectory(node)"
+			:selected="isSelected(key)"
+			@select="handleSelect(key)"
+		>
+			<template v-if="isDraft(key)" #nameLeft>
+				<WdsStateDot state="newDraft" />
+			</template>
+			<template #children>
+				<BuilderCodePanelSourceFilesTree
+					:source-files="node"
+					:path-active="pathActive"
+					:paths-unsaved="pathsUnsaved"
+					:path="[...path, key]"
+					@select="$emit('select', $event)"
+				/>
+			</template>
+		</BuilderTree>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { SourceFiles } from "@/writerTypes";
+import { computed, PropType } from "vue";
+import BuilderTree from "../BuilderTree.vue";
+import BuilderCodePanelSourceFilesTree from "./BuilderCodePanelSourceFilesTree.vue";
+import { isSourceFilesDirectory, isSourceFilesFile } from "@/core/sourceFiles";
+import WdsStateDot from "@/wds/WdsStateDot.vue";
+
+const props = defineProps({
+	sourceFiles: {
+		type: Object as PropType<SourceFiles>,
+		required: true,
+	},
+	path: { type: Array as PropType<string[]>, default: () => [] },
+	pathActive: { type: Array as PropType<string[]>, default: () => [] },
+	pathsUnsaved: { type: Array as PropType<string[][]>, default: () => [] },
+	displayAddFileButton: { type: Boolean },
+});
+
+const emits = defineEmits({
+	select: (path: string[]) => Array.isArray(path),
+	addFile: () => true,
+});
+
+function pathToStr(path: string[]) {
+	return path.join("/");
+}
+
+const pathActiveStr = computed(() => pathToStr(props.pathActive));
+
+const pathsUnsavedStr = computed(() => props.pathsUnsaved.map(pathToStr));
+
+const sourceFilesEntries = computed(() => {
+	if (!isSourceFilesDirectory(props.sourceFiles)) return [];
+
+	return Object.entries(props.sourceFiles.children).sort((a, b) =>
+		a[0].localeCompare(b[0]),
+	);
+});
+
+function isDraft(key: string) {
+	const path = pathToStr([...props.path, key]);
+	return pathsUnsavedStr.value.includes(path);
+}
+
+function isSelected(key: string) {
+	return pathToStr([...props.path, key]) === pathActiveStr.value;
+}
+
+function handleSelect(key: string) {
+	if (!isSourceFilesDirectory(props.sourceFiles)) return;
+
+	// only allow files to be selected
+	const node = props.sourceFiles.children[key];
+	if (!isSourceFilesFile(node)) return;
+
+	emits("select", [...props.path, key]);
+}
+</script>
+
+<style lang="css" scoped>
+:deep(.BuilderTree__main__name) {
+	text-overflow: ellipsis;
+	overflow: hidden;
+}
+</style>

--- a/src/ui/src/builder/panels/BuilderPanel.vue
+++ b/src/ui/src/builder/panels/BuilderPanel.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="BuilderPanel" :class="{ collapsed }">
-		<div class="collapser">
+		<div class="BuilderPanel__collapser">
 			<WdsButton
 				variant="neutral"
 				size="smallIcon"
@@ -14,15 +14,28 @@
 				}}</i>
 			</WdsButton>
 		</div>
-		<div class="title">{{ name }}</div>
-		<div class="titleCompanion">
+		<div class="BuilderPanel__title">{{ name }}</div>
+		<div class="BuilderPanel__titleCompanion">
 			<slot name="titleCompanion"></slot>
 		</div>
 		<template v-if="!collapsed">
 			<Teleport :to="contentsTeleportEl">
-				<div :style="{ order }" :data-order="order" class="contents">
-					<div class="actions">
-						<div class="actionsCompanion">
+				<div
+					:style="{ order }"
+					:data-order="order"
+					class="BuilderPanel__contents"
+					:class="{
+						'BuilderPanel__contents--leftPanel': enableLeftPanel,
+					}"
+				>
+					<div
+						v-if="enableLeftPanel"
+						class="BuilderPanel__contents__leftPanel"
+					>
+						<slot name="leftPanel" />
+					</div>
+					<div class="BuilderPanel__actions">
+						<div class="BuilderPanel__actionsCompanion">
 							<slot name="actionsCompanion"></slot>
 						</div>
 						<WdsButton
@@ -44,7 +57,7 @@
 							}}</i></WdsButton
 						>
 					</div>
-					<div class="mainContents">
+					<div class="BuilderPanel__mainContents">
 						<slot></slot>
 					</div>
 				</div>
@@ -83,7 +96,12 @@ const props = defineProps<{
 	contentsTeleportEl: HTMLElement;
 	scrollable: boolean;
 	keyboardShortcutKey: string;
+	enableLeftPanel?: boolean;
 }>();
+
+const emits = defineEmits({
+	openned: (open: boolean) => typeof open === "boolean",
+});
 
 const collapsed = computed(() => !wfbm.openPanels.value.has(props.panelId));
 const order = computed(() => panelIds.indexOf(props.panelId));
@@ -91,9 +109,11 @@ const order = computed(() => panelIds.indexOf(props.panelId));
 function togglePanel(panelId: typeof props.panelId) {
 	if (wfbm.openPanels.value.has(panelId)) {
 		wfbm.openPanels.value.delete(panelId);
+		emits("openned", false);
 		return;
 	}
 	wfbm.openPanels.value.add(panelId);
+	emits("openned", true);
 }
 
 function handleKeydown(ev: KeyboardEvent) {
@@ -145,26 +165,42 @@ onUnmounted(() => {
 	background: var(--builderBackgroundColor);
 }
 
-.title {
+.BuilderPanel__title {
 	font-size: 14px;
 	font-style: normal;
 	font-weight: 600;
 	line-height: 140%;
 }
 
-.titleCompanion {
+.BuilderPanel__titleCompanion {
 	margin-left: 8px;
 }
 
-.contents {
+.BuilderPanel__contents {
 	display: grid;
 	height: 100%;
-	grid-template-rows: 36px 1fr;
+	grid-template-rows: 56px 1fr;
 	grid-template-columns: 1fr;
 	overflow: hidden;
 }
 
-.actions {
+.BuilderPanel__contents--leftPanel {
+	grid-template-columns: auto 1fr;
+}
+
+.BuilderPanel__contents__leftPanel {
+	width: 200px;
+	height: 100%;
+	grid-row: 1 / 3;
+	border-right: 1px solid var(--builderSeparatorColor);
+}
+
+.BuilderPanel__actions,
+.BuilderPanel__actionsCompanion {
+	width: 100%;
+}
+
+.BuilderPanel__actions {
 	display: flex;
 	justify-content: right;
 	align-items: center;
@@ -173,7 +209,7 @@ onUnmounted(() => {
 	border-bottom: 1px solid var(--builderSeparatorColor);
 }
 
-.mainContents {
+.BuilderPanel__mainContents {
 	overflow-x: hidden;
 	overflow-y: auto;
 }

--- a/src/ui/src/builder/sidebar/BuilderSidebar.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebar.vue
@@ -13,16 +13,12 @@ import BuilderSidebarComponentTree from "./BuilderSidebarComponentTree.vue";
 
 <style scoped>
 .BuilderSidebar {
-	display: flex;
-	flex-direction: column;
+	display: grid;
+	grid-template-rows: 1fr 1fr;
 	height: 100%;
 }
 
 .BuilderSidebar > *:not(:first-child) {
 	border-top: 1px solid var(--builderSeparatorColor);
-}
-
-.BuilderSidebar > * {
-	flex: 0 0 50%;
 }
 </style>

--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTree.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTree.vue
@@ -8,7 +8,6 @@
 			class="rootBranch"
 			:component-id="rootComponentId"
 			:query="query"
-			:is-root="true"
 		></BuilderSidebarComponentTreeBranch>
 		<div class="add">
 			<WdsButton

--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTree.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTree.vue
@@ -4,33 +4,38 @@
 		class="BuilderSidebarComponentTree"
 		placeholder="Component tree"
 	>
-		<BuilderSidebarComponentTreeBranch
-			class="rootBranch"
-			:component-id="rootComponentId"
-			:query="query"
-		></BuilderSidebarComponentTreeBranch>
-		<div class="add">
-			<WdsButton
-				v-if="rootComponentId == 'root'"
-				variant="special"
-				size="small"
-				data-automation-action="add-page"
-				@click="addPage"
-			>
-				<i class="material-symbols-outlined"> add </i> Add
-				page</WdsButton
-			>
-			<WdsButton
-				v-if="rootComponentId == 'workflows_root'"
-				variant="special"
-				size="small"
-				data-automation-action="add-workflow"
-				@click="addWorkflow"
-			>
-				<i class="material-symbols-outlined"> add </i> Add
-				workflow</WdsButton
-			>
+		<div>
+			<BuilderSidebarComponentTreeBranch
+				class="rootBranch"
+				:component-id="rootComponentId"
+				:query="query"
+			></BuilderSidebarComponentTreeBranch>
 		</div>
+
+		<template #footer>
+			<div class="add">
+				<WdsButton
+					v-if="rootComponentId == 'root'"
+					variant="special"
+					size="small"
+					data-automation-action="add-page"
+					@click="addPage"
+				>
+					<i class="material-symbols-outlined"> add </i> Add
+					page</WdsButton
+				>
+				<WdsButton
+					v-if="rootComponentId == 'workflows_root'"
+					variant="special"
+					size="small"
+					data-automation-action="add-workflow"
+					@click="addWorkflow"
+				>
+					<i class="material-symbols-outlined"> add </i> Add
+					workflow</WdsButton
+				>
+			</div>
+		</template>
 	</BuilderSidebarPanel>
 </template>
 
@@ -75,8 +80,6 @@ async function addWorkflow() {
 
 <style scoped>
 .BuilderSidebarComponentTree {
-	display: flex;
-	flex-direction: column;
 	height: 100%;
 	position: relative;
 }
@@ -106,16 +109,12 @@ async function addWorkflow() {
 }
 
 .add {
-	position: sticky;
 	flex: 0 0 48px;
 	bottom: 0;
 	height: 48px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	margin-left: -16px;
-	margin-right: -16px;
-	margin-bottom: -16px;
 	border-top: 1px solid var(--builderSeparatorColor);
 	background: var(--builderBackgroundColor);
 }

--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
@@ -1,6 +1,7 @@
 <template>
 	<TreeBranch
 		ref="treeBranch"
+		class="BuilderSidebarComponentTreeBranch"
 		:component-id="componentId"
 		:name="name"
 		:query="query"
@@ -154,14 +155,21 @@ function expand() {
 	treeBranch.value.expand();
 	collapsed.value = false;
 	emit("expandBranch");
+	scrollToShow({ onlyHorizontal: true });
 }
 
-function scrollToShow() {
-	if (!treeBranch.value) return;
-	const treeEl = treeBranch.value.$el.closest(".BuilderSidebarComponentTree");
+function scrollToShow(opts?: { onlyHorizontal?: boolean }) {
+	const treeBranchEl = treeBranch.value?.$el as HTMLDivElement;
+	if (!treeBranchEl) return;
+	const treeEl = treeBranchEl.closest(".BuilderSidebarComponentTree");
 	const treeBCR = treeEl.getBoundingClientRect();
-	const scrollTop = treeBranch.value.$el.offsetTop - treeBCR.height / 2;
-	treeEl.scrollTo({ top: scrollTop, left: 0, behavior: "smooth" });
+	const top = treeBranch.value.$el.offsetTop - treeBCR.height / 2;
+	const left = treeBranch.value.$el.offsetLeft - treeBCR.left - 16;
+	treeEl.scrollTo({
+		top: opts?.onlyHorizontal ? undefined : top,
+		left: Math.max(0, left),
+		behavior: "smooth",
+	});
 }
 
 function handleDragStart(ev: DragEvent) {

--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
@@ -1,73 +1,74 @@
 <template>
-	<div ref="rootEl" class="BuilderSidebarComponentTreeBranch">
-		<div
-			class="main"
-			:class="{ selected, notMatched, childless }"
-			tabindex="0"
-			:draggable="isDraggingAllowed(componentId)"
-			:data-automation-key="component.type"
-			@click="select"
-			@keydown.enter="select"
-			@dragover="handleDragOver"
-			@dragstart="handleDragStart"
-			@dragend="handleDragEnd"
-			@drop="handleDrop"
-		>
-			<WdsButton
-				v-if="children.length > 0"
-				class="collapser"
-				variant="neutral"
-				size="icon"
-				@click.stop="toggleCollapse"
-			>
-				<i v-if="collapsed" class="material-symbols-outlined"
-					>expand_more</i
+	<TreeBranch
+		ref="treeBranch"
+		:component-id="componentId"
+		:name="name"
+		:query="query"
+		:has-children="children.length > 0"
+		:data-automation-key="component.type"
+		:draggable="isDraggingAllowed(componentId)"
+		:matched="matched"
+		:selected="selected"
+		@select="select"
+		@dragover="handleDragOver"
+		@dragstart="handleDragStart"
+		@dragend="handleDragEnd"
+		@drop="handleDrop"
+	>
+		<template #nameRight>
+			<span class="BuilderSidebarComponentTreeBranch__nameRight">
+				<template
+					v-if="Object.keys(component.handlers ?? {}).length > 0"
 				>
-				<i v-else class="material-symbols-outlined">expand_less</i>
-			</WdsButton>
+					<span class="middot"></span
+					><i class="material-symbols-outlined">bolt</i>
+				</template>
+				<template v-if="!isComponentVisible(component.id)">
+					<span class="middot"></span
+					><i class="material-symbols-outlined">visibility_off</i>
+				</template>
+				<template v-if="component.isCodeManaged">
+					<span class="middot"></span
+					><i class="material-symbols-outlined">terminal</i>
+				</template>
+				<template v-if="previewText">
+					<span class="middot"></span
+					><span class="previewText">{{ previewText }}</span>
+				</template>
+			</span>
+		</template>
 
-			<span class="name">{{ name }}</span>
-			<template v-if="Object.keys(component.handlers ?? {}).length > 0">
-				<span class="middot"></span
-				><i class="material-symbols-outlined">bolt</i>
-			</template>
-			<template v-if="!isComponentVisible(component.id)">
-				<span class="middot"></span
-				><i class="material-symbols-outlined">visibility_off</i>
-			</template>
-			<template v-if="component.isCodeManaged">
-				<span class="middot"></span
-				><i class="material-symbols-outlined">terminal</i>
-			</template>
-			<template v-if="previewText">
-				<span class="middot"></span
-				><span class="previewText">{{ previewText }}</span>
-			</template>
-		</div>
-		<div
-			v-show="(!collapsed || props.query) && children.length > 0"
-			class="children"
-		>
+		<template #children>
 			<BuilderSidebarComponentTreeBranch
 				v-for="childComponent in children"
 				:key="childComponent.id"
 				:component-id="childComponent.id"
 				:query="query"
 				@expand-branch="expand"
-			></BuilderSidebarComponentTreeBranch>
-		</div>
-	</div>
+			/>
+		</template>
+	</TreeBranch>
 </template>
 
 <script setup lang="ts">
 import injectionKeys from "@/injectionKeys";
 import { Component } from "@/writerTypes";
-import { computed, inject, nextTick, ref, watch } from "vue";
+import {
+	ComponentPublicInstance,
+	computed,
+	inject,
+	nextTick,
+	ref,
+	watch,
+} from "vue";
 import BuilderSidebarComponentTreeBranch from "./BuilderSidebarComponentTreeBranch.vue";
 import { useEvaluator } from "@/renderer/useEvaluator";
 import { useDragDropComponent } from "../useDragDropComponent";
 import { useComponentActions } from "../useComponentActions";
-import WdsButton from "@/wds/WdsButton.vue";
+
+import TreeBranch from "../BuilderTree.vue";
+
+const treeBranch = ref<ComponentPublicInstance<typeof TreeBranch>>();
 
 const wf = inject(injectionKeys.core);
 const wfbm = inject(injectionKeys.builderManager);
@@ -82,7 +83,6 @@ const {
 const { getComponentInfoFromDrag, removeInsertionCandidacy, isParentSuitable } =
 	useDragDropComponent(wf);
 const { isComponentVisible } = useEvaluator(wf);
-const rootEl = ref<HTMLElement>(null);
 const emit = defineEmits(["expandBranch"]);
 
 const matched = computed(() => {
@@ -98,8 +98,6 @@ const matched = computed(() => {
 	return false;
 });
 
-const notMatched = computed(() => !matched.value);
-
 const props = defineProps<{
 	componentId: Component["id"];
 	query?: string;
@@ -112,8 +110,6 @@ const component = computed(() => {
 const children = computed(() => {
 	return wf.getComponents(props.componentId, { sortedByPosition: true });
 });
-
-const childless = computed(() => children.value.length == 0);
 
 const previewText = computed(() => {
 	const key = def.value?.previewField;
@@ -154,15 +150,17 @@ async function select(ev: MouseEvent | KeyboardEvent) {
 }
 
 function expand() {
+	if (!treeBranch.value) return;
+	treeBranch.value.expand();
 	collapsed.value = false;
 	emit("expandBranch");
 }
 
 function scrollToShow() {
-	if (!rootEl.value) return;
-	const treeEl = rootEl.value.closest(".BuilderSidebarComponentTree");
+	if (!treeBranch.value) return;
+	const treeEl = treeBranch.value.$el.closest(".BuilderSidebarComponentTree");
 	const treeBCR = treeEl.getBoundingClientRect();
-	const scrollTop = rootEl.value.offsetTop - treeBCR.height / 2;
+	const scrollTop = treeBranch.value.$el.offsetTop - treeBCR.height / 2;
 	treeEl.scrollTo({ top: scrollTop, left: 0, behavior: "smooth" });
 }
 
@@ -200,10 +198,6 @@ function handleDrop(ev: DragEvent) {
 	removeInsertionCandidacy(ev);
 }
 
-function toggleCollapse() {
-	collapsed.value = !collapsed.value;
-}
-
 watch(
 	wfbm.firstSelectedItem,
 	async (newSelection) => {
@@ -220,71 +214,35 @@ watch(
 
 <style scoped>
 .BuilderSidebarComponentTreeBranch {
-	font-size: 12px;
+	min-width: 170px;
 }
-
-.main {
-	padding: 8px;
-	border-radius: 8px;
-	cursor: pointer;
+.BuilderSidebarComponentTreeBranch__nameRight {
 	display: flex;
+	align-items: center;
+	gap: 4px;
+
 	flex-wrap: nowrap;
 	text-wrap: nowrap;
-	max-width: 100%;
-	overflow: hidden;
-	align-items: center;
-	outline: none;
-	gap: 4px;
-	color: var(--builderSecondaryTextColor);
-}
-
-.main.childless {
-	padding-left: 12px;
-}
-
-.main:focus {
-	outline: 1px solid var(--builderSelectedColor);
-}
-
-.main:hover {
-	background: var(--builderSubtleSeparatorColor);
-}
-
-.main.selected {
-	background: var(--builderSelectedColor);
-}
-
-.main.notMatched {
-	filter: opacity(0.2);
-}
-
-.name {
-	color: var(--builderPrimaryTextColor);
+	text-overflow: ellipsis;
+	min-width: 0;
 }
 
 .previewText {
+	flex-wrap: nowrap;
 	text-wrap: nowrap;
+	flex-grow: 1;
+	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
 
-.collapser {
-	margin-left: -4px;
-	width: 20px;
-	height: 20px;
-}
-
 .middot {
-	margin: 0 2px 0 2px;
+	display: inline-block;
 	border-radius: 3px;
 	width: 3px;
 	min-width: 3px;
 	height: 3px;
 	background: var(--builderSecondaryTextColor);
 	opacity: 0.5;
-}
-
-.children {
-	margin-left: 20px;
 }
 </style>

--- a/src/ui/src/builder/sidebar/BuilderSidebarPanel.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarPanel.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="BuilderSidebarPanel">
-		<div class="inputContainer">
+		<div class="BuilderSidebarPanel__inputContainer">
 			<WdsTextInput
 				v-model="model"
 				class="searchInput"
@@ -9,7 +9,10 @@
 				:placeholder="placeholder"
 			></WdsTextInput>
 		</div>
-		<div class="main"><slot></slot></div>
+		<div class="BuilderSidebarPanel__main"><slot></slot></div>
+		<div class="BuilderSidebarPanel__footer">
+			<slot name="footer"></slot>
+		</div>
 	</div>
 </template>
 
@@ -25,17 +28,21 @@ defineProps<{
 
 <style scoped>
 .BuilderSidebarPanel {
-	display: flex;
-	flex-direction: column;
+	display: grid;
+	grid-template-rows: auto 1fr;
+	grid-template-columns: 100%;
 	height: 100%;
+	width: 100%;
 	position: relative;
-	overflow-x: hidden;
+	overflow-x: auto;
 	overflow-y: scroll;
 }
 
-.inputContainer {
+.BuilderSidebarPanel__inputContainer {
 	position: sticky;
 	top: 0;
+	left: 0;
+	right: 0;
 	padding: 16px 16px 0 16px;
 	background: var(--builderBackgroundColor);
 	z-index: 2;
@@ -43,14 +50,19 @@ defineProps<{
 
 .searchInput {
 	background: var(--builderSubtleSeparatorColor);
+	width: 100%;
 }
 
-.main {
+.BuilderSidebarPanel__main {
 	display: flex;
-	flex: 1 0 auto;
 	padding: 16px;
 	gap: 16px;
 	flex-direction: column;
+}
+.BuilderSidebarPanel__footer {
+	position: sticky;
+	bottom: 0px;
+	left: 0px;
 }
 
 .categories {

--- a/src/ui/src/builder/useToast.ts
+++ b/src/ui/src/builder/useToast.ts
@@ -1,0 +1,32 @@
+import { readonly, shallowRef } from "vue";
+
+export type Toast = {
+	id: number;
+	type: "error" | "success" | "info";
+	message: string;
+	closable?: boolean;
+	delayMs?: number;
+};
+
+const toasts = shallowRef<Toast[]>([]);
+
+export function useToasts() {
+	function removeToast(id: number) {
+		toasts.value = toasts.value.filter((t) => t.id !== id);
+	}
+
+	function pushToast(toast: Omit<Toast, "id">) {
+		const id = new Date().getTime();
+		toasts.value = [...toasts.value, { ...toast, id }];
+
+		if (!toast.closable) {
+			setTimeout(() => removeToast(id), toast.delayMs ?? 3_000);
+		}
+	}
+
+	return {
+		pushToast,
+		removeToast,
+		toasts: readonly(toasts),
+	};
+}

--- a/src/ui/src/components/core/base/BaseDropdown.vue
+++ b/src/ui/src/components/core/base/BaseDropdown.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+// TODO(WF-154): to be move in shared
 import { onMounted, onUnmounted, PropType, ref } from "vue";
 
 defineProps({
@@ -81,8 +82,8 @@ onUnmounted(() => window.removeEventListener("scroll", closePopover));
 
 .BaseDropdown__trigger {
 	cursor: pointer;
-	background-color: var(--separatorColor);
-	border: 1px solid var(--emptinessColor);
+	background-color: transparent;
+	border: none;
 	height: 16px;
 	width: 16px;
 	border-radius: 4px;
@@ -95,6 +96,7 @@ onUnmounted(() => window.removeEventListener("scroll", closePopover));
 	position: absolute;
 	z-index: 1;
 	top: 18px;
+	transform: translateX(calc(-100% + 18px));
 	background-color: white;
 
 	flex-direction: column;

--- a/src/ui/src/components/shared/ShareHorizontalResize.vue
+++ b/src/ui/src/components/shared/ShareHorizontalResize.vue
@@ -1,0 +1,58 @@
+<template>
+	<div ref="root" class="ShareHorizontalResize" :style="style">
+		<div class="ShareHorizontalResize__left">
+			<slot name="left" />
+		</div>
+		<hr
+			class="ShareHorizontalResize__divider"
+			@mousedown.prevent="handleMouseDown"
+		/>
+		<div class="ShareHorizontalResize__right">
+			<slot name="right" />
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, CSSProperties, ref } from "vue";
+
+const props = defineProps({
+	initialLeftSize: { type: Number, required: true },
+});
+const root = ref<HTMLElement | null>(null);
+
+let leftSize = ref(props.initialLeftSize);
+const style = computed<CSSProperties>(() => ({
+	gridTemplateColumns: `${leftSize.value}px 1px minmax(0, 100%)`,
+}));
+
+function handleMouseDown() {
+	document.addEventListener("mousemove", onMouseMove);
+	document.addEventListener("mouseup", onMouseUp);
+
+	const rootBoundingRect = root.value.getBoundingClientRect();
+
+	function onMouseMove(event: MouseEvent) {
+		leftSize.value = event.x - rootBoundingRect.left;
+	}
+
+	function onMouseUp() {
+		document.removeEventListener("mouseup", onMouseUp);
+		document.removeEventListener("mousemove", onMouseMove);
+	}
+}
+</script>
+
+<style scoped>
+.ShareHorizontalResize {
+	display: grid;
+	height: 100%;
+}
+
+.ShareHorizontalResize__divider {
+	border: none;
+	background-color: var(--builderSeparatorColor);
+	height: 100%;
+	cursor: ew-resize;
+}
+</style>

--- a/src/ui/src/components/shared/SharedCollapsible.vue
+++ b/src/ui/src/components/shared/SharedCollapsible.vue
@@ -1,11 +1,19 @@
 <template>
 	<details
 		class="SharedCollapsible"
-		:open="open"
+		:class="{ 'SharedCollapsible--customMarker': icons }"
+		:open="isOpen"
 		:disabled="disabled"
 		@toggle="onToggle"
 	>
-		<summary><slot name="title" /></summary>
+		<summary class="SharedCollapsible__summary">
+			<span
+				v-if="icons"
+				class="SharedCollapsible__summary__icon material-symbols-outlined"
+				>{{ icon }}</span
+			>
+			<slot name="title" />
+		</summary>
 		<div class="content">
 			<slot name="content" />
 		</div>
@@ -13,17 +21,35 @@
 </template>
 
 <script setup lang="ts">
-defineProps({
+import { computed, PropType, ref, toRef, watch } from "vue";
+
+const props = defineProps({
 	open: { type: Boolean, required: false },
 	disabled: { type: Boolean, required: false },
+	icons: {
+		type: Object as PropType<{ open: string; close: string }>,
+		required: false,
+		default: undefined,
+	},
 });
 
 const emit = defineEmits({
 	toggle: (open: boolean) => typeof open === "boolean",
 });
 
+const isOpen = ref(props.open);
+
+watch(toRef(props, "open"), (value) => (isOpen.value = value));
+
+const icon = computed(() => {
+	if (props.icons === undefined) return undefined;
+	return isOpen.value ? props.icons.open : props.icons.close;
+});
+
 function onToggle(event) {
-	emit("toggle", event.newState === "open");
+	const state = event.newState === "open";
+	isOpen.value = state;
+	emit("toggle", state);
 }
 </script>
 
@@ -50,7 +76,7 @@ summary {
 	cursor: pointer;
 }
 
-summary:before {
+details summary:before {
 	content: "";
 	border-width: 6px;
 	border-style: solid;
@@ -62,6 +88,24 @@ summary:before {
 	transform: rotate(0);
 	transform-origin: 3px 50%;
 	transition: 0.3s transform ease;
+}
+
+.SharedCollapsible--customMarker summary {
+	padding-left: unset;
+	display: grid;
+	grid-template-columns: auto 1fr;
+	gap: 6px;
+	align-items: center;
+}
+.SharedCollapsible--customMarker summary:before {
+	content: none;
+}
+.SharedCollapsible__summary__icon {
+	height: 18px;
+	width: 18px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 summary:focus-visible:before {

--- a/src/ui/src/components/shared/SharedJsonViewer/__snapshots__/SharedJsonViewer.spec.ts.snap
+++ b/src/ui/src/components/shared/SharedJsonViewer/__snapshots__/SharedJsonViewer.spec.ts.snap
@@ -13,8 +13,10 @@ exports[`SharedJsonViewer > should render a nested object 1`] = `
     disabled="false"
   >
     <summary
+      class="SharedCollapsible__summary"
       data-v-55c4d015=""
     >
+      <!--v-if-->
       
       <div
         class="SharedJsonViewerCollapsible__title"
@@ -57,8 +59,10 @@ exports[`SharedJsonViewer > should render a nested object 1`] = `
             disabled="false"
           >
             <summary
+              class="SharedCollapsible__summary"
               data-v-55c4d015=""
             >
+              <!--v-if-->
               
               <div
                 class="SharedJsonViewerCollapsible__title"
@@ -107,8 +111,10 @@ exports[`SharedJsonViewer > should render a nested object 1`] = `
             disabled="false"
           >
             <summary
+              class="SharedCollapsible__summary"
               data-v-55c4d015=""
             >
+              <!--v-if-->
               
               <div
                 class="SharedJsonViewerCollapsible__title"
@@ -171,8 +177,10 @@ exports[`SharedJsonViewer > should render an array 1`] = `
     disabled="false"
   >
     <summary
+      class="SharedCollapsible__summary"
       data-v-55c4d015=""
     >
+      <!--v-if-->
       
       <div
         class="SharedJsonViewerCollapsible__title"

--- a/src/ui/src/core/sourceFiles.spec.ts
+++ b/src/ui/src/core/sourceFiles.spec.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+
+import {
+	createFileToSourceFiles,
+	deleteFileToSourceFiles,
+	findSourceFileFromPath,
+	getSourceFilesPathsToFiles,
+	moveFileToSourceFiles,
+} from "./sourceFiles";
+import { SourceFiles, SourceFilesFile } from "@/writerTypes.js";
+
+describe(findSourceFileFromPath.name, () => {
+	it("should retreive from simple path", () => {
+		const file: SourceFilesFile = {
+			type: "file",
+			content: "a",
+		};
+
+		const tree: SourceFiles = {
+			type: "directory",
+			children: { file },
+		};
+
+		expect(findSourceFileFromPath(["file"], tree)).toBe(file);
+	});
+
+	it("should retreive from nested path", () => {
+		const file: SourceFilesFile = {
+			type: "file",
+			content: "a",
+		};
+
+		const tree: SourceFiles = {
+			type: "directory",
+			children: {
+				a: {
+					type: "directory",
+					children: { b: { type: "directory", children: { file } } },
+				},
+			},
+		};
+
+		expect(findSourceFileFromPath(["a", "b", "file"], tree)).toBe(file);
+	});
+});
+
+describe(getSourceFilesPathsToFiles.name, () => {
+	it("should generate simple path", () => {
+		const result = getSourceFilesPathsToFiles({
+			type: "directory",
+			children: {
+				"a.txt": {
+					type: "file",
+					content: "",
+				},
+				"b.txt": {
+					type: "file",
+					content: "",
+				},
+			},
+		});
+
+		expect(Array.from(result)).toStrictEqual([["a.txt"], ["b.txt"]]);
+	});
+
+	it("should generate all nestes path", () => {
+		const result = getSourceFilesPathsToFiles({
+			type: "directory",
+			children: {
+				"a.txt": {
+					type: "file",
+					content: "",
+				},
+				b: {
+					type: "directory",
+					children: {
+						c: {
+							type: "directory",
+							children: {
+								"d.txt": {
+									type: "file",
+									content: "",
+								},
+								e: {
+									type: "directory",
+									children: {},
+								},
+							},
+						},
+					},
+				},
+			},
+		});
+
+		expect(Array.from(result)).toStrictEqual([
+			["a.txt"],
+			["b", "c", "d.txt"],
+		]);
+	});
+});
+
+describe(createFileToSourceFiles.name, () => {
+	it("should create the file", () => {
+		const result = createFileToSourceFiles(["a", "b", "c.txt"], {
+			type: "directory",
+			children: {},
+		});
+
+		expect(result).toStrictEqual({
+			type: "directory",
+			children: {
+				a: {
+					type: "directory",
+					children: {
+						b: {
+							type: "directory",
+							children: {
+								"c.txt": {
+									type: "file",
+									content: "",
+									complete: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		});
+	});
+});
+
+describe(moveFileToSourceFiles.name, () => {
+	const initial: SourceFiles = {
+		type: "directory",
+		children: {
+			a: {
+				type: "directory",
+				children: {
+					"b.txt": {
+						type: "file",
+						content: "",
+						complete: true,
+					},
+				},
+			},
+		},
+	};
+
+	it("should move node", () => {
+		const result = moveFileToSourceFiles(
+			["a", "b.txt"],
+			["b", "b.txt"],
+			initial,
+		);
+
+		expect(result).toStrictEqual({
+			type: "directory",
+			children: {
+				a: {
+					type: "directory",
+					children: {},
+				},
+				b: {
+					type: "directory",
+					children: {
+						"b.txt": {
+							type: "file",
+							content: "",
+							complete: true,
+						},
+					},
+				},
+			},
+		});
+	});
+});
+
+describe(deleteFileToSourceFiles.name, () => {
+	const initial: SourceFiles = {
+		type: "directory",
+		children: {
+			a: {
+				type: "directory",
+				children: {
+					"b.txt": {
+						type: "file",
+						content: "",
+						complete: true,
+					},
+				},
+			},
+		},
+	};
+
+	it("should delete the file", () => {
+		const result = deleteFileToSourceFiles(["a", "b.txt"], initial);
+
+		expect(result).toStrictEqual({
+			type: "directory",
+			children: {
+				a: {
+					type: "directory",
+					children: {},
+				},
+			},
+		});
+	});
+
+	it("should delete the directory", () => {
+		const result = deleteFileToSourceFiles(["a"], initial);
+
+		expect(result).toStrictEqual({
+			type: "directory",
+			children: {},
+		});
+	});
+
+	it("should handle unexisting path", () => {
+		const result = deleteFileToSourceFiles(["x", "y"], initial);
+
+		expect(result).toStrictEqual(initial);
+	});
+});

--- a/src/ui/src/core/sourceFiles.spec.ts
+++ b/src/ui/src/core/sourceFiles.spec.ts
@@ -4,6 +4,7 @@ import {
 	createFileToSourceFiles,
 	deleteFileToSourceFiles,
 	findSourceFileFromPath,
+	getSourceFilesPathsToEdges,
 	getSourceFilesPathsToFiles,
 	moveFileToSourceFiles,
 } from "./sourceFiles";
@@ -41,6 +42,44 @@ describe(findSourceFileFromPath.name, () => {
 		};
 
 		expect(findSourceFileFromPath(["a", "b", "file"], tree)).toBe(file);
+	});
+});
+
+describe(getSourceFilesPathsToEdges.name, () => {
+	it("should generate all nestes path", () => {
+		const result = getSourceFilesPathsToEdges({
+			type: "directory",
+			children: {
+				"a.txt": {
+					type: "file",
+					content: "",
+				},
+				b: {
+					type: "directory",
+					children: {
+						c: {
+							type: "directory",
+							children: {
+								"d.txt": {
+									type: "file",
+									content: "",
+								},
+								e: {
+									type: "directory",
+									children: {},
+								},
+							},
+						},
+					},
+				},
+			},
+		});
+
+		expect(Array.from(result)).toStrictEqual([
+			["a.txt"],
+			["b", "c", "d.txt"],
+			["b", "c", "e"],
+		]);
 	});
 });
 

--- a/src/ui/src/core/sourceFiles.ts
+++ b/src/ui/src/core/sourceFiles.ts
@@ -1,0 +1,119 @@
+import {
+	SourceFilesFile,
+	SourceFilesDirectory,
+	SourceFiles,
+} from "@/writerTypes";
+
+export function isSourceFilesFile(value: unknown): value is SourceFilesFile {
+	if (typeof value !== "object" || value === null) return false;
+	return value["type"] === "file" && typeof value["content"] === "string";
+}
+
+export function isSourceFilesDirectory(
+	value: unknown,
+): value is SourceFilesDirectory {
+	if (typeof value !== "object" || value === null) return false;
+	return (
+		value["type"] === "directory" && typeof value["children"] === "object"
+	);
+}
+
+/**
+ * Generate all the possible paths leading to a file
+ */
+export function* getSourceFilesPathsToFiles(
+	tree: SourceFiles,
+	path: string[] = [],
+): Generator<string[]> {
+	if (isSourceFilesFile(tree)) {
+		yield path;
+		return;
+	}
+
+	for (const [root, node] of Object.entries(tree.children)) {
+		yield* getSourceFilesPathsToFiles(node, [...path, root]);
+	}
+}
+
+export function findSourceFileFromPath(
+	path: string[],
+	tree: SourceFiles,
+): SourceFilesDirectory | SourceFilesFile | undefined {
+	if (path.length === 0) return tree;
+	if (!isSourceFilesDirectory(tree)) return undefined;
+
+	const [key, ...restPath] = path;
+	const node = tree.children[key];
+
+	return restPath.length === 0
+		? node
+		: findSourceFileFromPath(restPath, node);
+}
+
+export function createFileToSourceFiles(
+	path: string[],
+	tree: SourceFiles,
+	newFile: SourceFilesFile = {
+		type: "file",
+		content: "",
+		complete: true,
+	},
+) {
+	const copy = structuredClone(tree);
+	let node = copy;
+
+	for (let i = 0; i < path.length; i++) {
+		if (!isSourceFilesDirectory(node)) return copy;
+
+		const key = path.at(i);
+
+		if (i === path.length - 1) {
+			node.children[key] = newFile;
+			return copy;
+		} else {
+			node.children[key] ??= { type: "directory", children: {} };
+			node = node.children[key];
+		}
+	}
+
+	return copy;
+}
+
+export function moveFileToSourceFiles(
+	fromPath: string[],
+	toPath: string[],
+	tree: SourceFiles,
+) {
+	const node = findSourceFileFromPath(fromPath, tree);
+	if (!isSourceFilesFile(node)) return tree;
+
+	const treeWithDelete = deleteFileToSourceFiles(fromPath, tree);
+	return createFileToSourceFiles(
+		toPath,
+		treeWithDelete,
+		structuredClone(node),
+	);
+}
+
+export function deleteFileToSourceFiles(path: string[], tree: SourceFiles) {
+	const copy = structuredClone(tree);
+	let node = copy;
+
+	for (let i = 0; i < path.length; i++) {
+		if (!isSourceFilesDirectory(node)) return copy;
+
+		const key = path.at(i);
+
+		if (!(key in node.children)) return copy;
+
+		if (i === path.length - 1) {
+			delete node.children[key];
+			return copy;
+		} else {
+			node.children[key] ??= { type: "directory", children: {} };
+			node = node.children[key];
+		}
+	}
+
+	return copy;
+}

--- a/src/ui/src/core/sourceFiles.ts
+++ b/src/ui/src/core/sourceFiles.ts
@@ -35,6 +35,42 @@ export function* getSourceFilesPathsToFiles(
 	}
 }
 
+/**
+ * Generate all the possible paths leading to an edge (file or folder)
+ */
+export function* getSourceFilesPathsToEdges(
+	tree: SourceFiles,
+	path: string[] = [],
+): Generator<string[]> {
+	if (isSourceFilesFile(tree)) {
+		yield path;
+		return;
+	}
+	if (Object.values(tree.children).length === 0) {
+		yield path;
+		return;
+	}
+
+	for (const [root, node] of Object.entries(tree.children)) {
+		yield* getSourceFilesPathsToEdges(node, [...path, root]);
+	}
+}
+
+/**
+ * Generate all the possible paths
+ */
+export function* getSourceFilesPathsToNodes(
+	tree: SourceFiles,
+	path: string[] = [],
+): Generator<string[]> {
+	yield path;
+	if (isSourceFilesFile(tree)) return;
+
+	for (const [root, node] of Object.entries(tree.children)) {
+		yield* getSourceFilesPathsToNodes(node, [...path, root]);
+	}
+}
+
 export function findSourceFileFromPath(
 	path: string[],
 	tree: SourceFiles,

--- a/src/ui/src/core/useSourceFiles.spec.ts
+++ b/src/ui/src/core/useSourceFiles.spec.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import { useSourceFiles } from "./useSourceFiles";
+import { buildMockCore } from "@/tests/mocks";
+import { flushPromises } from "@vue/test-utils";
+
+describe(useSourceFiles.name, () => {
+	it("should open a file", () => {
+		const { core, sourceFiles } = buildMockCore();
+		sourceFiles.value = {
+			type: "directory",
+			children: {
+				"main.py": {
+					type: "file",
+					content: "print('hello')",
+					complete: true,
+				},
+			},
+		};
+		const { openFile, filepathOpen, code } = useSourceFiles(core);
+
+		openFile(["main.py"]);
+
+		expect(filepathOpen.value).toStrictEqual(["main.py"]);
+		expect(code.value).toStrictEqual("print('hello')");
+	});
+
+	it("should edit a file a compute edited file", () => {
+		const { core, sourceFiles } = buildMockCore();
+		sourceFiles.value = {
+			type: "directory",
+			children: {
+				"a.txt": {
+					type: "file",
+					content: "A",
+					complete: true,
+				},
+				"b.txt": {
+					type: "file",
+					content: "B",
+					complete: true,
+				},
+				c: {
+					type: "directory",
+					children: {
+						"c.txt": {
+							type: "file",
+							content: "C",
+							complete: true,
+						},
+					},
+				},
+			},
+		};
+		const { openFile, code, pathsUnsaved } = useSourceFiles(core);
+
+		openFile(["a.txt"]);
+		code.value = "X";
+
+		expect(pathsUnsaved.value).toStrictEqual([["a.txt"]]);
+
+		openFile(["c", "c.txt"]);
+		code.value = "X";
+
+		expect(pathsUnsaved.value).toStrictEqual([["a.txt"], ["c", "c.txt"]]);
+	});
+
+	it("should add a file to the draft", async () => {
+		const { core, sourceFiles } = buildMockCore();
+		sourceFiles.value = { type: "directory", children: {} };
+
+		const { sourceFileDraft } = useSourceFiles(core);
+		expect(sourceFileDraft.value).toStrictEqual(sourceFiles.value);
+
+		sourceFiles.value = {
+			type: "directory",
+			children: {
+				"a.txt": { type: "file", content: "", complete: true },
+			},
+		};
+		await flushPromises();
+		expect(sourceFileDraft.value).toStrictEqual(sourceFiles.value);
+	});
+
+	it("should remove a file to the draft", async () => {
+		const { core, sourceFiles } = buildMockCore();
+		sourceFiles.value = {
+			type: "directory",
+			children: {
+				"a.txt": { type: "file", content: "", complete: true },
+			},
+		};
+
+		const { sourceFileDraft } = useSourceFiles(core);
+		expect(sourceFileDraft.value).toStrictEqual(sourceFiles.value);
+
+		sourceFiles.value = {
+			type: "directory",
+			children: {},
+		};
+		await flushPromises();
+		expect(sourceFileDraft.value).toStrictEqual(sourceFiles.value);
+	});
+
+	describe("lazy loading", () => {
+		it("should request fetchig whole file on opening", () => {
+			const { core, sourceFiles } = buildMockCore();
+
+			const requestSourceFileLoading = vi
+				.spyOn(core, "requestSourceFileLoading")
+				.mockImplementation(async () => {});
+
+			sourceFiles.value = {
+				type: "directory",
+				children: {
+					"a.txt": {
+						type: "file",
+						content: "A",
+						complete: false,
+					},
+					"b.txt": {
+						type: "file",
+						content: "B",
+						complete: true,
+					},
+				},
+			};
+
+			const { openFile } = useSourceFiles(core);
+
+			openFile(["a.txt"]);
+			expect(requestSourceFileLoading).toHaveBeenNthCalledWith(1, [
+				"a.txt",
+			]);
+
+			openFile(["b.txt"]);
+			expect(requestSourceFileLoading).toHaveBeenCalledOnce();
+		});
+
+		it("should refresh the draft when file is loaded", async () => {
+			const { core, sourceFiles } = buildMockCore();
+
+			vi.spyOn(core, "requestSourceFileLoading").mockImplementation(
+				async () => {},
+			);
+
+			sourceFiles.value = {
+				type: "directory",
+				children: {
+					"a.txt": {
+						type: "file",
+						content: "before",
+						complete: false,
+					},
+				},
+			};
+
+			const { openFile, code } = useSourceFiles(core);
+
+			openFile(["a.txt"]);
+
+			sourceFiles.value = {
+				type: "directory",
+				children: {
+					"a.txt": {
+						type: "file",
+						content: "after",
+						complete: true,
+					},
+				},
+			};
+			await flushPromises();
+
+			expect(code.value).toBe("after");
+		});
+	});
+});

--- a/src/ui/src/core/useSourceFiles.spec.ts
+++ b/src/ui/src/core/useSourceFiles.spec.ts
@@ -101,6 +101,62 @@ describe(useSourceFiles.name, () => {
 		expect(sourceFileDraft.value).toStrictEqual(sourceFiles.value);
 	});
 
+	it("should remove a folder to the draft", async () => {
+		const { core, sourceFiles } = buildMockCore();
+		sourceFiles.value = {
+			type: "directory",
+			children: {
+				a: {
+					type: "directory",
+					children: {
+						b: { type: "directory", children: {} },
+						"c.txt": { type: "file", content: "" },
+					},
+				},
+			},
+		};
+
+		const { sourceFileDraft } = useSourceFiles(core);
+		expect(sourceFileDraft.value).toStrictEqual(sourceFiles.value);
+
+		sourceFiles.value = {
+			type: "directory",
+			children: {
+				a: {
+					type: "directory",
+					children: {
+						"c.txt": { type: "file", content: "" },
+					},
+				},
+			},
+		};
+		await flushPromises();
+		expect(sourceFileDraft.value).toStrictEqual(sourceFiles.value);
+	});
+
+	it("should remove a root folder to the draft", async () => {
+		const { core, sourceFiles } = buildMockCore();
+		sourceFiles.value = {
+			type: "directory",
+			children: {
+				a: {
+					type: "directory",
+					children: {
+						b: { type: "directory", children: {} },
+						"c.txt": { type: "file", content: "" },
+					},
+				},
+			},
+		};
+
+		const { sourceFileDraft } = useSourceFiles(core);
+		expect(sourceFileDraft.value).toStrictEqual(sourceFiles.value);
+
+		sourceFiles.value = { type: "directory", children: {} };
+		await flushPromises();
+		expect(sourceFileDraft.value).toStrictEqual(sourceFiles.value);
+	});
+
 	describe("lazy loading", () => {
 		it("should request fetchig whole file on opening", () => {
 			const { core, sourceFiles } = buildMockCore();

--- a/src/ui/src/core/useSourceFiles.ts
+++ b/src/ui/src/core/useSourceFiles.ts
@@ -4,7 +4,9 @@ import {
 	createFileToSourceFiles,
 	deleteFileToSourceFiles,
 	findSourceFileFromPath,
+	getSourceFilesPathsToEdges,
 	getSourceFilesPathsToFiles,
+	getSourceFilesPathsToNodes,
 	isSourceFilesFile,
 } from "./sourceFiles";
 
@@ -49,7 +51,7 @@ export function useSourceFiles(wf: Core) {
 		}
 
 		// handle deleted nodes
-		for (const path of getSourceFilesPathsToFiles(previousSourceFiles)) {
+		for (const path of getSourceFilesPathsToNodes(tree)) {
 			if (
 				findSourceFileFromPath(path, currentSourceFiles) === undefined
 			) {

--- a/src/ui/src/core/useSourceFiles.ts
+++ b/src/ui/src/core/useSourceFiles.ts
@@ -1,0 +1,185 @@
+import { Core, SourceFiles } from "@/writerTypes";
+import { computed, ref, shallowRef, toRaw, watch } from "vue";
+import {
+	createFileToSourceFiles,
+	deleteFileToSourceFiles,
+	findSourceFileFromPath,
+	getSourceFilesPathsToFiles,
+	isSourceFilesFile,
+} from "./sourceFiles";
+
+export function useSourceFiles(wf: Core) {
+	const sourceFileDraft = ref<SourceFiles>(
+		structuredClone(toRaw(wf.sourceFiles.value)),
+	);
+
+	// synchronize `sourceFiles` & `sourceFileDraft`
+	watch(wf.sourceFiles, (currentSourceFiles, previousSourceFiles) => {
+		let wasUpdated = false;
+		let tree = structuredClone(toRaw(sourceFileDraft.value));
+
+		for (const path of getSourceFilesPathsToFiles(currentSourceFiles)) {
+			const prev = findSourceFileFromPath(path, previousSourceFiles);
+
+			const cur = findSourceFileFromPath(path, currentSourceFiles);
+			if (!isSourceFilesFile(cur)) continue;
+
+			if (prev === undefined) {
+				// a file was added, we duplicate it to the draft
+				tree = createFileToSourceFiles(
+					path,
+					tree,
+					structuredClone(toRaw(cur)),
+				);
+				wasUpdated = true;
+				continue;
+			}
+
+			if (!isSourceFilesFile(prev)) continue;
+			const wasLoaded = !prev.complete && cur.complete;
+			if (!wasLoaded) continue;
+
+			//  change because an element is loaded, we update the draft
+			const draft = findSourceFileFromPath(path, tree);
+			if (!isSourceFilesFile(draft)) continue;
+
+			wasUpdated = true;
+			draft.complete = true;
+			draft.content = cur.content;
+		}
+
+		// handle deleted nodes
+		for (const path of getSourceFilesPathsToFiles(previousSourceFiles)) {
+			if (
+				findSourceFileFromPath(path, currentSourceFiles) === undefined
+			) {
+				tree = deleteFileToSourceFiles(path, tree);
+				wasUpdated = true;
+			}
+		}
+
+		if (wasUpdated) sourceFileDraft.value = tree;
+	});
+
+	const filepathOpen = shallowRef<string[] | undefined>();
+
+	const sourceFilesDraftPaths = computed(() =>
+		Array.from(getSourceFilesPathsToFiles(sourceFileDraft.value)),
+	);
+
+	const pathsUnsaved = computed(() => {
+		return sourceFilesDraftPaths.value.filter((path) => {
+			const draft = findSourceFileFromPath(path, sourceFileDraft.value);
+			if (!isSourceFilesFile(draft)) return true;
+
+			const file = findSourceFileFromPath(path, wf.sourceFiles.value);
+			if (!isSourceFilesFile(file)) return true;
+
+			if (!draft.complete || !file.complete) return false;
+
+			return draft.content !== file.content;
+		});
+	});
+
+	const fileOpen = computed(() => {
+		if (filepathOpen.value === undefined) return undefined;
+		return findSourceFileFromPath(
+			filepathOpen.value,
+			sourceFileDraft.value,
+		);
+	});
+
+	const code = computed({
+		get() {
+			return isSourceFilesFile(fileOpen.value)
+				? fileOpen.value.content
+				: "";
+		},
+		set(newCode: string) {
+			if (filepathOpen.value === undefined) return;
+			const node = findSourceFileFromPath(
+				filepathOpen.value,
+				sourceFileDraft.value,
+			);
+			if (!isSourceFilesFile(node)) return;
+			node.content = newCode;
+		},
+	});
+
+	function getNewFilename(i = 1): string {
+		const filename = `new-file-${i}.txt`;
+
+		return findSourceFileFromPath([filename], sourceFileDraft.value)
+			? getNewFilename(i + 1)
+			: filename;
+	}
+
+	async function openNewFile() {
+		const newFile = getNewFilename();
+
+		sourceFileDraft.value = createFileToSourceFiles(
+			[newFile],
+			toRaw(sourceFileDraft.value),
+		);
+
+		openFile([newFile]);
+
+		await wf.sendCreateSourceFileRequest([newFile]);
+	}
+
+	const openedFileExtension = computed(() => {
+		if (!filepathOpen.value?.length) return "";
+		const filename = filepathOpen.value.at(-1);
+		return filename.split(".").at(-1);
+	});
+
+	const openedFileLanguage = computed(() => {
+		switch (openedFileExtension.value) {
+			case "py":
+				return "python";
+			case "md":
+			case "markdown":
+				return "markdown";
+			default:
+				return openedFileExtension.value;
+		}
+	});
+
+	function openFile(path: string[]) {
+		filepathOpen.value = path;
+
+		if (isSourceFilesFile(fileOpen.value) && !fileOpen.value.complete) {
+			wf.requestSourceFileLoading(path);
+		}
+	}
+
+	async function save(newPath?: string[]) {
+		if (!filepathOpen.value) return;
+
+		await wf.sendCodeSaveRequest(code.value, filepathOpen.value);
+
+		if (newPath) {
+			const oldPath = [...toRaw(filepathOpen.value)];
+			filepathOpen.value = undefined;
+			try {
+				await wf.sendRenameSourceFileRequest(oldPath, newPath);
+			} catch (e) {
+				filepathOpen.value = oldPath;
+				throw e;
+			}
+			openFile(newPath);
+		}
+	}
+
+	return {
+		code,
+		sourceFileDraft,
+		filepathOpen,
+		pathsUnsaved,
+		openedFileLanguage,
+		save,
+		openFile,
+		openNewFile,
+		getNewFilename,
+	};
+}

--- a/src/ui/src/tests/mocks.ts
+++ b/src/ui/src/tests/mocks.ts
@@ -1,7 +1,7 @@
 import { generateCore } from "@/core";
 import injectionKeys from "@/injectionKeys";
 import { flattenInstancePath } from "@/renderer/instancePath";
-import type { Component, InstancePath } from "@/writerTypes";
+import type { Component, InstancePath, SourceFiles } from "@/writerTypes";
 import { ref } from "vue";
 
 export const mockComponentId = "component-id-test";
@@ -27,10 +27,13 @@ export function buildMockComponent(component: Partial<Component>) {
 export function buildMockCore() {
 	const core = generateCore();
 	const userState = ref({});
+	const sourceFiles = ref<SourceFiles>({ type: "directory", children: {} });
 
-	core.userState = ref(userState);
+	core.userState = userState;
+	// @ts-expect-error overide the default value
+	core.sourceFiles = sourceFiles;
 
-	return { core, userState };
+	return { core, userState, sourceFiles };
 }
 
 export const mockProvides: Record<symbol, unknown> = {

--- a/src/ui/src/wds/WdsButton.vue
+++ b/src/ui/src/wds/WdsButton.vue
@@ -68,6 +68,7 @@ const className = computed(() => [
 .WdsButton--primary:disabled {
 	border-color: var(--wdsColorBlue6);
 	background-color: var(--wdsColorBlue6);
+	opacity: 40%;
 }
 
 /* VARIANTS -- secondary */

--- a/src/ui/src/wds/WdsStateDot.vue
+++ b/src/ui/src/wds/WdsStateDot.vue
@@ -1,0 +1,62 @@
+<script lang="ts">
+export type WdsStateDotState = "error" | "deployed" | "newDraft" | "draft";
+</script>
+
+<script setup lang="ts">
+import { PropType } from "vue";
+
+defineProps({
+	state: { type: String as PropType<WdsStateDotState>, required: true },
+});
+</script>
+
+<template>
+	<div class="WdsStateDotState" :class="`WdsStateDotState--${state}`"></div>
+</template>
+
+<style scoped>
+.WdsStateDotState {
+	height: 16px;
+	width: 16px;
+	border-radius: 50%;
+}
+.WdsStateDotState::after {
+	content: "";
+	display: block;
+	height: 8px;
+	width: 8px;
+	border-radius: 50%;
+	position: relative;
+	top: 4px;
+	left: 4px;
+}
+
+/* error */
+.WdsStateDotState--error {
+	background-color: var(--wdsColorOrange2);
+}
+.WdsStateDotState--error::after {
+	background-color: var(--wdsColorOrange5);
+}
+/* deployed */
+.WdsStateDotState--deployed {
+	background-color: var(--wdsColorGreen3);
+}
+.WdsStateDotState--deployed::after {
+	background-color: var(--wdsColorGreen5);
+}
+/* newDraft */
+.WdsStateDotState--newDraft {
+	background-color: var(--wdsColorBlue2);
+}
+.WdsStateDotState--newDraft::after {
+	background-color: var(--wdsColorBlue4);
+}
+/* draft */
+.WdsStateDotState--draft {
+	background-color: var(--wdsColorGray3);
+}
+.WdsStateDotState--draft::after {
+	background-color: var(--wdsColorWhite);
+}
+</style>

--- a/src/ui/src/wds/WdsTextInput.vue
+++ b/src/ui/src/wds/WdsTextInput.vue
@@ -1,10 +1,11 @@
 <template>
 	<div
 		v-if="leftIcon"
-		v-bind="$attrs"
 		class="WdsTextInput WdsTextInput--leftIcon colorTransformer"
+		:class="{ 'WdsTextInput--ghost': variant === 'ghost' }"
+		v-bind="$attrs"
 		:aria-invalid="invalid"
-		@click="input.focus()"
+		@click="focus"
 	>
 		<i class="material-symbols-outlined">{{ leftIcon }}</i>
 		<input ref="input" v-model="model" v-bind="$attrs" />
@@ -16,11 +17,12 @@
 		v-model="model"
 		:aria-invalid="invalid"
 		class="WdsTextInput colorTransformer"
+		:class="{ 'WdsTextInput--ghost': variant === 'ghost' }"
 	/>
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { PropType, ref } from "vue";
 
 const model = defineModel({ type: String });
 
@@ -30,6 +32,7 @@ defineOptions({ inheritAttrs: false });
 defineProps({
 	leftIcon: { type: String, required: false, default: undefined },
 	invalid: { type: Boolean, required: false },
+	variant: { type: String as PropType<"ghost">, default: undefined },
 });
 
 defineExpose({
@@ -80,6 +83,19 @@ function focus() {
 .WdsTextInput--leftIcon:focus-within {
 	border: 1px solid var(--softenedAccentColor);
 	box-shadow: 0px 0px 0px 3px rgba(81, 31, 255, 0.05);
+}
+
+.WdsTextInput--ghost {
+	border-color: transparent;
+}
+.WdsTextInput--ghost:hover {
+	background-color: var(--wdsColorGray1);
+}
+.WdsTextInput--ghost:focus,
+.WdsTextInput--ghost:focus-within {
+	background-color: var(--wdsColorGray1);
+	border-color: transparent;
+	box-shadow: unset;
 }
 
 .WdsTextInput--leftIcon {

--- a/src/ui/src/wds/WdsTextInput.vue
+++ b/src/ui/src/wds/WdsTextInput.vue
@@ -113,6 +113,7 @@ function focus() {
 	font-size: 14px;
 	border: none;
 	background: transparent;
+	width: 100%;
 }
 .WdsTextInput--leftIcon input:focus {
 	border: none;

--- a/src/ui/src/wds/WdsToast.vue
+++ b/src/ui/src/wds/WdsToast.vue
@@ -1,0 +1,97 @@
+<template>
+	<div class="WdsToast" :class="`WdsToast--${type}`">
+		<div class="WdsToast__icon">
+			<span class="material-symbols-outlined">{{ icon }}</span>
+		</div>
+		<p>{{ message }}</p>
+		<WdsButton
+			v-if="closable"
+			class="WdsToast__close"
+			variant="neutral"
+			size="smallIcon"
+			@click="$emit('close')"
+		>
+			<span class="material-symbols-outlined">close</span>
+		</WdsButton>
+	</div>
+</template>
+
+<script lang="ts">
+export type WdsToastData = {
+	type: "error" | "success" | "info";
+	message: string;
+	closable: boolean;
+};
+</script>
+
+<script setup lang="ts">
+import { computed, PropType } from "vue";
+import WdsButton from "./WdsButton.vue";
+
+const props = defineProps({
+	type: { type: String as PropType<WdsToastData["type"]>, required: true },
+	message: { type: String, required: true },
+	closable: { type: Boolean },
+});
+
+defineEmits({
+	close: () => true,
+});
+
+const icon = computed(() => {
+	switch (props.type) {
+		case "info":
+			return "info";
+		case "success":
+			return "check";
+		case "error":
+			return "close";
+		default:
+			return "question_mark";
+	}
+});
+</script>
+
+<style scoped>
+.WdsToast {
+	height: 48px;
+	padding: 10px 12px;
+
+	display: flex;
+	align-items: center;
+	gap: 12px;
+
+	background-color: var(--wdsColorBlack);
+	color: var(--wdsColorWhite);
+	border-radius: 4px;
+	box-shadow: var(--wdsShadowMenu);
+}
+
+.WdsToast__icon {
+	height: 18px;
+	width: 18px;
+	border-radius: 50%;
+	color: var(--wdsColorBlack);
+
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	background-color: var(--wdsColorGreen3);
+}
+
+.WdsToast--success .WdsToast__icon {
+	background-color: var(--wdsColorGreen3);
+}
+.WdsToast--error .WdsToast__icon {
+	background-color: var(--wdsColorOrange5);
+}
+.WdsToast--info .WdsToast__icon {
+	background-color: var(--wdsColorBlue2);
+}
+
+.WdsToast__close:hover,
+.WdsToast__close:focus {
+	color: var(--wdsColorBlack);
+}
+</style>

--- a/src/ui/src/writerTypes.ts
+++ b/src/ui/src/writerTypes.ts
@@ -164,3 +164,27 @@ export type AbstractTemplate = {
 };
 
 export type TemplateMap = Record<string, VueComponent>;
+
+export type SourceFilesFile = {
+	type: "file";
+	complete?: boolean;
+	content: string;
+};
+
+export type SourceFilesDirectory = {
+	type: "directory";
+	children: Record<string, SourceFiles>;
+};
+
+/**
+ * Represent a file tree as an object with:
+ *
+ * - the key representing the filename
+ * - the content as a string for a readable text file, or as a recursive `SourceFiles` if it's a directory
+ *
+ * @example
+ * ```json
+ * { "type": "directory", "children": { "main.py": { "type": "file", "content": "print('hello')", "complete": true } } }
+ * ```
+ */
+export type SourceFiles = SourceFilesDirectory | SourceFilesFile;

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -7,6 +7,7 @@ import multiprocessing
 import multiprocessing.connection
 import multiprocessing.synchronize
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -749,7 +750,8 @@ class AppRunner:
         to_path_abs = os.path.join(self.app_path, to_path)
         self._check_file_in_app_path(to_path_abs)
 
-        os.renames(from_path_abs, to_path_abs)
+        os.makedirs(os.path.dirname(to_path_abs), exist_ok=True)
+        os.rename(from_path_abs, to_path_abs)
 
         self.source_files = wf_project.build_source_files(self.app_path)
 
@@ -760,7 +762,10 @@ class AppRunner:
         path = os.path.join(self.app_path, file)
         self._check_file_in_app_path(path)
 
-        os.remove(path)
+        if os.path.isfile(path):
+            os.remove(path)
+        else:
+            shutil.rmtree(path)
 
         self.source_files = wf_project.build_source_files(self.app_path)
 

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -8,6 +8,7 @@ import multiprocessing.connection
 import multiprocessing.synchronize
 import os
 import signal
+import subprocess
 import sys
 import threading
 from types import ModuleType
@@ -43,6 +44,7 @@ from writer.ss_types import (
     InitSessionRequestPayload,
     InitSessionResponsePayload,
     ServeMode,
+    SourceFilesDirectory,
     StateContentRequest,
     StateContentResponsePayload,
     StateEnquiryRequest,
@@ -501,9 +503,9 @@ class FileEventHandler(watchdog.events.PatternMatchingEventHandler):
     Watches for changes in files and triggers code reloads.
     """
 
-    def __init__(self, update_callback: Callable):
+    def __init__(self, update_callback: Callable, patterns: List[str]):
         self.update_callback = update_callback
-        super().__init__(patterns=["*.py"], ignore_patterns=[
+        super().__init__(patterns=patterns, ignore_patterns=[
             ".*"], ignore_directories=False, case_sensitive=False)
 
     def on_any_event(self, event) -> None:
@@ -605,6 +607,7 @@ class AppRunner:
         self.client_conn: Optional[multiprocessing.connection.Connection] = None
         self.app_process: Optional[AppProcess] = None
         self.run_code: Optional[str] = None
+        self.source_files: SourceFilesDirectory = {"children": {}, "type": "directory"}
         self.bmc_components: Optional[Dict] = None
         self.is_app_process_server_ready = multiprocessing.Event()
         self.is_app_process_server_failed = multiprocessing.Event()
@@ -644,14 +647,37 @@ class AppRunner:
 
     def _start_fs_observer(self):
         self.observer = PollingObserver(AppRunner.UPDATE_CHECK_INTERVAL_SECONDS)
-        self.observer.schedule(FileEventHandler(self.reload_code_from_saved), path=self.app_path, recursive=True)
+        self.observer.schedule(FileEventHandler(self.reload_code_from_saved, patterns=["*.py"]), path=self.app_path, recursive=True)
+        self.observer.schedule(FileEventHandler(self._install_requirements, patterns=["requirements.txt"]), path=self.app_path)
         self.observer.start()
 
     def _start_wf_project_process_write_files(self):
         wf_project.start_process_write_files_async(self.wf_project_context, AppRunner.WF_PROJECT_SAVE_INTERVAL)
 
+    def _install_requirements(self) -> None:
+        logger = logging.getLogger('writer')
+        logger.debug("\nDetected changes in requirements.txt. Installing dependencies...")
+        try:
+            # Run pip install command
+            subprocess.run(
+                ["pip", "install", "-r", "requirements.txt"], 
+                check=True,
+                capture_output=True,
+                text=True,
+                # stdout=subprocess.DEVNULL,  # Suppress pip output
+                cwd=self.app_path,
+            )
+            logger.debug("Dependencies installed successfully, restart server!\n")
+            self.reload_code_from_saved()
+        except subprocess.CalledProcessError as e:
+            logger.warning(f"Error installing dependencies: {e.stderr}")
+            # TODO(WF-170): find a way to dispatch log
+        except Exception as e:
+            logger.warning(f"Unexpected error: {e}")
+
     def load(self) -> None:
-        self.run_code = self._load_persisted_script()
+        self.run_code = self.load_persisted_script("main.py")
+        self.source_files = wf_project.build_source_files(self.app_path)
         self.bmc_components = self._load_persisted_components()
 
         if self.mode == "edit":
@@ -701,17 +727,64 @@ class AppRunner:
 
         return response
 
-    def _load_persisted_script(self) -> str:
+
+    def create_persisted_script(self, file = "main.py"):
+        path = os.path.join(self.app_path, file)
+        self._check_file_in_app_path(path)
+
+        with open(path, "x", encoding='utf-8') as f:
+            f.write('')
+
+        self.source_files = wf_project.build_source_files(self.app_path)
+
+    def rename_persisted_script(self, from_path: str, to_path: str):
+        if from_path == 'main.py':
+            raise PermissionError("cannot rename main script")
+        if to_path == 'main.py':
+            raise PermissionError("cannot overwrite main script")
+
+        from_path_abs = os.path.join(self.app_path, from_path)
+        self._check_file_in_app_path(from_path_abs)
+
+        to_path_abs = os.path.join(self.app_path, to_path)
+        self._check_file_in_app_path(to_path_abs)
+
+        os.renames(from_path_abs, to_path_abs)
+
+        self.source_files = wf_project.build_source_files(self.app_path)
+
+    def delete_persisted_script(self, file: str):
+        if file == 'main.py':
+            raise PermissionError("cannot delete main script")
+
+        path = os.path.join(self.app_path, file)
+        self._check_file_in_app_path(path)
+
+        os.remove(path)
+
+        self.source_files = wf_project.build_source_files(self.app_path)
+
+    def load_persisted_script(self, file = "main.py") -> str:
+        path = os.path.join(self.app_path, file)
+        self._check_file_in_app_path(path)
+
         logger = logging.getLogger('writer')
         try:
             contents = None
-            with open(os.path.join(self.app_path, "main.py"), "r", encoding='utf-8') as f:
+            with open(path, "r", encoding='utf-8') as f:
                 contents = f.read()
             return contents
-        except FileNotFoundError:
-            logger.error(
-                "Couldn't find main.py in the path provided: %s.", self.app_path)
-            sys.exit(1)
+        except FileNotFoundError as error:
+            logger.error("Couldn't find %s in the path provided: %s.", file, self.app_path)
+            if file == "main.py":
+                sys.exit(1)
+            else:
+                raise error
+
+    def _check_file_in_app_path(self, path):
+        if not os.path.abspath(path).startswith(os.path.abspath((self.app_path))):
+            raise PermissionError(f"{path} is outside of application ({self.app_path})")
+
 
     def _load_persisted_components(self) -> Dict[str, ComponentDefinition]:
         logger = logging.getLogger('writer')
@@ -783,12 +856,20 @@ class AppRunner:
             type="stateContent"
         ))
 
-    def save_code(self, session_id: str, code: str) -> None:
+    def save_code(self, session_id: str, code: str, path: List[str] = ['main.py']) -> None:
         if self.mode != "edit":
             raise PermissionError("Cannot save code in non-edit mode.")
 
-        with open(os.path.join(self.app_path, "main.py"), "w") as f:
+        filepath = os.path.join(self.app_path, *path)
+
+        # ensure we don't load a file outside of the application (like `../../../etc/passwd`)
+        if not os.path.abspath(filepath).startswith(self.app_path):
+            raise FileNotFoundError(f"{filepath} is outside of application ({self.app_path})")
+
+        with open(filepath, "w") as f:
             f.write(code)
+
+        self.source_files = wf_project.build_source_files(self.app_path)
 
     def _clean_process(self) -> None:
         # Terminate the AppProcess server by sending an empty message
@@ -861,7 +942,7 @@ class AppRunner:
     def reload_code_from_saved(self) -> None:
         if not self.is_app_process_server_ready.is_set():
             return
-        self.update_code(None, self._load_persisted_script())
+        self.update_code(None, self.load_persisted_script())
 
     def update_code(self, session_id: Optional[str], run_code: str) -> None:
 
@@ -876,6 +957,7 @@ class AppRunner:
         if not self.is_app_process_server_ready.is_set():
             return
         self.run_code = run_code
+        self.source_files = wf_project.build_source_files(self.app_path)
         self._clean_process()
         self._start_app_process()
         self.is_app_process_server_ready.wait()

--- a/src/writer/ss_types.py
+++ b/src/writer/ss_types.py
@@ -33,6 +33,19 @@ class AbstractTemplate(BaseModel):
     baseType: str
     writer: Dict
 
+
+class SourceFilesFile(TypedDict):
+    type: Literal["file"]
+    complete: Optional[bool]
+    content: str
+
+
+class SourceFilesDirectory(TypedDict):
+    type: Literal["directory"]
+    children: Dict[str, 'SourceFiles']
+
+SourceFiles = Union[SourceFilesFile, SourceFilesDirectory]
+
 # Web server models
 
 
@@ -59,6 +72,7 @@ class InitResponseBodyRun(InitResponseBody):
 class InitResponseBodyEdit(InitResponseBody):
     mode: Literal["edit"]
     runCode: Optional[str] = None
+    sourceFiles: SourceFilesDirectory = {"type": "directory", "children": {}}
 
 
 class WriterWebsocketIncoming(BaseModel):
@@ -231,3 +245,4 @@ class WorkflowExecutionLog(BaseModel):
 
 class WriterConfigurationError(ValueError):
     pass
+

--- a/src/writer/wf_project.py
+++ b/src/writer/wf_project.py
@@ -340,10 +340,12 @@ def build_source_files(app_path: str) -> SourceFilesDirectory:
         with open(path, "r", encoding='utf-8') as f:
             return f.read()
 
-    # we can't use `glob`'s `include_hidden` options since it's only available on Python 3.11+
     files = []
-    for pattern in ['**/*', '**/.*', '.**/*', '.**/.*']:
-        files += glob.glob(os.path.join(app_path, pattern), recursive=True)
+    for root, dirs, filenames in os.walk(app_path):
+        # ignore specific folders
+        dirs[:] = [d for d in dirs if d not in {'.venv', 'venv', '__pycache__', '.wf'}]
+        for filename in filenames:
+            files.append(os.path.realpath(os.path.join(root, filename)))
 
     file_tree: SourceFilesDirectory = {
         "type": "directory",

--- a/tests/e2e/tests/stateAutocompletion.spec.ts
+++ b/tests/e2e/tests/stateAutocompletion.spec.ts
@@ -137,8 +137,8 @@ test.describe("state autocompletion", () => {
 	}
 
 	testFieldType("BuilderFieldsColor", "primaryTextColor", 'div.CoreText.component');
-	testFieldType("BuilderFieldsShadow", "buttonShadow", '.BuilderSidebarComponentTreeBranch [data-automation-key="root"]');
-	testFieldType("BuilderFieldsAlign", "contentHAlign", '.BuilderSidebarComponentTreeBranch [data-automation-key="root"]');
-	testFieldType("BuilderFieldsPadding", "contentPadding", '.BuilderSidebarComponentTreeBranch [data-automation-key="root"]');
-	testFieldType("BuilderFieldsWidth", "contentWidth", '.BuilderSidebarComponentTreeBranch [data-automation-key="root"]');
+	testFieldType("BuilderFieldsShadow", "buttonShadow", '.BuilderSidebarComponentTree [data-automation-key="root"]');
+	testFieldType("BuilderFieldsAlign", "contentHAlign", '.BuilderSidebarComponentTree [data-automation-key="root"]');
+	testFieldType("BuilderFieldsPadding", "contentPadding", '.BuilderSidebarComponentTree [data-automation-key="root"]');
+	testFieldType("BuilderFieldsWidth", "contentWidth", '.BuilderSidebarComponentTree [data-automation-key="root"]');
 });


### PR DESCRIPTION
Implement the feature to allow the user to create, update and delete any source file of the application.

The logic flow is:

1. Python backend returns the `sourceFiles` in the Init request. It's an object representing the tree structure like
    ```json
    {"type": "directory", "children": {"README.md": {"type": "file", "content": "This app w", "complete": false}}}
    ```
3. the frontend stores this and creates a  copy of this as `sourceFilesDraft`
4. different action in the editor will trigger new sockets events I implemented: `createSourceFile`, `deleteSourceFile` or `renameSourceFile`

The main challenge was the synchronization between `sourceFiles` and `sourceFilesDraft`. This main logic stands in the composable `useSourceFilesDraft`.

## Quick demo

https://github.com/user-attachments/assets/be75f433-5101-4895-a5a6-c51029cafab1



