### PR TITLE
fix(ui): use word break in tooltip

### DIFF
--- a/src/ui/src/builder/BuilderTooltip.vue
+++ b/src/ui/src/builder/BuilderTooltip.vue
@@ -183,5 +183,6 @@ onUnmounted(() => {
 	margin: 4px;
 	position: relative;
 	z-index: 1;
+	word-break: break-word;
 }
 </style>


### PR DESCRIPTION
| before | after |
|---|---|
| ![Screenshot 2025-02-20 at 17 49 09](https://github.com/user-attachments/assets/1da4cd79-0d5a-4176-be27-df9549b50e3e) | ![Screenshot 2025-02-20 at 17 48 57](https://github.com/user-attachments/assets/89f0e167-8388-4efd-a417-19b604f2a48c) |
