### PR TITLE
 feat: setup knwoledge graph selector - WF-138 

### DIFF
--- a/src/ui/src/builder/BuilderGraphSelect.spec.ts
+++ b/src/ui/src/builder/BuilderGraphSelect.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import BuilderGraphSelect from "./BuilderGraphSelect.vue";
+import { flushPromises, shallowMount } from "@vue/test-utils";
+import { buildMockCore } from "@/tests/mocks";
+import injectionKeys from "@/injectionKeys";
+import BuilderSelect from "./BuilderSelect.vue";
+import WdsTextInput from "@/wds/WdsTextInput.vue";
+
+describe("BuilderGraphSelect", () => {
+	const graphs = [
+		{ id: "1", name: "one" },
+		{ id: "2", name: "two" },
+	];
+	let core: ReturnType<typeof buildMockCore>["core"];
+
+	beforeEach(() => {
+		core = buildMockCore().core;
+	});
+
+	it("should fetch and display graphs", async () => {
+		const sendListResourcesRequest = vi
+			.spyOn(core, "sendListResourcesRequest")
+			.mockResolvedValue(graphs);
+
+		const wrapper = shallowMount(BuilderGraphSelect, {
+			props: { modelValue: "1" },
+			global: {
+				stubs: {
+					BuilderSelect: true,
+				},
+				provide: {
+					[injectionKeys.core as symbol]: core,
+				},
+			},
+		});
+		await flushPromises();
+		expect(sendListResourcesRequest).toHaveBeenCalledOnce();
+		expect(wrapper.findComponent(BuilderSelect).exists()).toBe(true);
+	});
+
+	it("should fallback to input", async () => {
+		const sendListResourcesRequest = vi
+			.spyOn(core, "sendListResourcesRequest")
+			.mockRejectedValue(new Error());
+
+		const wrapper = shallowMount(BuilderGraphSelect, {
+			props: { modelValue: "1" },
+			global: {
+				stubs: {
+					BuilderSelect: true,
+				},
+				provide: {
+					[injectionKeys.core as symbol]: core,
+				},
+			},
+		});
+		await flushPromises();
+		expect(sendListResourcesRequest).toHaveBeenCalledOnce();
+		expect(wrapper.findComponent(BuilderSelect).exists()).toBe(false);
+		expect(wrapper.findComponent(WdsTextInput).exists()).toBe(true);
+	});
+});

--- a/src/ui/src/builder/BuilderGraphSelect.vue
+++ b/src/ui/src/builder/BuilderGraphSelect.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import injectionKeys from "@/injectionKeys";
+import {
+	computed,
+	defineAsyncComponent,
+	inject,
+	onMounted,
+	PropType,
+} from "vue";
+import { useListResources } from "@/composables/useListResources";
+import type { Option } from "./BuilderSelect.vue";
+import BuilderAsyncLoader from "./BuilderAsyncLoader.vue";
+import type { WriterGraph } from "@/writerTypes";
+import WdsTextInput from "@/wds/WdsTextInput.vue";
+import LoadingSymbol from "@/renderer/LoadingSymbol.vue";
+
+const BuilderSelect = defineAsyncComponent({
+	loader: () => import("./BuilderSelect.vue"),
+	loadingComponent: BuilderAsyncLoader,
+});
+
+const wf = inject(injectionKeys.core);
+
+defineProps({
+	enableMultiSelection: { type: Boolean, required: false },
+});
+
+const currentValue = defineModel({
+	type: [String, Array] as PropType<string | string[]>,
+	required: true,
+});
+
+const {
+	load: loadGraphs,
+	data: graphs,
+	isLoading,
+} = useListResources<WriterGraph>(wf, "graphs");
+
+onMounted(loadGraphs);
+
+const options = computed(() =>
+	graphs.value
+		.map<Option>((graph) => ({
+			label: graph.name,
+			detail: graph.description,
+			value: graph.id,
+		}))
+		.sort((a, b) => a.label.localeCompare(b.label)),
+);
+
+const currentValueStr = computed<string>({
+	get() {
+		if (currentValue.value === undefined) return "";
+
+		return typeof currentValue.value === "string"
+			? currentValue.value
+			: currentValue.value.join(",");
+	},
+	set(value: string) {
+		currentValue.value = value.split(",");
+	},
+});
+</script>
+
+<template>
+	<div class="BuilderGraphSelect--text">
+		<BuilderSelect
+			v-if="graphs.length > 0"
+			v-model="currentValue"
+			:options="options"
+			hide-icons
+			enable-search
+			:enable-multi-selection="enableMultiSelection"
+		/>
+		<WdsTextInput v-else v-model="currentValueStr" />
+		<LoadingSymbol v-if="isLoading" />
+	</div>
+</template>
+
+<style scoped>
+.BuilderGraphSelect--text {
+	width: 100%;
+	display: flex;
+	gap: 12px;
+	align-items: center;
+}
+</style>

--- a/src/ui/src/builder/BuilderGraphSelect.vue
+++ b/src/ui/src/builder/BuilderGraphSelect.vue
@@ -12,7 +12,6 @@ import type { Option } from "./BuilderSelect.vue";
 import BuilderAsyncLoader from "./BuilderAsyncLoader.vue";
 import type { WriterGraph } from "@/writerTypes";
 import WdsTextInput from "@/wds/WdsTextInput.vue";
