### PR TITLE
feat(ui): improve component tree search. WF-183

### DIFF
--- a/src/ui/src/builder/BuilderTree.vue
+++ b/src/ui/src/builder/BuilderTree.vue
@@ -6,6 +6,7 @@
 			tabindex="0"
 			:draggable="draggable"
 			:data-automation-key="dataAutomationKey"
+			:aria-expanded="!collapsed"
 			@mouseenter="isMainHovered = true"
 			@mouseleave="isMainHovered = false"
 			@click="$emit('select', $event)"
@@ -20,7 +21,7 @@
 				class="BuilderTree__main__collapser"
 				variant="neutral"
 				size="icon"
-				@click.stop="toggleCollapse"
+				@click.stop="toggleCollapse(undefined)"
 			>
 				<i class="material-symbols-outlined">{{
 					collapsed ? "expand_more" : "expand_less"
@@ -45,12 +46,14 @@
 				/>
 			</div>
 		</div>
-		<div
-			v-show="(!collapsed || props.query) && hasChildren"
-			class="BuilderTree__children"
-		>
-			<slot name="children" />
-		</div>
+		<Transition name="slide-fade">
+			<div
+				v-show="!collapsed && hasChildren"
+				class="BuilderTree__children"
+			>
+				<slot name="children" />
+			</div>
+		</Transition>
 	</div>
 </template>
 
@@ -86,7 +89,7 @@ const emit = defineEmits({
 	dropdownSelect: (key: string) => typeof key === "string",
 });
 
-defineExpose({ expand });
+defineExpose({ expand, toggleCollapse });
 
 const collapsed = ref(false);
 const isMainHovered = ref(false);
@@ -100,8 +103,9 @@ function expand() {
 	emit("expandBranch");
 }
 
-function toggleCollapse() {
-	collapsed.value = !collapsed.value;
+function toggleCollapse(newCollapse?: boolean) {
+	newCollapse ??= !collapsed.value;
+	if (newCollapse !== collapsed.value) collapsed.value = newCollapse;
 }
 </script>
 
@@ -165,5 +169,27 @@ function toggleCollapse() {
 	justify-content: flex-end;
 	color: var(--builderPrimaryTextColor);
 	--containerShadow: var(--wdsShadowMenu);
+}
+
+.slide-fade-enter-active {
+	transition: all 0.1s ease-out;
+}
+
+.slide-fade-leave-active {
+	transition: all 0.1s ease-in;
+}
+
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+	transform: translateY(-18px);
+	opacity: 0;
+}
+@media (prefers-reduced-motion) {
+	.slide-fade-enter-from,
+	.slide-fade-leave-to,
+	.slide-fade-enter-active,
+	.slide-fade-leave-active {
+		transition: unset;
+	}
 }
 </style>

--- a/src/ui/src/builder/builderManager.ts
+++ b/src/ui/src/builder/builderManager.ts
@@ -102,13 +102,30 @@ export function generateBuilderManager() {
 	let mutationTransactionOffset = 0;
 	const mutationTransactions: ComponentMutationTransaction[] = [];
 
+	/**
+	 * @deprecated use {@link mode} instead
+	 */
 	const setMode = (newMode: State["mode"]): void => {
 		state.value.mode = newMode;
 	};
 
+	/**
+	 * @deprecated use {@link mode} instead
+	 */
 	const getMode = () => {
 		return state.value.mode;
 	};
+
+	const mode = computed<State["mode"]>({
+		get: () => state.value.mode,
+		set(newValue) {
+			state.value.mode = newValue;
+		},
+	});
+
+	const activeRootId = computed<Component["id"]>(() =>
+		mode.value == "workflows" ? "workflows_root" : "root",
+	);
 
 	const setSelection = (
 		componentId: Component["id"] | null,
@@ -361,6 +378,8 @@ export function generateBuilderManager() {
 	const builder = {
 		setMode,
 		getMode,
+		mode,
+		activeRootId,
 		openPanels: ref(new Set<"code" | "log">()),
 		isSettingsBarCollapsed: ref(false),
 		isComponentIdSelected,

--- a/src/ui/src/builder/panels/BuilderLogWorkflowExecution.vue
+++ b/src/ui/src/builder/panels/BuilderLogWorkflowExecution.vue
@@ -311,6 +311,7 @@ function formatExecutionTime(timeInSeconds: number): string {
 	border-radius: 8px;
 	margin-top: 8px;
 	font-size: 14px;
+	overflow-x: auto;
 }
 
 .markdown :deep(code) {

--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTree.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTree.vue
@@ -3,13 +3,14 @@
 		v-model="query"
 		class="BuilderSidebarComponentTree"
 		placeholder="Component tree"
+		:search-count="searchResultCount"
 	>
 		<div>
 			<BuilderSidebarComponentTreeBranch
 				class="rootBranch"
 				:component-id="rootComponentId"
 				:query="query"
-			></BuilderSidebarComponentTreeBranch>
+			/>
 		</div>
 
 		<template #footer>
@@ -40,12 +41,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, nextTick, ref } from "vue";
+import { inject, nextTick, ref } from "vue";
 import BuilderSidebarPanel from "./BuilderSidebarPanel.vue";
 import injectionKeys from "@/injectionKeys";
 import BuilderSidebarComponentTreeBranch from "./BuilderSidebarComponentTreeBranch.vue";
 import WdsButton from "@/wds/WdsButton.vue";
 import { useComponentActions } from "../useComponentActions";
+import { useComponentsTreeSearchResults } from "./composables/useComponentsTreeSearch";
 
 const wf = inject(injectionKeys.core);
 const wfbm = inject(injectionKeys.builderManager);
@@ -53,12 +55,13 @@ const query = ref("");
 
 const { createAndInsertComponent } = useComponentActions(wf, wfbm);
 
-const rootComponentId = computed(() => {
-	if (wfbm.getMode() == "workflows") {
-		return "workflows_root";
-	}
-	return "root";
-});
+const rootComponentId = wfbm.activeRootId;
+
+const { searchResultCount } = useComponentsTreeSearchResults(
+	wf,
+	query,
+	rootComponentId,
+);
 
 async function addPage() {
 	const pageId = createAndInsertComponent("page", "root");

--- a/src/ui/src/builder/sidebar/BuilderSidebarPanel.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarPanel.vue
@@ -7,7 +7,9 @@
 				left-icon="search"
 				data-automation-action="search"
 				:placeholder="placeholder"
-			></WdsTextInput>
+				:right-text="searchRightText"
+				enable-clear-button
+			/>
 		</div>
 		<div class="BuilderSidebarPanel__main"><slot></slot></div>
 		<div class="BuilderSidebarPanel__footer">
@@ -18,12 +20,20 @@
 
 <script setup lang="ts">
 import WdsTextInput from "@/wds/WdsTextInput.vue";
+import { computed } from "vue";
 
 const model = defineModel<string>();
 
-defineProps<{
-	placeholder: string;
-}>();
+const props = defineProps({
+	placeholder: { type: String, required: true },
+	searchCount: { type: Number, required: false, default: undefined },
+});
+
+const searchRightText = computed(() => {
+	if (props.searchCount === undefined) return undefined;
+
+	return `${props.searchCount} result${props.searchCount === 1 ? "" : "s"}`;
+});
 </script>
 
 <style scoped>

--- a/src/ui/src/builder/sidebar/BuilderSidebarToolkit.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarToolkit.vue
@@ -3,6 +3,7 @@
 		v-model="query"
 		class="BuilderSidebarToolkit"
 		:placeholder="placeholder"
+		:search-count="searchCount"
 	>
 		<div
 			v-for="(tools, categoryId) in categories"
@@ -70,7 +71,9 @@ const activeToolkit = computed(() => {
 	return "core";
 });
 
-const categories = computed(() => {
+const categories = computed<
+	Record<string, ReturnType<typeof getRelevantToolsInCategory>>
+>(() => {
 	const categoriesWithTools = displayedCategories
 		.map((categoryId) => [
 			categoryId,
@@ -79,6 +82,14 @@ const categories = computed(() => {
 		.filter(([_categoryId, tools]) => tools.length > 0);
 
 	return Object.fromEntries(categoriesWithTools);
+});
+
+const searchCount = computed(() => {
+	if (!query.value) return undefined;
+	return Object.values(categories.value).reduce(
+		(acc, v) => acc + v.length,
+		0,
+	);
 });
 
 const placeholder = computed(() => {

--- a/src/ui/src/builder/sidebar/composables/useComponentsTreeSearch.spec.ts
+++ b/src/ui/src/builder/sidebar/composables/useComponentsTreeSearch.spec.ts
@@ -1,0 +1,105 @@
+import { computed, ref } from "vue";
+import { beforeAll, describe, expect, it } from "vitest";
+import { buildMockComponent, buildMockCore } from "@/tests/mocks";
+import {
+	useComponentsTreeSearch,
+	useComponentsTreeSearchForComponent,
+} from "./useComponentsTreeSearch";
+import { generateCore } from "@/core";
+
+describe(useComponentsTreeSearch.name, () => {
+	const q = ref("");
+	const component = buildMockComponent({
+		type: "button",
+		content: {
+			tag1: "Tag1",
+		},
+	});
+	let hook: ReturnType<typeof useComponentsTreeSearch>;
+
+	beforeAll(() => {
+		const core = buildMockCore().core;
+		core.addComponent(component);
+		hook = useComponentsTreeSearch(core, q);
+	});
+
+	it("should match a component when the query is empty", () => {
+		q.value = "";
+		expect(hook.isComponentMatchingQuery(component)).toBe(true);
+	});
+
+	it("should match a component from its content", () => {
+		q.value = "tag1";
+		expect(hook.isComponentMatchingQuery(component)).toBe(true);
+	});
+
+	it("should match a component from its type", () => {
+		q.value = "button";
+		expect(hook.isComponentMatchingQuery(component)).toBe(true);
+	});
+
+	it("should not match a component", () => {
+		q.value = "foo";
+		expect(hook.isComponentMatchingQuery(component)).toBe(false);
+	});
+});
+
+describe(useComponentsTreeSearchForComponent.name, () => {
+	let core: ReturnType<typeof generateCore>;
+	const q = ref("");
+	const component1 = buildMockComponent({
+		id: "component1",
+		type: "button",
+		content: {
+			tag1: "Tag1",
+		},
+	});
+	const component2 = buildMockComponent({
+		id: "component2",
+		parentId: component1.id,
+		type: "button",
+		content: {
+			tag1: "Tag2",
+		},
+	});
+	let hook: ReturnType<typeof useComponentsTreeSearchForComponent>;
+
+	beforeAll(() => {
+		core = buildMockCore().core;
+		core.addComponent(component1);
+		core.addComponent(component2);
+		hook = useComponentsTreeSearchForComponent(
+			core,
+			q,
+			computed(() => component1),
+		);
+	});
+
+	it("should match a component when the query is empty", () => {
+		q.value = "";
+
+		expect(hook.hasMatchingChildren.value).toBe(true);
+		expect(hook.matched.value).toBe(true);
+	});
+
+	it("should match a component from its content", () => {
+		q.value = "tag1";
+
+		expect(hook.hasMatchingChildren.value).toBe(false);
+		expect(hook.matched.value).toBe(true);
+	});
+
+	it("should match a children from its content", () => {
+		q.value = "tag2";
+
+		expect(hook.hasMatchingChildren.value).toBe(true);
+		expect(hook.matched.value).toBe(false);
+	});
+
+	it("should not match a component", () => {
+		q.value = "foo";
+
+		expect(hook.hasMatchingChildren.value).toBe(false);
+		expect(hook.matched.value).toBe(false);
+	});
+});

--- a/src/ui/src/builder/sidebar/composables/useComponentsTreeSearch.ts
+++ b/src/ui/src/builder/sidebar/composables/useComponentsTreeSearch.ts
@@ -1,0 +1,67 @@
+import type { generateCore } from "@/core";
+import { computed, ComputedRef, Ref } from "vue";
+import { Component } from "@/writerTypes";
+
+export function useComponentsTreeSearch(
+	wf: ReturnType<typeof generateCore>,
+	query: ComputedRef<string> | Ref<string>,
+) {
+	function isComponentMatchingQuery(component: Component) {
+		if (!query.value) return true;
+
+		const def = wf.getComponentDefinition(component.type);
+		if (def?.name.toLocaleLowerCase().includes(query.value)) return true;
+
+		const matchingFields = Object.values(component.content).filter(
+			(fieldContent) =>
+				fieldContent.toLocaleLowerCase().includes(query.value),
+		);
+		if (matchingFields.length > 0) return true;
+
+		return false;
+	}
+
+	return { isComponentMatchingQuery };
+}
+
+export function useComponentsTreeSearchResults(
+	wf: ReturnType<typeof generateCore>,
+	query: ComputedRef<string> | Ref<string>,
+	rootId: ComputedRef<Component["id"]>,
+) {
+	const { isComponentMatchingQuery } = useComponentsTreeSearch(wf, query);
+
+	const searchResultCount = computed<undefined | number>(() => {
+		if (!query.value) return undefined;
+		let count = 0;
+
+		for (const c of wf.getComponentsNested(rootId.value)) {
+			if (isComponentMatchingQuery(c)) count++;
+		}
+		return count;
+	});
+
+	return { searchResultCount };
+}
+
+export function useComponentsTreeSearchForComponent(
+	wf: ReturnType<typeof generateCore>,
+	query: ComputedRef<string> | Ref<string>,
+	component: ComputedRef<Component>,
+) {
+	const { isComponentMatchingQuery } = useComponentsTreeSearch(wf, query);
+
+	const matched = computed(
+		() => !query.value || isComponentMatchingQuery(component.value),
+	);
+
+	const hasMatchingChildren = computed(() => {
+		if (!query.value) return true;
+		for (const c of wf.getComponentsNested(component.value.id)) {
+			if (isComponentMatchingQuery(c)) return true;
+		}
+		return false;
+	});
+
+	return { hasMatchingChildren, matched };
+}

--- a/src/ui/src/components/workflows/base/WorkflowNavigator.vue
+++ b/src/ui/src/components/workflows/base/WorkflowNavigator.vue
@@ -132,7 +132,7 @@ function toggleMiniMap() {
 	isMiniMapShown.value = !isMiniMapShown.value;
 }
 
-function handleAutoArrange(ev: MouseEvent) {
+function handleAutoArrange() {
 	emit("autoArrange");
 }
 

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -653,6 +653,27 @@ export function generateCore() {
 		return ca;
 	}
 
+	/**
+	 * Gets registered Writer Framework components with their child components
+	 *
+	 * @param parentId If specified, only include results that are children of a component with this id.
+	 * @param opts Whether to include Builder-managed components and code-managed components, and whether to sort.
+	 * @returns An iterable of components.
+	 */
+	function* getComponentsNested(
+		parentId?: Component["id"],
+		opts: {
+			includeBMC?: boolean;
+			includeCMC?: boolean;
+			sortedByPosition?: boolean;
+		} = {},
+	): Generator<Component> {
+		for (const component of getComponents(parentId, opts)) {
+			yield component;
+			yield* getComponentsNested(component.id, opts);
+		}
+	}
+
 	function setActivePageFromKey(targetPageKey: string) {
 		const pages = getComponents("root");
 		const matches = pages.filter((pageComponent) => {
@@ -693,6 +714,7 @@ export function generateCore() {
 		deleteComponent,
 		getComponentById,
 		getComponents,
+		getComponentsNested,
 		setActivePageId,
 		activePageId: readonly(activePageId),
 		setActivePageFromKey,

--- a/src/ui/src/renderer/ComponentRenderer.vue
+++ b/src/ui/src/renderer/ComponentRenderer.vue
@@ -22,15 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import {
-	inject,
-	ref,
-	computed,
-	watch,
-	ComputedRef,
-	onBeforeMount,
-	onMounted,
-} from "vue";
+import { inject, ref, computed, watch, onBeforeMount, onMounted } from "vue";
 import { Component } from "@/writerTypes";
 import ComponentProxy from "./ComponentProxy.vue";
 import RendererNotifications from "./RendererNotifications.vue";
@@ -48,11 +40,9 @@ const wfbm = inject(injectionKeys.builderManager);
 const templateEvaluator = useEvaluator(wf);
 const importedModulesSpecifiers: Record<string, string> = {};
 
-const activeRootId: ComputedRef<Component["id"]> = computed(() => {
-	if (!wfbm) return "root";
-	if (wfbm.getMode() == "workflows") return "workflows_root";
-	return "root";
-});
+const activeRootId = computed<Component["id"]>(
+	() => wfbm?.activeRootId.value ?? "root",
+);
 
 const coreRootFields = templateEvaluator.getEvaluatedFields([
 	{ componentId: "root", instanceNumber: 0 },

--- a/src/ui/src/wds/WdsTextInput.vue
+++ b/src/ui/src/wds/WdsTextInput.vue
@@ -1,14 +1,26 @@
 <template>
 	<div
-		v-if="leftIcon"
+		v-if="leftIcon || enableClearButton"
 		class="WdsTextInput WdsTextInput--leftIcon colorTransformer"
 		:class="{ 'WdsTextInput--ghost': variant === 'ghost' }"
 		v-bind="$attrs"
 		:aria-invalid="invalid"
+		:style="{
+			gridTemplateColumns: gridTemplateColumns,
+		}"
 		@click="focus"
 	>
-		<i class="material-symbols-outlined">{{ leftIcon }}</i>
+		<i v-if="leftIcon" class="material-symbols-outlined">{{ leftIcon }}</i>
 		<input ref="input" v-model="model" v-bind="$attrs" />
+		<p v-if="rightText" class="WdsTextInput__rightText">{{ rightText }}</p>
+		<button
+			v-if="enableClearButton && model"
+			class="WdsTextInput__clearBtn"
+			type="button"
+			@click="model = ''"
+		>
+			<i class="material-symbols-outlined">close</i>
+		</button>
 	</div>
 	<input
 		v-else
@@ -22,17 +34,19 @@
 </template>
 
 <script setup lang="ts">
-import { PropType, useTemplateRef } from "vue";
+import { computed, PropType, useTemplateRef } from "vue";
 
 const model = defineModel({ type: String });
 
 // disable attributes inheritance to apply attr to nested input
 defineOptions({ inheritAttrs: false });
 
-defineProps({
+const props = defineProps({
 	leftIcon: { type: String, required: false, default: undefined },
 	invalid: { type: Boolean, required: false },
 	variant: { type: String as PropType<"ghost">, default: undefined },
+	enableClearButton: { type: Boolean, required: false },
+	rightText: { type: String, required: false, default: "" },
 });
 
 defineExpose({
@@ -44,6 +58,17 @@ defineExpose({
 });
 
 const input = useTemplateRef("input");
+
+const gridTemplateColumns = computed(() =>
+	[
+		props.leftIcon ? "auto" : undefined,
+		"1fr",
+		props.rightText ? "auto" : undefined,
+		props.enableClearButton ? "auto" : undefined,
+	]
+		.filter(Boolean)
+		.join(" "),
+);
 
 function setSelectionStart(value: number) {
 	if (input.value) input.value.selectionStart = value;
@@ -100,7 +125,7 @@ function focus() {
 
 .WdsTextInput--leftIcon {
 	cursor: pointer;
-	display: flex;
+	display: grid;
 	align-items: center;
 	gap: 8px;
 }
@@ -119,6 +144,19 @@ function focus() {
 	border: none;
 	box-shadow: none;
 	outline: none;
+}
+
+.WdsTextInput__clearBtn {
+	border: none;
+	background-color: transparent;
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+}
+
+.WdsTextInput__rightText {
+	padding-left: 8px;
+	border-left: 2px solid var(--separatorColor);
 }
 
 .WdsTextInput[aria-invalid="true"] {


### PR DESCRIPTION
When searching for a component in the tree, we start to display only components matching the query, or those containing children matching the query.

It'll

- collapse component that doesn't match the query (with a small animation)
- display the number of matches
- allow to clear search with a button


Before

https://github.com/user-attachments/assets/0f0ca13e-711d-4861-9cbc-058acdd00012



After


https://github.com/user-attachments/assets/a31a137a-61e6-4811-a513-e536e88e9c40

