### PR TITLE
fix(ui): move only unselected node in worflow

### DIFF
--- a/src/ui/src/components/workflows/WorkflowsWorkflow.vue
+++ b/src/ui/src/components/workflows/WorkflowsWorkflow.vue
@@ -502,6 +502,19 @@ function moveNode(ev: MouseEvent) {
 	const translationX = newX - component.x;
 	const translationY = newY - component.y;
 
+	const isMovingNodeSelected = wfbm.selection.value.some(
+		(c) => c.componentId === nodeId,
+	);
+
+	if (!isMovingNodeSelected) {
+		// if the user moves a node that is not selected, we don't move other selected nodes
+		temporaryNodeCoordinates.value = {
+			...temporaryNodeCoordinates.value,
+			[nodeId]: { x: newX, y: newY },
+		};
+		return;
+	}
+
 	// apply the same vector to other selected components
 	const otherSelectedComponents = wfbm.selection.value
 		.map((c) => wf.getComponentById(c.componentId))


### PR DESCRIPTION
if the user moves a node that is not selected, we don't move the other selected node.

https://github.com/user-attachments/assets/f771e4fd-d751-4850-a8f7-bba3d8ae7ac9