-import LoadingSymbol from "@/renderer/LoadingSymbol.vue";
 
 const BuilderSelect = defineAsyncComponent({
 	loader: () => import("./BuilderSelect.vue"),
@@ -65,15 +64,15 @@ const currentValueStr = computed<string>({
 <template>
 	<div class="BuilderGraphSelect--text">
 		<BuilderSelect
-			v-if="graphs.length > 0"
+			v-if="graphs.length > 0 || isLoading"
 			v-model="currentValue"
 			:options="options"
 			hide-icons
 			enable-search
+			:loading="isLoading"
 			:enable-multi-selection="enableMultiSelection"
 		/>
 		<WdsTextInput v-else v-model="currentValueStr" />
-		<LoadingSymbol v-if="isLoading" />
 	</div>
 </template>
 

--- a/src/ui/src/builder/BuilderSelect.spec.ts
+++ b/src/ui/src/builder/BuilderSelect.spec.ts
@@ -1,0 +1,54 @@
+import { flushPromises, mount, shallowMount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import BuilderSelect from "./BuilderSelect.vue";
+import { Option } from "./BuilderSelect.vue";
+import WdsDropdownMenu from "@/wds/WdsDropdownMenu.vue";
+
+describe("BuilderSelect", () => {
+	const options: Option[] = [
+		{ label: "Label A", value: "a" },
+		{ label: "Label B", value: "b" },
+		{ label: "Label C", value: "c" },
+	];
+
+	it("should display unknow value selected", () => {
+		const wrapper = shallowMount(BuilderSelect, {
+			props: {
+				modelValue: "x",
+				enableMultiSelection: false,
+				hideIcons: true,
+				options,
+			},
+		});
+
+		expect(wrapper.get(".material-symbols-outlined").text()).toBe(
+			"help_center",
+		);
+	});
+
+	it("should support single mode", async () => {
+		const wrapper = mount(BuilderSelect, {
+			props: {
+				modelValue: "a",
+				enableMultiSelection: false,
+				options,
+			},
+			global: {
+				stubs: {
+					WdsDropdownMenu: true,
+				},
+			},
+		});
+		await flushPromises();
+
+		await wrapper.get(".BuilderSelect__trigger").trigger("click");
+		await flushPromises();
+
+		const dropdownMenu = wrapper.getComponent(WdsDropdownMenu);
+		dropdownMenu.vm.$emit("select", "b");
+		await flushPromises();
+
+		expect(wrapper.emitted("update:modelValue").at(0)).toStrictEqual(["b"]);
+	});
+});

--- a/src/ui/src/builder/BuilderSelect.vue
+++ b/src/ui/src/builder/BuilderSelect.vue
@@ -6,7 +6,10 @@
 			@click="isOpen = !isOpen"
 		>
 			<i
-				v-if="!hideIcons || hasUnknowOptionSelected"
+				v-if="
+					(hasUnknowOptionSelected || !hideIcons) &&
+					!enableMultiSelection
+				"
 				class="material-symbols-outlined"
 				>{{ currentIcon }}</i
 			>
@@ -40,6 +43,7 @@
 			:enable-search="enableSearch"
 			:enable-multi-selection="enableMultiSelection"
 			:hide-icons="hideIcons"
+			:loading="loading"
 			:options="options"
 			:selected="currentValue"
 			:style="floatingStyles"
@@ -83,6 +87,7 @@ const props = defineProps({
 	hideIcons: { type: Boolean, required: false },
 	enableSearch: { type: Boolean, required: false },
 	enableMultiSelection: { type: Boolean, required: false },
+	loading: { type: Boolean, required: false },
 });
 
 const currentValue = defineModel({

--- a/src/ui/src/builder/builderManager.ts
+++ b/src/ui/src/builder/builderManager.ts
@@ -1,5 +1,6 @@
 import { computed, ref, Ref } from "vue";
 import { Component, ClipboardOperation } from "@/writerTypes";
+import { useLocalStorageJSON } from "@/composables/useLocalStorageJSON";
 
 export const CANDIDATE_CONFIRMATION_DELAY_MS = 1500;
 
@@ -86,8 +87,11 @@ type State = {
 };
 
 export function generateBuilderManager() {
+	const modeCache = useLocalStorageJSON<State["mode"]>(
+		"generateBuilderManager__mode",
+	);
 	const initState: State = {
-		mode: "ui",
+		mode: modeCache.value ?? "ui",
 		selection: [],
 		clipboard: null,
 		mutationTransactionsSnapshot: {
@@ -106,7 +110,7 @@ export function generateBuilderManager() {
 	 * @deprecated use {@link mode} instead
 	 */
 	const setMode = (newMode: State["mode"]): void => {
-		state.value.mode = newMode;
+		mode.value = newMode;
 	};
 
 	/**
@@ -120,6 +124,7 @@ export function generateBuilderManager() {
 		get: () => state.value.mode,
 		set(newValue) {
 			state.value.mode = newValue;
+			modeCache.value = newValue;
 		},
 	});
 

--- a/src/ui/src/builder/settings/BuilderFieldsTools.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsTools.vue
@@ -31,6 +31,7 @@
 			:close-action="customHandlerModalCloseAction"
 			icon="add"
 			modal-title="Add tool"
+			allow-overflow
 		>
 			<div class="addToolForm">
 				<WdsFieldWrapper label="Tool type">
@@ -58,13 +59,16 @@
 					label="Graph id(s)"
 					hint="Specify the id of the knowledge graph you want to use. If multiple, separate the ids using commas."
 				>
-					<WdsTextareaInput
-						v-model="toolForm.graphIds"
-					></WdsTextareaInput>
+					<BuilderGraphSelect
+						v-model="graphIds"
+						enable-multi-selection
+					/>
 				</WdsFieldWrapper>
 			</div>
 			<div class="addToolFormActions">
-				<WdsButton @click="saveToolForm">Save</WdsButton>
+				<WdsButton :disabled.prop="saveDisabled" @click="saveToolForm"
+					>Save</WdsButton
+				>
 			</div>
 		</BuilderModal>
 	</div>
@@ -78,9 +82,9 @@ import injectionKeys from "@/injectionKeys";
 import WdsButton from "@/wds/WdsButton.vue";
 import BuilderModal, { ModalAction } from "../BuilderModal.vue";
 import WdsTextInput from "@/wds/WdsTextInput.vue";
-import WdsTextareaInput from "@/wds/WdsTextareaInput.vue";
 import WdsDropdownInput from "@/wds/WdsDropdownInput.vue";
 import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
+import BuilderGraphSelect from "../BuilderGraphSelect.vue";
 
 const BuilderEmbeddedCodeEditor = defineAsyncComponent(
 	() => import("../BuilderEmbeddedCodeEditor.vue"),
@@ -127,15 +131,36 @@ const initFunctionToolCode = `
 }
 `.trim();
 
-const toolFormInitValue = {
+const toolFormInitValue: ToolForm = {
 	isShown: false,
 	type: "function" as "function" | "graph",
 	name: "new_tool",
 	code: initFunctionToolCode,
-	graphIds: "6029b226-1ee0-4239-a1b0-cdeebfa3ad5a",
+	graphIds: "",
 };
 
 const toolForm = ref<ToolForm>(toolFormInitValue);
+
+const saveDisabled = computed(() => {
+	switch (toolForm.value.type) {
+		case "function":
+			return !toolForm.value.code;
+		case "graph":
+			return !toolForm.value.graphIds;
+		default:
+			return true;
+	}
+});
+
+const graphIds = computed<string[]>({
+	get: () => toolForm.value.graphIds.split(","),
+	set(ids) {
+		toolForm.value = {
+			...toolForm.value,
+			graphIds: ids.join(","),
+		};
+	},
+});
 
 const props = defineProps<{
 	componentId: Component["id"];

--- a/src/ui/src/builder/settings/BuilderFieldsWriterGraphId.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsWriterGraphId.vue
@@ -1,0 +1,35 @@
+<template>
+	<div
+		class="BuilderFieldsWriterGraphId"
+		:data-automation-key="props.fieldKey"
+	>
+		<BuilderGraphSelect v-model="selectedGraph" />
+	</div>
+</template>
+
+<script setup lang="ts">
+import { toRefs, inject, computed, PropType } from "vue";
+import { Component } from "@/writerTypes";
+import { useComponentActions } from "../useComponentActions";
+import injectionKeys from "@/injectionKeys";
+import BuilderGraphSelect from "../BuilderGraphSelect.vue";
+
+const wf = inject(injectionKeys.core);
+const ssbm = inject(injectionKeys.builderManager);
+const { setContentValue } = useComponentActions(wf, ssbm);
+
+const props = defineProps({
+	componentId: { type: String as PropType<Component["id"]>, required: true },
+	fieldKey: { type: String, required: true },
+	error: { type: String, required: false, default: undefined },
+});
+const { componentId, fieldKey } = toRefs(props);
+const component = computed(() => wf.getComponentById(componentId.value));
+
+const selectedGraph = computed<string>({
+	get: () => component.value.content[props.fieldKey] ?? "",
+	set(value) {
+		setContentValue(component.value.id, fieldKey.value, String(value));
+	},
+});
+</script>

--- a/src/ui/src/builder/settings/BuilderSettingsHandlers.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsHandlers.vue
@@ -113,7 +113,7 @@
 <script setup lang="ts">
 import * as monaco from "monaco-editor";
 
-import { computed, ComputedRef, inject, nextTick, Ref, ref } from "vue";
+import { computed, ComputedRef, inject, Ref, ref } from "vue";
 import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "@/injectionKeys";
 import BuilderModal, { ModalAction } from "../BuilderModal.vue";

--- a/src/ui/src/builder/settings/BuilderSettingsProperties.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsProperties.vue
@@ -132,6 +132,13 @@
 						:component-id="selectedComponent.id"
 					>
 					</BuilderFieldsTools>
+
+					<BuilderFieldsWriterGraphId
+						v-if="fieldValue.type == FieldType.WriterGraphId"
+						:field-key="fieldKey"
+						:component-id="selectedComponent.id"
+						:error="errorsByFields[fieldKey]"
+					/>
 				</WdsFieldWrapper>
 			</div>
 		</div>
@@ -156,6 +163,7 @@ import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
 import BuilderFieldsWorkflowKey from "./BuilderFieldsWorkflowKey.vue";
 import BuilderFieldsHandler from "./BuilderFieldsHandler.vue";
 import { useFieldsErrors } from "@/renderer/useFieldsErrors";
+import BuilderFieldsWriterGraphId from "./BuilderFieldsWriterGraphId.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);

--- a/src/ui/src/components/core/root/CoreRoot.vue
+++ b/src/ui/src/components/core/root/CoreRoot.vue
@@ -89,8 +89,6 @@ export default {
 import {
 	computed,
 	inject,
-	ref,
-	Ref,
 	watch,
 	nextTick,
 	onBeforeMount,

--- a/src/ui/src/composables/useListResources.spec.ts
+++ b/src/ui/src/composables/useListResources.spec.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeEach, describe, expect, it, Mock, vi } from "vitest";
+import { useListResources } from "./useListResources";
+import { buildMockCore } from "@/tests/mocks";
+
+describe(useListResources.name, () => {
+	const resources = [
+		{ id: 1, name: "one" },
+		{ id: 2, name: "two" },
+	];
+	let core: ReturnType<typeof buildMockCore>["core"];
+	let localStorage: { getItem: Mock; setItem: Mock; removeItem: Mock };
+
+	beforeEach(() => {
+		localStorage = {
+			getItem: vi.fn().mockReturnValue(JSON.stringify(resources)),
+			setItem: vi.fn(),
+			removeItem: vi.fn(),
+		};
+
+		vi.stubGlobal("localStorage", localStorage);
+
+		core = buildMockCore().core;
+	});
+
+	afterAll(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("should load the resources", async () => {
+		const loadedResources = [...resources, { id: 3, name: "three" }];
+		vi.spyOn(core, "sendListResourcesRequest").mockResolvedValue(
+			loadedResources,
+		);
+
+		const { load, data } = useListResources(core, "graphs");
+
+		expect(data.value).toStrictEqual(resources);
+
+		await load();
+
+		expect(data.value).toStrictEqual(loadedResources);
+	});
+
+	it("should handle error", async () => {
+		const apiError = new Error("ooops");
+		vi.spyOn(core, "sendListResourcesRequest").mockRejectedValue(apiError);
+
+		const { load, data, error } = useListResources(core, "graphs");
+
+		expect(data.value).toStrictEqual(resources);
+
+		await load();
+
+		expect(data.value).toStrictEqual([]);
+		expect(error.value).toStrictEqual(apiError);
+	});
+});

--- a/src/ui/src/composables/useListResources.ts
+++ b/src/ui/src/composables/useListResources.ts
@@ -1,0 +1,39 @@
+import { generateCore } from "@/core";
+import { readonly, ref, shallowRef } from "vue";
+import { useLocalStorageJSON } from "./useLocalStorageJSON";
+
+export function useListResources<T>(
+	wf: ReturnType<typeof generateCore>,
+	type: string,
+) {
+	const isLoading = ref(false);
+	const error = ref();
+
+	const cache = useLocalStorageJSON<T[]>(
+		`useListResources(${type})`,
+		Array.isArray,
+	);
+
+	const data = shallowRef<T[]>(cache.value ?? []);
+
+	async function load() {
+		isLoading.value = true;
+		error.value = undefined;
+		try {
+			data.value = await wf.sendListResourcesRequest<T>(type);
+			cache.value = data.value;
+		} catch (e) {
+			error.value = e;
+			data.value = [];
+		} finally {
+			isLoading.value = false;
+		}
+	}
+
+	return {
+		data: readonly(data),
+		isLoading: readonly(isLoading),
+		error: readonly(error),
+		load,
+	};
+}

--- a/src/ui/src/composables/useLocalStorageJSON.spec.ts
+++ b/src/ui/src/composables/useLocalStorageJSON.spec.ts
@@ -1,0 +1,58 @@
+import { afterAll, beforeEach, describe, expect, it, Mock, vi } from "vitest";
+import { useLocalStorageJSON } from "./useLocalStorageJSON";
+
+describe(useLocalStorageJSON.name, () => {
+	let localStorage: { getItem: Mock; setItem: Mock; removeItem: Mock };
+
+	beforeEach(() => {
+		localStorage = {
+			getItem: vi.fn(),
+			setItem: vi.fn(),
+			removeItem: vi.fn(),
+		};
+
+		vi.stubGlobal("localStorage", localStorage);
+	});
+
+	afterAll(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("should get the value", () => {
+		localStorage.getItem.mockReturnValue(JSON.stringify({ a: 1 }));
+
+		const cache = useLocalStorageJSON("key");
+
+		expect(cache.value).toStrictEqual({ a: 1 });
+		expect(localStorage.getItem).toHaveBeenNthCalledWith(1, "key");
+	});
+
+	it("should set the value", () => {
+		const cache = useLocalStorageJSON("key");
+
+		cache.value = { b: 2 };
+		expect(localStorage.setItem).toHaveBeenNthCalledWith(
+			1,
+			"key",
+			JSON.stringify({ b: 2 }),
+		);
+	});
+
+	it("should delete a non JSON value", () => {
+		localStorage.getItem.mockReturnValue("{");
+
+		const cache = useLocalStorageJSON("key");
+
+		expect(cache.value).toBeUndefined();
+		expect(localStorage.removeItem).toHaveBeenNthCalledWith(1, "key");
+	});
+
+	it("should delete an invalid value", () => {
+		localStorage.getItem.mockReturnValue(1);
+
+		const cache = useLocalStorageJSON("key", Array.isArray);
+
+		expect(cache.value).toBeUndefined();
+		expect(localStorage.removeItem).toHaveBeenNthCalledWith(1, "key");
+	});
+});

--- a/src/ui/src/composables/useLocalStorageJSON.ts
+++ b/src/ui/src/composables/useLocalStorageJSON.ts
@@ -1,0 +1,34 @@
+import { computed } from "vue";
+
+/**
+ * Get/Set the JSON object in localStorage
+ * @param validator validate that the data has a given shape, remote the localStorage value if returns `false`
+ */
+export function useLocalStorageJSON<T>(
+	key: string,
+	validator?: (value: T) => boolean,
+) {
+	return computed<T | undefined>({
+		get() {
+			const value = localStorage.getItem(key);
+			if (!value) return undefined;
+
+			try {
+				const data = JSON.parse(value);
+				if (validator?.(data) === false) {
+					localStorage.removeItem(key);
+					return undefined;
+				}
+				return data;
+			} catch {
+				localStorage.removeItem(key);
+				return undefined;
+			}
+		},
+		set(value) {
+			value === undefined
+				? localStorage.removeItem(key)
+				: localStorage.setItem(key, JSON.stringify(value));
+		},
+	});
+}

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -9,9 +9,6 @@ import {
 	MailItem,
 	SourceFiles,
 	UserFunction,
-	WriterGraph,
-	WriterGraphRequest,
-	WriterGraphResponse,
 } from "@/writerTypes";
 import {
 	getSupportedComponentTypes,

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -9,6 +9,9 @@ import {
 	MailItem,
 	SourceFiles,
 	UserFunction,
+	WriterGraph,
+	WriterGraphRequest,
+	WriterGraphResponse,
 } from "@/writerTypes";
 import {
 	getSupportedComponentTypes,
@@ -490,6 +493,23 @@ export function generateCore() {
 		});
 	}
 
+	async function sendListResourcesRequest<T>(type: string): Promise<T[]> {
+		return new Promise<T[]>((resolve, reject) => {
+			const messageCallback = (r: {
+				ok: boolean;
+				payload: { data: T[] };
+			}) => {
+				if (!r.ok) return reject("Couldn't connect to the server.");
+				resolve(r.payload?.data ?? []);
+			};
+			sendFrontendMessage(
+				"listResources",
+				{ resource_type: type },
+				messageCallback,
+			);
+		});
+	}
+
 	async function sendStateEnquiry(callback: Function) {
 		sendFrontendMessage("stateEnquiry", {}, callback, true);
 	}
@@ -708,6 +728,7 @@ export function generateCore() {
 		sendRenameSourceFileRequest,
 		sendDeleteSourceFileRequest,
 		requestSourceFileLoading,
+		sendListResourcesRequest,
 		sendComponentUpdate,
 		addComponent,
 		deleteComponent,

--- a/src/ui/src/wds/WdsCheckbox.vue
+++ b/src/ui/src/wds/WdsCheckbox.vue
@@ -1,4 +1,4 @@
-<script lang="tsx" setup>
+<script lang="ts" setup>
 import { computed, defineProps, useId } from "vue";
 
 const props = defineProps({

--- a/src/ui/src/wds/WdsCheckbox.vue
+++ b/src/ui/src/wds/WdsCheckbox.vue
@@ -1,0 +1,106 @@
+<script lang="tsx" setup>
+import { computed, defineProps, useId } from "vue";
+
+const props = defineProps({
+	label: { type: String, required: false, default: undefined },
+	detail: { type: String, required: false, default: undefined },
+	disabled: { type: Boolean, required: false },
+});
+
+const id = useId();
+
+const checked = defineModel({ type: Boolean, default: false });
+
+const classes = computed(() =>
+	[
+		props.disabled ? "WdsCheckbox--disabled" : undefined,
+		checked.value ? "WdsCheckbox--checked" : undefined,
+	].filter(Boolean),
+);
+function onChange(event: InputEvent) {
+	checked.value = (event.target as HTMLInputElement).checked;
+}
+</script>
+
+<template>
+	<label
+		:for="id"
+		class="WdsCheckbox"
+		:class="classes"
+		@mousedown.prevent
+		@click.prevent="checked = !checked"
+	>
+		<div class="WdsCheckbox__checkbox">
+			<i class="WdsCheckbox__checkbox__check material-symbols-outlined"
+				>check</i
+			>
+		</div>
+		<span v-if="label" class="WdsCheckbox__label">{{ label }}</span>
+		<span v-if="detail" class="WdsCheckbox__detail">{{ detail }}</span>
+		<input
+			:id="id"
+			type="checkbox"
+			:checked="checked"
+			:disabled="disabled"
+			@change.stop="onChange"
+		/>
+	</label>
+</template>
+
+<style lang="css" scoped>
+.WdsCheckbox {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	grid-template-rows: auto;
+	align-items: center;
+	column-gap: 12px;
+	row-gap: 2px;
+	cursor: pointer;
+}
+.WdsCheckbox__checkbox {
+	border: 1px solid var(--wdsColorGray4);
+	width: 18px;
+	height: 18px;
+
+	border-radius: 4px;
+	grid-row-start: 1;
+	grid-row-end: -1;
+}
+.WdsCheckbox--checked .WdsCheckbox__checkbox {
+	background-color: var(--wdsColorBlue5);
+	font-weight: bold;
+}
+
+.WdsCheckbox__checkbox__check {
+	display: none;
+}
+
+.WdsCheckbox:hover:not(.WdsCheckbox--checked) .WdsCheckbox__checkbox__check {
+	display: block;
+	color: var(--wdsColorGray4);
+}
+.WdsCheckbox--checked .WdsCheckbox__checkbox__check {
+	display: block;
+	color: var(--wdsColorWhite);
+}
+
+.WdsCheckbox__detail,
+.WdsCheckbox__label {
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	overflow: hidden;
+	text-align: left;
+}
+
+.WdsCheckbox:has(.WdsCheckbox__detail) {
+	grid-template-rows: auto auto;
+}
+
+.WdsCheckbox__detail {
+	color: var(--wdsColorGray4);
+}
+
+.WdsCheckbox input {
+	display: none;
+}
+</style>

--- a/src/ui/src/wds/WdsDropdownMenu.spec.ts
+++ b/src/ui/src/wds/WdsDropdownMenu.spec.ts
@@ -1,0 +1,49 @@
+import { shallowMount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import WdsDropdownMenu from "./WdsDropdownMenu.vue";
+import { WdsDropdownMenuOption } from "./WdsDropdownMenu.vue";
+
+describe("WdsDropdownMenu", () => {
+	const options: WdsDropdownMenuOption[] = [
+		{ label: "Label A", value: "a" },
+		{ label: "Label B", value: "b" },
+		{ label: "Label C", value: "c" },
+	];
+
+	describe("single mode", () => {
+		it("should select an option", async () => {
+			const wrapper = shallowMount(WdsDropdownMenu, {
+				props: {
+					selected: "a",
+					enableMultiSelection: false,
+					options,
+				},
+			});
+
+			await wrapper
+				.get(`.WdsDropdownMenu__item[data-automation-key="b"]`)
+				.trigger("click");
+
+			expect(wrapper.emitted("select").at(0)).toStrictEqual(["b"]);
+		});
+	});
+
+	describe("multiple mode", () => {
+		it("should support multiple mode", async () => {
+			const wrapper = shallowMount(WdsDropdownMenu, {
+				props: {
+					selected: ["???"],
+					enableMultiSelection: true,
+					options,
+				},
+			});
+
+			await wrapper
+				.get(`.WdsDropdownMenu__item[data-automation-key="b"]`)
+				.trigger("click");
+
+			expect(wrapper.emitted("select").at(0)).toStrictEqual([["b"]]);
+		});
+	});
+});

--- a/src/ui/src/wds/WdsDropdownMenu.spec.ts
+++ b/src/ui/src/wds/WdsDropdownMenu.spec.ts
@@ -1,4 +1,4 @@
-import { shallowMount } from "@vue/test-utils";
+import { mount, shallowMount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 
 import WdsDropdownMenu from "./WdsDropdownMenu.vue";
@@ -31,7 +31,7 @@ describe("WdsDropdownMenu", () => {
 
 	describe("multiple mode", () => {
 		it("should support multiple mode", async () => {
-			const wrapper = shallowMount(WdsDropdownMenu, {
+			const wrapper = mount(WdsDropdownMenu, {
 				props: {
 					selected: ["???"],
 					enableMultiSelection: true,
@@ -40,7 +40,7 @@ describe("WdsDropdownMenu", () => {
 			});
 
 			await wrapper
-				.get(`.WdsDropdownMenu__item[data-automation-key="b"]`)
+				.get(`.WdsDropdownMenu__checkbox[data-automation-key="b"]`)
 				.trigger("click");
 
 			expect(wrapper.emitted("select").at(0)).toStrictEqual([["b"]]);

--- a/src/ui/src/wds/WdsDropdownMenu.vue
+++ b/src/ui/src/wds/WdsDropdownMenu.vue
@@ -24,16 +24,28 @@
 				:key="index"
 				class="WdsDropdownMenu__item"
 			>
-				<div
+				<WdsSkeletonLoader
 					v-if="enableMultiSelection || !hideIcons"
-					class="WdsDropdownMenu__item__checkbox"
-				>
-					<WdsSkeletonLoader style="width: 20px" />
-				</div>
+					style="width: 20px"
+				/>
 				<div class="WdsDropdownMenu__item__label">
 					<WdsSkeletonLoader />
 				</div>
 			</button>
+		</template>
+
+		<template v-else-if="enableMultiSelection">
+			<WdsCheckbox
+				v-for="option in optionsFiltered"
+				:key="option.value"
+				class="WdsDropdownMenu__checkbox"
+				:checked="isSelected(option.value)"
+				:label="option.label"
+				:detail="option.detail"
+				:data-automation-key="option.value"
+				:model-value="isSelected(option.value)"
+				@update:model-value="onSelect(option.value)"
+			/>
 		</template>
 
 		<template v-else>
@@ -48,16 +60,7 @@
 				:data-automation-key="option.value"
 				@click="onSelect(option.value)"
 			>
-				<div
-					v-if="enableMultiSelection"
-					class="WdsDropdownMenu__item__checkbox"
-				>
-					<input
-						type="checkbox"
-						:checked="isSelected(option.value)"
-					/>
-				</div>
-				<i v-else-if="!hideIcons" class="material-symbols-outlined">{{
+				<i v-if="!hideIcons" class="material-symbols-outlined">{{
 					getOptionIcon(option)
 				}}</i>
 				<div
@@ -99,6 +102,7 @@ export type WdsDropdownMenuOption = {
 // from https://www.figma.com/design/jgLDtwVwg3hReC1t4Vw20D/.WDS-Writer-Design-System?node-id=128-396&t=9Gy9MYDycjVV8C2Y-1
 import { computed, PropType, ref, watch } from "vue";
 import WdsSkeletonLoader from "./WdsSkeletonLoader.vue";
+import WdsCheckbox from "./WdsCheckbox.vue";
 
 const props = defineProps({
 	options: {
@@ -185,6 +189,16 @@ watch(searchTerm, () => emits("search", searchTerm.value));
 	padding-top: 0px;
 }
 
+.WdsDropdownMenu__checkbox,
+.WdsDropdownMenu__item {
+	min-height: 36px;
+}
+
+.WdsDropdownMenu__checkbox {
+	margin-top: 8px;
+	margin-bottom: 8px;
+}
+
 .WdsDropdownMenu__item {
 	background-color: transparent;
 	border: none;
@@ -196,8 +210,6 @@ watch(searchTerm, () => emits("search", searchTerm.value));
 	column-gap: 8px;
 	align-items: center;
 
-	min-height: 36px;
-
 	border-radius: 4px;
 
 	padding: 8px;
@@ -208,8 +220,7 @@ watch(searchTerm, () => emits("search", searchTerm.value));
 	transition: all 0.2s;
 	pointer-events: all;
 }
-.WdsDropdownMenu__item:has(.material-symbols-outlined),
-.WdsDropdownMenu__item:has(.WdsDropdownMenu__item__checkbox) {
+.WdsDropdownMenu__item:has(.material-symbols-outlined) {
 	grid-template-columns: auto 1fr auto;
 }
 
@@ -223,16 +234,6 @@ watch(searchTerm, () => emits("search", searchTerm.value));
 }
 .WdsDropdownMenu__item--hideIcon {
 	grid-template-columns: 1fr auto;
-}
-
-.WdsDropdownMenu__item__checkbox {
-	grid-row-start: 1;
-	grid-row-end: -1;
-
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	height: 100%;
 }
 
 .WdsDropdownMenu__item__detail,

--- a/src/ui/src/wds/WdsDropdownMenu.vue
+++ b/src/ui/src/wds/WdsDropdownMenu.vue
@@ -1,15 +1,30 @@
 <template>
 	<div class="WdsDropdownMenu">
 		<div
-			v-if="enableSearch && !loading"
-			class="WdsDropdownMenu__search-wrapper"
+			v-if="(enableSearch || enableMultiSelection) && !loading"
+			class="WdsDropdownMenu__header"
 		>
-			<div class="WdsDropdownMenu__search">
+			<div
+				v-if="enableMultiSelection"
+				class="WdsDropdownMenu__header__multiSelect"
+			>
+				<div class="WdsDropdownMenu__header__multiSelect__count">
+					{{ headerSelectCountText }}
+				</div>
+				<button
+					class="WdsDropdownMenu__header__multiSelect__clear"
+					role="button"
+					@click="$emit('select', [])"
+				>
+					Clear all
+				</button>
+			</div>
+			<div v-if="enableSearch" class="WdsDropdownMenu__header__search">
 				<i class="material-symbols-outlined">search</i>
 				<input
 					ref="searchInput"
 					v-model="searchTerm"
-					class="WdsDropdownMenu__search__input"
+					class="WdsDropdownMenu__header__search__input"
 					type="text"
 					placeholder="Search"
 					autocomplete="off"
@@ -130,10 +145,13 @@ const emits = defineEmits({
 
 const searchTerm = ref("");
 
-function getOptionIcon(option: WdsDropdownMenuOption) {
-	if (props.hideIcons) return "";
-	return option.icon ?? "help_center";
-}
+const headerSelectCountText = computed(() => {
+	const selectedArray = Array.isArray(props.selected)
+		? props.selected
+		: [props.selected];
+	const count = selectedArray.filter(Boolean).length;
+	return `${count}/${props.options.length} selected`;
+});
 
 const optionsFiltered = computed(() => {
 	if (!props.enableSearch) return props.options;
@@ -143,6 +161,11 @@ const optionsFiltered = computed(() => {
 		option.label.toLowerCase().includes(query),
 	);
 });
+
+function getOptionIcon(option: WdsDropdownMenuOption) {
+	if (props.hideIcons) return "";
+	return option.icon ?? "help_center";
+}
 
 function isSelected(value: string) {
 	return Array.isArray(props.selected)
@@ -185,7 +208,7 @@ watch(searchTerm, () => emits("search", searchTerm.value));
 	box-shadow: var(--wdsShadowMenu);
 	box-sizing: border-box;
 }
-.WdsDropdownMenu:has(.WdsDropdownMenu__search-wrapper) {
+.WdsDropdownMenu:has(.WdsDropdownMenu__header) {
 	padding-top: 0px;
 }
 
@@ -253,15 +276,19 @@ watch(searchTerm, () => emits("search", searchTerm.value));
 	color: var(--wdsColorGray4);
 }
 
-.WdsDropdownMenu__search-wrapper {
+.WdsDropdownMenu__header {
 	position: sticky;
 	top: 0px;
 	padding-top: 8px;
 	padding-bottom: 8px;
 	background: #fff;
+
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
 }
 
-.WdsDropdownMenu__search {
+.WdsDropdownMenu__header__search {
 	background-color: var(--wdsColorGray1);
 	border-radius: 4px;
 	height: 36px;
@@ -277,15 +304,15 @@ watch(searchTerm, () => emits("search", searchTerm.value));
 
 	color: currentcolor;
 }
-.WdsDropdownMenu__search:hover {
+.WdsDropdownMenu__header__search:hover {
 	border-color: var(--wdsColorBlue1);
 }
-.WdsDropdownMenu__search:focus-within {
+.WdsDropdownMenu__header__search:focus-within {
 	background-color: white;
 	outline: 4px solid var(--wdsColorBlue1);
 }
 
-.WdsDropdownMenu__search__input {
+.WdsDropdownMenu__header__search__input {
 	letter-spacing: inherit;
 	color: currentcolor;
 	padding: 4px 0px 5px;
@@ -301,7 +328,28 @@ watch(searchTerm, () => emits("search", searchTerm.value));
 	animation-duration: 10ms;
 	appearance: textfield;
 }
-.WdsDropdownMenu__search__input:focus-visible {
+.WdsDropdownMenu__header__search__input:focus-visible {
 	outline: none;
+}
+
+.WdsDropdownMenu__header__multiSelect {
+	display: flex;
+	gap: 12px;
+}
+.WdsDropdownMenu__header__multiSelect__count,
+.WdsDropdownMenu__header__multiSelect__clear {
+	text-transform: uppercase;
+	font-size: 13px;
+}
+.WdsDropdownMenu__header__multiSelect__count {
+	flex-grow: 1;
+	color: var(--wdsColorGray6);
+}
+.WdsDropdownMenu__header__multiSelect__clear {
+	background-color: transparent;
+	border: none;
+	cursor: pointer;
+	text-align: right;
+	color: var(--wdsColorGray4);
 }
 </style>

--- a/src/ui/src/wds/WdsDropdownMenu.vue
+++ b/src/ui/src/wds/WdsDropdownMenu.vue
@@ -1,6 +1,9 @@
 <template>
 	<div class="WdsDropdownMenu">
-		<div v-if="enableSearch" class="WdsDropdownMenu__search-wrapper">
+		<div
+			v-if="enableSearch && !loading"
+			class="WdsDropdownMenu__search-wrapper"
+		>
 			<div class="WdsDropdownMenu__search">
 				<i class="material-symbols-outlined">search</i>
 				<input
@@ -10,51 +13,76 @@
 					type="text"
 					placeholder="Search"
 					autocomplete="off"
+					:disabled="loading"
 				/>
 			</div>
 		</div>
-		<button
-			v-for="option in optionsFiltered"
-			:key="option.value"
-			:data-automation-key="option.value"
-			class="WdsDropdownMenu__item"
-			:class="{
-				'WdsDropdownMenu__item--selected': isSelected(option.value),
-				'WdsDropdownMenu__item--hideIcon': hideIcons,
-			}"
-			@click="onSelect(option.value)"
-		>
-			<div
-				v-if="enableMultiSelection"
-				class="WdsDropdownMenu__item__checkbox"
+
+		<template v-if="loading">
+			<button
+				v-for="index in 6"
+				:key="index"
+				class="WdsDropdownMenu__item"
 			>
-				<input type="checkbox" :checked="isSelected(option.value)" />
-			</div>
-			<i v-else-if="!hideIcons" class="material-symbols-outlined">{{
-				getOptionIcon(option)
-			}}</i>
-			<div
-				class="WdsDropdownMenu__item__label"
-				:data-writer-tooltip="option.label"
-				data-writer-tooltip-strategy="overflow"
+				<div
+					v-if="enableMultiSelection || !hideIcons"
+					class="WdsDropdownMenu__item__checkbox"
+				>
+					<WdsSkeletonLoader style="width: 20px" />
+				</div>
+				<div class="WdsDropdownMenu__item__label">
+					<WdsSkeletonLoader />
+				</div>
+			</button>
+		</template>
+
+		<template v-else>
+			<button
+				v-for="option in optionsFiltered"
+				:key="option.value"
+				class="WdsDropdownMenu__item"
+				:class="{
+					'WdsDropdownMenu__item--selected': isSelected(option.value),
+					'WdsDropdownMenu__item--hideIcon': hideIcons,
+				}"
+				:data-automation-key="option.value"
+				@click="onSelect(option.value)"
 			>
-				{{ option.label }}
-			</div>
-			<div
-				v-if="option.detail"
-				class="WdsDropdownMenu__item__detail"
-				:data-writer-tooltip="option.detail"
-				data-writer-tooltip-strategy="overflow"
-			>
-				{{ option.detail }}
-			</div>
-			<i
-				v-if="isSelected(option.value)"
-				class="material-symbols-outlined"
-			>
-				check
-			</i>
-		</button>
+				<div
+					v-if="enableMultiSelection"
+					class="WdsDropdownMenu__item__checkbox"
+				>
+					<input
+						type="checkbox"
+						:checked="isSelected(option.value)"
+					/>
+				</div>
+				<i v-else-if="!hideIcons" class="material-symbols-outlined">{{
+					getOptionIcon(option)
+				}}</i>
+				<div
+					class="WdsDropdownMenu__item__label"
+					:data-writer-tooltip="option.label"
+					data-writer-tooltip-strategy="overflow"
+				>
+					{{ option.label }}
+				</div>
+				<div
+					v-if="option.detail"
+					class="WdsDropdownMenu__item__detail"
+					:data-writer-tooltip="option.detail"
+					data-writer-tooltip-strategy="overflow"
+				>
+					{{ option.detail }}
+				</div>
+				<i
+					v-if="isSelected(option.value)"
+					class="material-symbols-outlined"
+				>
+					check
+				</i>
+			</button>
+		</template>
 	</div>
 </template>
 
@@ -69,7 +97,8 @@ export type WdsDropdownMenuOption = {
 
 <script setup lang="ts">
 // from https://www.figma.com/design/jgLDtwVwg3hReC1t4Vw20D/.WDS-Writer-Design-System?node-id=128-396&t=9Gy9MYDycjVV8C2Y-1
-import { computed, PropType, ref, useTemplateRef, watch } from "vue";
+import { computed, PropType, ref, watch } from "vue";
+import WdsSkeletonLoader from "./WdsSkeletonLoader.vue";
 
 const props = defineProps({
 	options: {
@@ -86,6 +115,7 @@ const props = defineProps({
 		required: false,
 		default: () => {},
 	},
+	loading: { type: Boolean, required: false },
 });
 
 const emits = defineEmits({
@@ -94,7 +124,6 @@ const emits = defineEmits({
 	search: (value: string) => typeof value === "string",
 });
 
-const searchInput = useTemplateRef("searchInput");
 const searchTerm = ref("");
 
 function getOptionIcon(option: WdsDropdownMenuOption) {
@@ -166,6 +195,8 @@ watch(searchTerm, () => emits("search", searchTerm.value));
 	grid-template-columns: 1fr auto;
 	column-gap: 8px;
 	align-items: center;
+
+	min-height: 36px;
 
 	border-radius: 4px;
 

--- a/src/ui/src/wds/WdsSkeletonLoader.vue
+++ b/src/ui/src/wds/WdsSkeletonLoader.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts"></script>
+
+<template>
+	<div class="WdsSkeletonLoader" aria-busy="true"></div>
+</template>
+
+<style lang="css" scoped>
+.WdsSkeletonLoader {
+	width: 100%;
+	height: 12px;
+	background-color: var(--wdsColorGray2);
+	border-radius: 8px;
+	background: linear-gradient(
+		90deg,
+		var(--wdsColorGray0) 0%,
+		var(--wdsColorGray2) 50%,
+		var(--wdsColorGray0) 100%
+	);
+	background-size: 200% 100%;
+	animation: shimmer 1.5s infinite;
+}
+
+@keyframes shimmer {
+	0% {
+		background-position: 100% 0;
+	}
+	100% {
+		background-position: -100% 0;
+	}
+}
+</style>

--- a/src/ui/src/wds/WdsTag.vue
+++ b/src/ui/src/wds/WdsTag.vue
@@ -1,0 +1,73 @@
+<script lang="ts">
+export type WdsTagVariant = "normal" | "category" | "status";
+export type WdsTagSize = "normal" | "small";
+</script>
+<script setup lang="ts">
+import { computed, PropType } from "vue";
+
+const props = defineProps({
+	text: { type: String, required: true },
+	closable: { type: Boolean, required: false },
+	size: { type: String as PropType<WdsTagSize>, default: "normal" },
+	variant: { type: String as PropType<WdsTagVariant>, default: "normal" },
+});
+
+const classes = computed<string[]>(() => [
+	`WdsTag--size-${props.size}`,
+	`WdsTag--variant-${props.variant}`,
+]);
+
+defineEmits({
+	close: () => true,
+});
+</script>
+
+<template>
+	<div class="WdsTag" :class="classes">
+		<span class="WdsTag__text">{{ text }}</span>
+		<button
+			v-if="closable"
+			role="button"
+			class="WdsTag__close"
+			@click.stop="$emit('close')"
+		>
+			<i class="material-symbols-outlined">close</i>
+		</button>
+	</div>
+</template>
+
+<style scoped>
+.WdsTag {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 4px;
+	border-radius: 12px;
+	padding: 3px 12px;
+}
+
+.WdsTag--size-normal {
+	font-size: 12px;
+}
+.WdsTag--size-small {
+	font-size: 10px;
+}
+
+.WdsTag--variant-normal {
+	background-color: var(--wdsColorBlue2);
+}
+.WdsTag--variant-normal:hover {
+	background-color: var(--wdsColorBlue3);
+}
+
+.WdsTag__close {
+	border: none;
+	background-color: transparent;
+
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	cursor: pointer;
+}
+</style>

--- a/src/ui/src/writerTypes.ts
+++ b/src/ui/src/writerTypes.ts
@@ -138,6 +138,7 @@ export const enum FieldType {
 	ComponentPicker = "Component",
 	WorkflowKey = "WorkflowKey",
 	Handler = "Handler",
+	WriterGraphId = "WriterGraphId",
 }
 
 export const enum FieldCategory {
@@ -193,3 +194,35 @@ export type SourceFilesDirectory = {
  * ```
  */
 export type SourceFiles = SourceFilesDirectory | SourceFilesFile;
+
+export type WriterGraph = {
+	id: string;
+	created_at: string;
+	name: string;
+	description: string;
+	file_status: {
+		in_progress: number;
+		completed: number;
+		failed: number;
+		total: number;
+	};
+	type: "connector" | "manual";
+};
+
+export type WriterGraphRequest = {
+	/** Specifies the order of the results. Valid values are asc for ascending and desc for descending. default is `'desc` */
+	order?: "asc" | "desc";
+	/** The ID of the first object in the previous page. This parameter instructs the API to return the previous page of results. */
+	before?: string;
+	/** The ID of the last object in the previous page. This parameter instructs the API to return the next page of results. */
+	after?: string;
+	/** Specifies the maximum number of objects returned in a page. The default value is 50. The minimum value is 1, and the maximum value is 100. */
+	limit?: number;
+};
+
+export type WriterGraphResponse = {
+	data: WriterGraph[];
+	has_more: boolean;
+	first_id: string;
+	last_id: string;
+};

--- a/src/ui/src/writerTypes.ts
+++ b/src/ui/src/writerTypes.ts
@@ -208,21 +208,3 @@ export type WriterGraph = {
 	};
 	type: "connector" | "manual";
 };
-
-export type WriterGraphRequest = {
-	/** Specifies the order of the results. Valid values are asc for ascending and desc for descending. default is `'desc` */
-	order?: "asc" | "desc";
-	/** The ID of the first object in the previous page. This parameter instructs the API to return the previous page of results. */
-	before?: string;
-	/** The ID of the last object in the previous page. This parameter instructs the API to return the next page of results. */
-	after?: string;
-	/** Specifies the maximum number of objects returned in a page. The default value is 50. The minimum value is 1, and the maximum value is 100. */
-	limit?: number;
-};
-
-export type WriterGraphResponse = {
-	data: WriterGraph[];
-	has_more: boolean;
-	first_id: string;
-	last_id: string;
-};

--- a/src/writer/blocks/writeraddtokg.py
+++ b/src/writer/blocks/writeraddtokg.py
@@ -19,7 +19,7 @@ class WriterAddToKG(WorkflowBlock):
                 "fields": {
                     "graphId": {
                         "name": "Graph id",
-                        "type": "Text",
+                        "type": "WriterGraphId",
                         "desc": "The id for an existing knowledge graph. It has a UUID format.",
                         "validator": {
                             "type": "string",

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -26,6 +26,7 @@ from pydantic import ValidationError
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
 from writer import VERSION, abstract, crypto
+from writer.ai import Graph
 from writer.app_runner import AppRunner
 from writer.ss_types import (
     AppProcessServerResponse,
@@ -596,7 +597,9 @@ def get_asgi_app(
                 app_runner.rename_persisted_script(from_path, to_path)
             except Exception as error:
                 response.payload = {"error": str(error)}
-
+        elif req_message.type == "listResources":
+            res = await app_runner.list_resources(session_id, req_message.payload["resource_type"])
+            response.payload = res.payload
         await websocket.send_json(response.model_dump())
 
     async def _handle_keep_alive_message(

--- a/src/writer/ss_types.py
+++ b/src/writer/ss_types.py
@@ -26,7 +26,7 @@ class Readable(Protocol):
 ServeMode = Literal["run", "edit"]
 MessageType = Literal["sessionInit", "componentUpdate",
                       "event", "codeUpdate", "codeSave", "checkSession",
-                      "keepAlive", "stateEnquiry", "setUserinfo", "stateContent", "hashRequest"]
+                      "keepAlive", "stateEnquiry", "setUserinfo", "stateContent", "hashRequest", "listResources"]
 
 
 class AbstractTemplate(BaseModel):
@@ -112,6 +112,12 @@ class ComponentUpdateRequest(AppProcessServerRequest):
     type: Literal["componentUpdate"]
     payload: ComponentUpdateRequestPayload
 
+class ListResourcesRequestPayload(BaseModel):
+    resource_type: str
+
+class ListResourcesRequest(AppProcessServerRequest):
+    type: Literal["listResources"]
+    payload: ListResourcesRequestPayload
 
 class WriterEvent(BaseModel):
     type: str


### PR DESCRIPTION
This feature introduces a new selector that allows the user to select a knowledge graph from Writer's platform instead of copy/pasting the UUID.


| in workflow block | in tools editor |
|---|---|
| ![Screenshot 2025-02-11 at 17 53 43](https://github.com/user-attachments/assets/2de10f51-5121-4b6a-b9b6-2e743b456219) | ![Screenshot 2025-02-11 at 17 54 06](https://github.com/user-attachments/assets/8a3bbc7b-3c5b-4555-a226-7c9dec715d55) |

- introduce a new event called `listResources` that gets the list of Writer's graph (and will support other things later)
- make `BuilderSelect` and `WdsDropdownMenu` compatible with multi-selector
- introduce a new field `FieldType.WriterGraphId` to support graph selector for component's settings 
