### PR TITLE
writer framework build process is compatible with poetry 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,10 @@ packages = [
     { include = "writer", from = "src" }
 ]
 include = [
-    "src/writer/*.py",
-    "src/writer/static/**/*",
-    "src/writer/templates/**/*",
-    "src/writer/app_templates/**/*"
+    { path = "src/writer/*.py", format = ["sdist", "wheel"] },
+    { path = "src/writer/static/**/*", format = ["sdist", "wheel"] },
+    { path = "src/writer/templates/**/*", format = ["sdist", "wheel"] },
+    { path = "src/writer/app_templates/**/*", format = ["sdist", "wheel"] }
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
* feat: change include list in pyproject.toml to use path dictionaries with format specified for sdist and wheel

![image](https://github.com/user-attachments/assets/bd2e0369-c8fe-4347-8aab-7a42cf370cb0)
*wheel package has all the files*
