### PR TITLE
fix(writer): bump default model for workflow completion block - WF-175

### DIFF
--- a/src/writer/blocks/writercompletion.py
+++ b/src/writer/blocks/writercompletion.py
@@ -2,7 +2,7 @@ from writer.abstract import register_abstract_template
 from writer.blocks.base_block import WorkflowBlock
 from writer.ss_types import AbstractTemplate
 
-DEFAULT_MODEL = "palmyra-x-003-instruct"
+DEFAULT_MODEL = "palmyra-x-004"
 
 class WriterCompletion(WorkflowBlock):
 


### PR DESCRIPTION
Make it consistent with `WriterInitChat`

https://github.com/writer/writer-framework/blob/7de351f298d78ec90a6657c214924f621cd4388b/src/writer/blocks/writerinitchat.py#L5