### PR TITLE
fix(ui): refresh ext. source file changes on code editor

### DIFF
--- a/src/ui/src/components/core/other/__snapshots__/CoreHtml.spec.ts.snap
+++ b/src/ui/src/components/core/other/__snapshots__/CoreHtml.spec.ts.snap
@@ -1,21 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CoreCheckboxInput > should filter invalid Attributes props 1`] = `
-<div
-  class="CoreHTML"
-  data-writer-container=""
-  style="color: red;"
-  valid="valid"
->
-  
-  slot
-  
-  <div>
-    inside
-  </div>
-</div>
-`;
-
 exports[`CoreHtml > should filter invalid Attributes props 1`] = `
 <div
   class="CoreHTML"

--- a/src/ui/src/components/shared/SharedMoreDropdown.vue
+++ b/src/ui/src/components/shared/SharedMoreDropdown.vue
@@ -59,7 +59,7 @@ const props = defineProps({
 	hideIcons: { type: Boolean, required: false },
 	dropdownPlacement: {
 		type: String as PropType<Placement>,
-		required: true,
+		required: false,
 		default: "bottom-end",
 	},
 	floatingMiddleware: {

--- a/src/ui/src/core/useSourceFiles.spec.ts
+++ b/src/ui/src/core/useSourceFiles.spec.ts
@@ -96,6 +96,60 @@ describe(useSourceFiles.name, () => {
 		expect(sourceFileDraft.value).toStrictEqual(sourceFiles.value);
 	});
 
+	it("should update a file to the draft", async () => {
+		const { core, sourceFiles } = buildMockCore();
+		sourceFiles.value = {
+			type: "directory",
+			children: {
+				"a.txt": { type: "file", content: "init", complete: true },
+				"b.txt": { type: "file", content: "init", complete: true },
+			},
+		};
+
+		const { sourceFileDraft, openFile, code, pathsUnsaved } =
+			useSourceFiles(core);
+		expect(pathsUnsaved.value).toHaveLength(0);
+		expect(sourceFileDraft.value).toStrictEqual(sourceFiles.value);
+
+		// open a file and start editing
+		openFile(["b.txt"]);
+		code.value = "unsaved changes";
+		expect(sourceFileDraft.value).toStrictEqual({
+			type: "directory",
+			children: {
+				"a.txt": { type: "file", content: "init", complete: true },
+				"b.txt": {
+					type: "file",
+					content: "unsaved changes",
+					complete: true,
+				},
+			},
+		});
+		expect(pathsUnsaved.value).toHaveLength(1);
+
+		// simulate loading new file
+		sourceFiles.value = {
+			type: "directory",
+			children: {
+				"a.txt": { type: "file", content: "after", complete: true },
+				"b.txt": { type: "file", content: "init", complete: true },
+			},
+		};
+
+		await flushPromises();
+		expect(sourceFileDraft.value).toStrictEqual({
+			type: "directory",
+			children: {
+				"a.txt": { type: "file", content: "after", complete: true },
+				"b.txt": {
+					type: "file",
+					content: "unsaved changes",
+					complete: true,
+				},
+			},
+		});
+	});
+
 	it("should remove a file to the draft", async () => {
 		const { core, sourceFiles } = buildMockCore();
 		sourceFiles.value = {


### PR DESCRIPTION
When user edits a source file with an external editor, we need to reflect this change in `sourceFileDraft` (monaco editor in the panel).