### PR TITLE
fix: update playwright to support ubuntu 24.04 agent for e2e test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5185,18 +5185,19 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.42.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
-			"integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+			"integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.42.1"
+				"playwright": "1.49.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@radix-ui/react-compose-refs": {
@@ -19071,33 +19072,35 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.42.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-			"integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+			"integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.42.1"
+				"playwright-core": "1.49.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			},
 			"optionalDependencies": {
 				"fsevents": "2.3.2"
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.42.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-			"integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+			"integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
 		},
 		"node_modules/playwright/node_modules/fsevents": {
@@ -19106,6 +19109,7 @@
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -24233,7 +24237,7 @@
 				"writer-ui": "*"
 			},
 			"devDependencies": {
-				"@playwright/test": "1.42.1",
+				"@playwright/test": "^1.49.1",
 				"nodemon": "3.1.0"
 			}
 		}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -15,12 +15,12 @@
     "e2e:grep": "playwright test --project=chromium --grep "
   },
   "dependencies": {
-    "writer-ui": "*",
     "express": "4.19.2",
-    "http-proxy": "1.18.1"
+    "http-proxy": "1.18.1",
+    "writer-ui": "*"
   },
   "devDependencies": {
-    "@playwright/test": "1.42.1",
+    "@playwright/test": "^1.49.1",
     "nodemon": "3.1.0"
   }
 }


### PR DESCRIPTION
CI pipeline is broken due to update of ubuntu 24.04.

According to the [Ubuntu 24.04 release notes](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890) in the section [Year 2038 support for the armhf architecture](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890#year-2038-support-for-the-armhf-architecture-5)

> More than a thousand packages have been updated to handle time using a 64-bit value rather than a 32-bit one, making it possible to handle times up to 292 billion years in the future.

* update playwright to support ubuntu 24.04