### PR TITLE
feat: Announcement queue with mail support

### DIFF
--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -213,12 +213,22 @@ export function generateCore() {
 
 			if (
 				message.messageType == "announcement" &&
-				message.payload.announce == "codeUpdate"
+				message.payload.type == "codeUpdate"
 			) {
 				webSocket.close();
 				initSession();
 				return;
-			} else if (
+			}
+
+			if (
+				message.messageType == "announcement" &&
+				message.payload.type == "mail"
+			) {
+				collateMail(message.payload.payload);
+				return;
+			}
+
+			if (
 				message.messageType == "eventResponse" ||
 				message.messageType == "stateEnquiryResponse"
 			) {

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -695,7 +695,6 @@ class AppRunner:
                     }
                 ],
             )
-            # TODO(WF-170): find a way to dispatch log
         except Exception as e:
             logger.warning(f"Unexpected error: {e}")
 

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 import threading
 from types import ModuleType
-from typing import Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, cast
 
 import watchdog.events
 from pydantic import ValidationError
@@ -54,7 +54,7 @@ from writer.ss_types import (
 )
 from writer.wf_project import WfProjectContext
 
-logging.basicConfig(level=logging.INFO, format='%(message)s')
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 
 class MessageHandlingException(Exception):
@@ -62,15 +62,13 @@ class MessageHandlingException(Exception):
 
 
 class SessionPruner(threading.Thread):
-
     """
     Prunes sessions in intervals, without interfering with the AppProcess server thread.
     """
 
     PRUNE_SESSIONS_INTERVAL_SECONDS = 60
 
-    def __init__(self,
-                 is_session_pruner_terminated: threading.Event):
+    def __init__(self, is_session_pruner_terminated: threading.Event):
         super().__init__(name="SessionPrunerThread")
         self.is_session_pruner_terminated = is_session_pruner_terminated
 
@@ -79,28 +77,30 @@ class SessionPruner(threading.Thread):
 
         while True:
             self.is_session_pruner_terminated.wait(
-                timeout=SessionPruner.PRUNE_SESSIONS_INTERVAL_SECONDS)
+                timeout=SessionPruner.PRUNE_SESSIONS_INTERVAL_SECONDS
+            )
             if self.is_session_pruner_terminated.is_set():
                 return
             writer.session_manager.prune_sessions()
 
 
 class AppProcess(multiprocessing.Process):
-
     """
     Writer Framework runs the user's app code using an isolated process, based on this class.
     The main process is able to communicate with the user app process via app messages (e.g. event, componentUpdate).
     """
 
-    def __init__(self,
-                 client_conn: multiprocessing.connection.Connection,
-                 server_conn: multiprocessing.connection.Connection,
-                 app_path: str,
-                 mode: ServeMode,
-                 run_code: str,
-                 bmc_components: Dict,
-                 is_app_process_server_ready: multiprocessing.synchronize.Event,
-                 is_app_process_server_failed: multiprocessing.synchronize.Event):
+    def __init__(
+        self,
+        client_conn: multiprocessing.connection.Connection,
+        server_conn: multiprocessing.connection.Connection,
+        app_path: str,
+        mode: ServeMode,
+        run_code: str,
+        bmc_components: Dict,
+        is_app_process_server_ready: multiprocessing.synchronize.Event,
+        is_app_process_server_failed: multiprocessing.synchronize.Event,
+    ):
         super().__init__(name="AppProcess")
         self.client_conn = client_conn
         self.server_conn = server_conn
@@ -109,11 +109,10 @@ class AppProcess(multiprocessing.Process):
         self.run_code = run_code
         self.bmc_components = bmc_components
         self.is_app_process_server_ready = is_app_process_server_ready
-        self.is_app_process_server_failed = is_app_process_server_failed 
+        self.is_app_process_server_failed = is_app_process_server_failed
         self.logger = logging.getLogger("app")
         self.handler_registry = EventHandlerRegistry()
         self.middleware_registry = MiddlewareRegistry()
-
 
     def _load_module(self) -> ModuleType:
         """
@@ -137,7 +136,9 @@ class AppProcess(multiprocessing.Process):
         """
         return self.handler_registry.gather_handler_meta()
 
-    def _handle_session_init(self, payload: InitSessionRequestPayload) -> InitSessionResponsePayload:
+    def _handle_session_init(
+        self, payload: InitSessionRequestPayload
+    ) -> InitSessionResponsePayload:
         """
         Handles session initialisation and provides a starter pack.
         """
@@ -146,9 +147,13 @@ class AppProcess(multiprocessing.Process):
 
         import writer
 
-        session = writer.session_manager.get_session(payload.proposedSessionId, restore_initial_mail=True)
+        session = writer.session_manager.get_session(
+            payload.proposedSessionId, restore_initial_mail=True
+        )
         if session is None:
-            session = writer.session_manager.get_new_session(payload.cookies, payload.headers, payload.proposedSessionId)
+            session = writer.session_manager.get_new_session(
+                payload.cookies, payload.headers, payload.proposedSessionId
+            )
 
         if session is None:
             raise MessageHandlingException("Session rejected.")
@@ -157,11 +162,11 @@ class AppProcess(multiprocessing.Process):
         try:
             user_state = session.session_state.user_state.to_dict()
         except BaseException:
-            session.session_state.add_log_entry(
-                "error", "Serialisation error", tb.format_exc())
+            session.session_state.add_log_entry("error", "Serialisation error", tb.format_exc())
 
         ui_component_tree = core_ui.export_component_tree(
-            session.session_component_tree, mode=writer.Config.mode)
+            session.session_component_tree, mode=writer.Config.mode
+        )
 
         res_payload = InitSessionResponsePayload(
             userState=user_state,
@@ -169,7 +174,7 @@ class AppProcess(multiprocessing.Process):
             mail=session.session_state.mail,
             components=ui_component_tree,
             userFunctions=self._get_user_functions(),
-            featureFlags=writer.Config.feature_flags
+            featureFlags=writer.Config.feature_flags,
         )
 
         session.session_state.clear_mail()
@@ -186,21 +191,21 @@ class AppProcess(multiprocessing.Process):
         try:
             mutations = session.session_state.user_state.get_mutations_as_dict()
         except BaseException:
-            session.session_state.add_log_entry("error",
-                                                "Serialisation Error",
-                                                "An exception was raised during serialisation.",
-                                                tb.format_exc())
+            session.session_state.add_log_entry(
+                "error",
+                "Serialisation Error",
+                "An exception was raised during serialisation.",
+                tb.format_exc(),
+            )
 
         mail = session.session_state.mail
 
         ui_component_tree = core_ui.export_component_tree(
-            session.session_component_tree, mode=Config.mode, only_update=True)
+            session.session_component_tree, mode=Config.mode, only_update=True
+        )
 
         res_payload = EventResponsePayload(
-            result=result,
-            mutations=mutations,
-            components=ui_component_tree,
-            mail=mail
+            result=result, mutations=mutations, components=ui_component_tree, mail=mail
         )
         session.session_state.clear_mail()
 
@@ -214,17 +219,16 @@ class AppProcess(multiprocessing.Process):
         try:
             mutations = session.session_state.user_state.get_mutations_as_dict()
         except BaseException:
-            session.session_state.add_log_entry("error",
-                                                "Serialisation Error",
-                                                "An exception was raised during serialisation.",
-                                                tb.format_exc())
+            session.session_state.add_log_entry(
+                "error",
+                "Serialisation Error",
+                "An exception was raised during serialisation.",
+                tb.format_exc(),
+            )
 
         mail = session.session_state.mail
 
-        res_payload = StateEnquiryResponsePayload(
-            mutations=mutations,
-            mail=mail
-        )
+        res_payload = StateEnquiryResponsePayload(mutations=mutations, mail=mail)
 
         session.session_state.clear_mail()
 
@@ -236,25 +240,31 @@ class AppProcess(multiprocessing.Process):
             serialized_state = session.session_state.user_state.to_raw_state()
         except BaseException:
             import traceback as tb
-            session.session_state.add_log_entry("error",
-                                                "Serialisation Error",
-                                                "An exception was raised during serialisation.",
-                                                tb.format_exc())
+
+            session.session_state.add_log_entry(
+                "error",
+                "Serialisation Error",
+                "An exception was raised during serialisation.",
+                tb.format_exc(),
+            )
 
         return StateContentResponsePayload(state=serialized_state)
 
     def _handle_hash_request(self, req_payload: HashRequestPayload) -> HashRequestResponsePayload:
-        res_payload = HashRequestResponsePayload(
-            message=crypto.get_hash(req_payload.message)
-        )
+        res_payload = HashRequestResponsePayload(message=crypto.get_hash(req_payload.message))
         return res_payload
 
-    def _handle_component_update(self, session: WriterSession, payload: ComponentUpdateRequestPayload) -> None:
+    def _handle_component_update(
+        self, session: WriterSession, payload: ComponentUpdateRequestPayload
+    ) -> None:
         import writer
+
         ingest_bmc_component_tree(writer.base_component_tree, payload.components)
         ingest_bmc_component_tree(session.session_component_tree, payload.components, True)
 
-    def _handle_message(self, session_id: str, request: AppProcessServerRequest) -> AppProcessServerResponse:
+    def _handle_message(
+        self, session_id: str, request: AppProcessServerRequest
+    ) -> AppProcessServerResponse:
         """
         Handles messages from the main process to the app's isolated process.
         """
@@ -265,12 +275,11 @@ class AppProcess(multiprocessing.Process):
             type = request.type
 
             if type == "sessionInit":
-                si_req_payload = InitSessionRequestPayload.parse_obj(
-                    request.payload)
+                si_req_payload = InitSessionRequestPayload.parse_obj(request.payload)
                 return AppProcessServerResponse(
                     status="ok",
                     status_message=None,
-                    payload=self._handle_session_init(si_req_payload)
+                    payload=self._handle_session_init(si_req_payload),
                 )
 
             session = writer.session_manager.get_session(session_id)
@@ -279,59 +288,42 @@ class AppProcess(multiprocessing.Process):
             session.update_last_active_timestamp()
 
             if type == "checkSession":
-                return AppProcessServerResponse(
-                    status="ok",
-                    status_message=None,
-                    payload=None
-                )
+                return AppProcessServerResponse(status="ok", status_message=None, payload=None)
 
             if type == "event":
                 ev_req_payload = WriterEvent.parse_obj(request.payload)
                 return AppProcessServerResponse(
                     status="ok",
                     status_message=None,
-                    payload=self._handle_event(session, ev_req_payload)
+                    payload=self._handle_event(session, ev_req_payload),
                 )
 
             if type == "stateEnquiry":
                 return AppProcessServerResponse(
-                    status="ok",
-                    status_message=None,
-                    payload=self._handle_state_enquiry(session)
+                    status="ok", status_message=None, payload=self._handle_state_enquiry(session)
                 )
 
             if type == "stateContent":
                 return AppProcessServerResponse(
-                    status="ok",
-                    status_message=None,
-                    payload=self._handle_state_content(session)
+                    status="ok", status_message=None, payload=self._handle_state_content(session)
                 )
 
             if type == "setUserinfo":
                 session.userinfo = request.payload
-                return AppProcessServerResponse(
-                    status="ok",
-                    status_message=None,
-                    payload=None
-                )
+                return AppProcessServerResponse(status="ok", status_message=None, payload=None)
 
             if self.mode == "edit" and type == "hashRequest":
                 hash_request_payload = HashRequestPayload.model_validate(request.payload)
                 return AppProcessServerResponse(
                     status="ok",
                     status_message=None,
-                    payload=self._handle_hash_request(hash_request_payload)
+                    payload=self._handle_hash_request(hash_request_payload),
                 )
 
             if self.mode == "edit" and type == "componentUpdate":
-                cu_req_payload = ComponentUpdateRequestPayload.parse_obj(
-                    request.payload)
+                cu_req_payload = ComponentUpdateRequestPayload.parse_obj(request.payload)
                 self._handle_component_update(session, cu_req_payload)
-                return AppProcessServerResponse(
-                    status="ok",
-                    status_message=None,
-                    payload=None
-                )
+                return AppProcessServerResponse(status="ok", status_message=None, payload=None)
 
             raise MessageHandlingException("Invalid event.")
 
@@ -357,7 +349,8 @@ class AppProcess(multiprocessing.Process):
 
         if captured_stdout:
             writer.core.initial_state.add_log_entry(
-                "info", "Stdout message during initialization", captured_stdout)
+                "info", "Stdout message during initialization", captured_stdout
+            )
 
         # Register non-private functions as handlers
         self.handler_registry.register_module(writeruserapp)
@@ -382,6 +375,7 @@ class AppProcess(multiprocessing.Process):
     def _main(self) -> None:
         self._apply_configuration()
         import os
+
         os.chdir(self.app_path)
         self._load_module()
         # Allows for relative imports from the app's path
@@ -397,7 +391,11 @@ class AppProcess(multiprocessing.Process):
             ingest_bmc_component_tree(writer.base_component_tree, self.bmc_components)
         except BaseException:
             writer.core.initial_state.add_log_entry(
-                "error", "UI Components Error", "Couldn't load components. An exception was raised.", tb.format_exc())
+                "error",
+                "UI Components Error",
+                "Couldn't load components. An exception was raised.",
+                tb.format_exc(),
+            )
             if self.mode == "run":
                 terminate_early = True
 
@@ -407,10 +405,14 @@ class AppProcess(multiprocessing.Process):
             # Initialisation errors will be sent to all sessions via mail during session initialisation
 
             writer.core.initial_state.add_log_entry(
-                "error", "Code Error", "Couldn't execute code. An exception was raised.", tb.format_exc())
-            
+                "error",
+                "Code Error",
+                "Couldn't execute code. An exception was raised.",
+                tb.format_exc(),
+            )
+
             # Exit if in run mode
-            
+
             if self.mode == "run":
                 terminate_early = True
 
@@ -420,19 +422,18 @@ class AppProcess(multiprocessing.Process):
 
         self._run_app_process_server()
 
-    def _handle_message_and_get_packet(self, message_id: int, session_id: str, request: AppProcessServerRequest) -> AppProcessServerResponsePacket:
+    def _handle_message_and_get_packet(
+        self, message_id: int, session_id: str, request: AppProcessServerRequest
+    ) -> AppProcessServerResponsePacket:
         response = None
         try:
             response = self._handle_message(session_id, request)
         except (MessageHandlingException, ValidationError) as e:
             response = AppProcessServerResponse(
-                status="error",
-                status_message=repr(e),
-                payload=None
+                status="error", status_message=repr(e), payload=None
             )
 
-        packet: AppProcessServerResponsePacket = (
-            message_id, session_id, response)
+        packet: AppProcessServerResponsePacket = (message_id, session_id, response)
         return packet
 
     def _send_packet(self, packet_future: concurrent.futures.Future) -> None:
@@ -443,8 +444,7 @@ class AppProcess(multiprocessing.Process):
 
     def _run_app_process_server(self) -> None:
         is_app_process_server_terminated = threading.Event()
-        session_pruner = SessionPruner(
-            is_app_process_server_terminated)
+        session_pruner = SessionPruner(is_app_process_server_terminated)
         session_pruner.start()
 
         def terminate_server():
@@ -481,15 +481,17 @@ class AppProcess(multiprocessing.Process):
                     terminate_server()
                     return
                 except BaseException as e:
-                    logging.error(
-                        f"Unexpected exception in AppProcess server.\n{repr(e)}")
+                    self.logger.error(f"Unexpected exception in AppProcess server.\n{repr(e)}")
                     terminate_server()
                     return
 
-    def _handle_app_process_server_packet(self, packet: AppProcessServerRequestPacket, thread_pool) -> None:
+    def _handle_app_process_server_packet(
+        self, packet: AppProcessServerRequestPacket, thread_pool
+    ) -> None:
         (message_id, session_id, request) = packet
-        thread_pool_future = thread_pool.submit(self._handle_message_and_get_packet,
-                                                message_id, session_id, request)
+        thread_pool_future = thread_pool.submit(
+            self._handle_message_and_get_packet, message_id, session_id, request
+        )
         thread_pool_future.add_done_callback(self._send_packet)
 
     def run(self) -> None:
@@ -499,15 +501,18 @@ class AppProcess(multiprocessing.Process):
 
 
 class FileEventHandler(watchdog.events.PatternMatchingEventHandler):
-
     """
     Watches for changes in files and triggers code reloads.
     """
 
     def __init__(self, update_callback: Callable, patterns: List[str]):
         self.update_callback = update_callback
-        super().__init__(patterns=patterns, ignore_patterns=[
-            ".*"], ignore_directories=False, case_sensitive=False)
+        super().__init__(
+            patterns=patterns,
+            ignore_patterns=[".*"],
+            ignore_directories=False,
+            case_sensitive=False,
+        )
 
     def on_any_event(self, event) -> None:
         if event.event_type not in ("modified", "deleted", "created"):
@@ -516,8 +521,7 @@ class FileEventHandler(watchdog.events.PatternMatchingEventHandler):
 
 
 class ThreadSafeAsyncEvent(asyncio.Event):
-
-    """ Asyncio event adapted to be thread-safe."""
+    """Asyncio event adapted to be thread-safe."""
 
     def __init__(self):
         super().__init__()
@@ -529,17 +533,18 @@ class ThreadSafeAsyncEvent(asyncio.Event):
 
 
 class AppProcessListener(threading.Thread):
-
     """
     Listens to messages from the AppProcess server.
-    Notifies receipt via events in response_events and makes the responses available in response_packets.  
+    Notifies receipt via events in response_events and makes the responses available in response_packets.
     """
 
-    def __init__(self,
-                 client_conn: multiprocessing.connection.Connection,
-                 is_app_process_server_ready: multiprocessing.synchronize.Event,
-                 response_packets: Dict,
-                 response_events: Dict):
+    def __init__(
+        self,
+        client_conn: multiprocessing.connection.Connection,
+        is_app_process_server_ready: multiprocessing.synchronize.Event,
+        response_packets: Dict,
+        response_events: Dict,
+    ):
         super().__init__(name="AppProcessListenerThread")
         self.client_conn = client_conn
         self.is_app_process_server_ready = is_app_process_server_ready
@@ -554,7 +559,7 @@ class AppProcessListener(threading.Thread):
             try:
                 packet = self.client_conn.recv()
             except OSError:
-                logging.error("Connection to AppProcess closed.")
+                self.logger.error("Connection to AppProcess closed.")
                 return
             if packet is None:
                 return
@@ -564,19 +569,16 @@ class AppProcessListener(threading.Thread):
             if response_event:
                 response_event.set()
             else:
-                raise ValueError(
-                    f"No response event found for message {message_id}.")
+                raise ValueError(f"No response event found for message {message_id}.")
 
 
 class LogListener(threading.Thread):
-
     """
     Logs messages stored in the multiprocessing queue.
-    This allows log messages from the AppProcess to be safely managed.  
+    This allows log messages from the AppProcess to be safely managed.
     """
 
-    def __init__(self,
-                 log_queue: multiprocessing.Queue):
+    def __init__(self, log_queue: multiprocessing.Queue):
         super().__init__(name="LogListenerThread")
         self.log_queue = log_queue
         self.logger = logging.getLogger("from_app")
@@ -592,7 +594,6 @@ class LogListener(threading.Thread):
 
 
 class AppRunner:
-
     """
     Starts a given user app in a separate process.
     Manages changes to the app.
@@ -620,8 +621,8 @@ class AppRunner:
         self.message_counter = 0
         self.log_queue: multiprocessing.Queue = multiprocessing.Queue()
         self.log_listener: Optional[LogListener] = None
-        self.code_update_loop: Optional[asyncio.AbstractEventLoop] = None
-        self.code_update_condition: Optional[asyncio.Condition] = None
+        self.serve_loop: Optional[asyncio.AbstractEventLoop] = None
+        self.announcement_queue: Optional[asyncio.Queue] = None
         self.wf_project_context = WfProjectContext(app_path=app_path)
 
         if mode not in ("edit", "run"):
@@ -631,14 +632,13 @@ class AppRunner:
         self._set_logger()
 
     def hook_to_running_event_loop(self):
-
         """
-        Sets the properties required to notify the web server of the code update. 
-        Should be performed from the event loop which will consume the notification.
+        Sets the properties required to notify the web server of the announcements.
+        Should be performed from the event loop which will consume the notifications.
         """
 
-        self.code_update_loop = asyncio.get_running_loop()
-        self.code_update_condition = asyncio.Condition()
+        self.serve_loop = asyncio.get_running_loop()
+        self.announcement_queue = asyncio.Queue()
 
     def _set_logger(self):
         logger = logging.getLogger("app")
@@ -648,20 +648,29 @@ class AppRunner:
 
     def _start_fs_observer(self):
         self.observer = PollingObserver(AppRunner.UPDATE_CHECK_INTERVAL_SECONDS)
-        self.observer.schedule(FileEventHandler(self.reload_code_from_saved, patterns=["*.py"]), path=self.app_path, recursive=True)
-        self.observer.schedule(FileEventHandler(self._install_requirements, patterns=["requirements.txt"]), path=self.app_path)
+        self.observer.schedule(
+            FileEventHandler(self.reload_code_from_saved, patterns=["*.py"]),
+            path=self.app_path,
+            recursive=True,
+        )
+        self.observer.schedule(
+            FileEventHandler(self._install_requirements, patterns=["requirements.txt"]),
+            path=self.app_path,
+        )
         self.observer.start()
 
     def _start_wf_project_process_write_files(self):
-        wf_project.start_process_write_files_async(self.wf_project_context, AppRunner.WF_PROJECT_SAVE_INTERVAL)
+        wf_project.start_process_write_files_async(
+            self.wf_project_context, AppRunner.WF_PROJECT_SAVE_INTERVAL
+        )
 
     def _install_requirements(self) -> None:
-        logger = logging.getLogger('writer')
+        logger = logging.getLogger("writer")
         logger.debug("\nDetected changes in requirements.txt. Installing dependencies...")
         try:
             # Run pip install command
             subprocess.run(
-                ["pip", "install", "-r", "requirements.txt"], 
+                ["pip", "install", "-r", "requirements.txt"],
                 check=True,
                 capture_output=True,
                 text=True,
@@ -672,6 +681,20 @@ class AppRunner:
             self.reload_code_from_saved()
         except subprocess.CalledProcessError as e:
             logger.warning(f"Error installing dependencies: {e.stderr}")
+            self.queue_announcement(
+                "mail",
+                [
+                    {
+                        "type": "logEntry",
+                        "payload": {
+                            "type": "error",
+                            "title": "Error installing dependencies",
+                            "message": "The dependencies specified on `requirements.txt` could not be installed.",
+                            "code": e.stderr,
+                        },
+                    }
+                ],
+            )
             # TODO(WF-170): find a way to dispatch log
         except Exception as e:
             logger.warning(f"Unexpected error: {e}")
@@ -694,8 +717,9 @@ class AppRunner:
         # parent pid and pid.
         self._subscribe_terminal_signal()
 
-    async def dispatch_message(self, session_id: Optional[str], request: AppProcessServerRequest) -> AppProcessServerResponse:
-
+    async def dispatch_message(
+        self, session_id: Optional[str], request: AppProcessServerRequest
+    ) -> AppProcessServerResponse:
         """
         Sends a message to the AppProcess server, waits for the listener to obtain a response and returns it.
         """
@@ -704,44 +728,40 @@ class AppRunner:
         self.message_counter += 1
         is_response_ready = ThreadSafeAsyncEvent()
         self.response_events[message_id] = is_response_ready
-        packet: AppProcessServerRequestPacket = (
-            message_id, session_id, request)
+        packet: AppProcessServerRequestPacket = (message_id, session_id, request)
 
         if self.client_conn is None:
-            raise ValueError(
-                "Cannot dispatch message. No connection to AppProcess server is set.")
+            raise ValueError("Cannot dispatch message. No connection to AppProcess server is set.")
         self.client_conn.send(packet)
 
         await is_response_ready.wait()  # Set by the listener thread
 
         response_packet = self.response_packets.get(message_id)
         if response_packet is None:
-            raise ValueError(
-                f"Empty packet received in response to message {message_id}.")
+            raise ValueError(f"Empty packet received in response to message {message_id}.")
         response_message_id, response_session_id, response = response_packet
         del self.response_packets[message_id]
         del self.response_events[message_id]
-        if (session_id != response_session_id):
+        if session_id != response_session_id:
             raise PermissionError("Session mismatch.")
-        if (message_id != response_message_id):
+        if message_id != response_message_id:
             raise PermissionError("Message mismatch.")
 
         return response
 
-
-    def create_persisted_script(self, file = "main.py"):
+    def create_persisted_script(self, file="main.py"):
         path = os.path.join(self.app_path, file)
         self._check_file_in_app_path(path)
 
-        with open(path, "x", encoding='utf-8') as f:
-            f.write('')
+        with open(path, "x", encoding="utf-8") as f:
+            f.write("")
 
         self.source_files = wf_project.build_source_files(self.app_path)
 
     def rename_persisted_script(self, from_path: str, to_path: str):
-        if from_path == 'main.py':
+        if from_path == "main.py":
             raise PermissionError("cannot rename main script")
-        if to_path == 'main.py':
+        if to_path == "main.py":
             raise PermissionError("cannot overwrite main script")
 
         from_path_abs = os.path.join(self.app_path, from_path)
@@ -756,7 +776,7 @@ class AppRunner:
         self.source_files = wf_project.build_source_files(self.app_path)
 
     def delete_persisted_script(self, file: str):
-        if file == 'main.py':
+        if file == "main.py":
             raise PermissionError("cannot delete main script")
 
         path = os.path.join(self.app_path, file)
@@ -769,14 +789,14 @@ class AppRunner:
 
         self.source_files = wf_project.build_source_files(self.app_path)
 
-    def load_persisted_script(self, file = "main.py") -> str:
+    def load_persisted_script(self, file="main.py") -> str:
         path = os.path.join(self.app_path, file)
         self._check_file_in_app_path(path)
 
-        logger = logging.getLogger('writer')
+        logger = logging.getLogger("writer")
         try:
             contents = None
-            with open(path, "r", encoding='utf-8') as f:
+            with open(path, "r", encoding="utf-8") as f:
                 contents = f.read()
             return contents
         except FileNotFoundError as error:
@@ -790,13 +810,14 @@ class AppRunner:
         if not os.path.abspath(path).startswith(os.path.abspath((self.app_path))):
             raise PermissionError(f"{path} is outside of application ({self.app_path})")
 
-
     def _load_persisted_components(self) -> Dict[str, ComponentDefinition]:
-        logger = logging.getLogger('writer')
+        logger = logging.getLogger("writer")
         if os.path.isfile(os.path.join(self.app_path, "ui.json")):
             wf_project.migrate_obsolete_ui_json(self.app_path, metadata={"writer_version": VERSION})
 
-        if not os.path.isfile(os.path.join(self.app_path, ".wf", 'components-workflows_root.jsonl')):
+        if not os.path.isfile(
+            os.path.join(self.app_path, ".wf", "components-workflows_root.jsonl")
+        ):
             wf_project.create_default_workflows_root(self.app_path)
 
         if not os.path.isdir(os.path.join(self.app_path, ".wf")):
@@ -808,48 +829,46 @@ class AppRunner:
         return components
 
     async def check_session(self, session_id: str) -> bool:
-        response = await self.dispatch_message(session_id, AppProcessServerRequest(
-            type="checkSession",
-            payload=None
-        ))
+        response = await self.dispatch_message(
+            session_id, AppProcessServerRequest(type="checkSession", payload=None)
+        )
         is_ok: bool = response.status == "ok"
         return is_ok
 
     async def init_session(self, payload: InitSessionRequestPayload) -> AppProcessServerResponse:
-        return await self.dispatch_message(None, InitSessionRequest(
-            type="sessionInit",
-            payload=payload
-        ))    
+        return await self.dispatch_message(
+            None, InitSessionRequest(type="sessionInit", payload=payload)
+        )
 
-    async def update_components(self, session_id: str, payload: ComponentUpdateRequestPayload) -> AppProcessServerResponse:
+    async def update_components(
+        self, session_id: str, payload: ComponentUpdateRequestPayload
+    ) -> AppProcessServerResponse:
         if self.mode != "edit":
-            raise PermissionError(
-                "Cannot update components in non-update mode.")
+            raise PermissionError("Cannot update components in non-update mode.")
         self.bmc_components = payload.components
 
-        wf_project.write_files_async(self.wf_project_context, metadata={"writer_version": VERSION}, components=payload.components)
+        wf_project.write_files_async(
+            self.wf_project_context,
+            metadata={"writer_version": VERSION},
+            components=payload.components,
+        )
 
-        return await self.dispatch_message(session_id, ComponentUpdateRequest(
-            type="componentUpdate",
-            payload=payload
-        ))
+        return await self.dispatch_message(
+            session_id, ComponentUpdateRequest(type="componentUpdate", payload=payload)
+        )
 
     async def handle_event(self, session_id: str, event: WriterEvent) -> AppProcessServerResponse:
-        return await self.dispatch_message(session_id, EventRequest(
-            type="event",
-            payload=event
-        ))
+        return await self.dispatch_message(session_id, EventRequest(type="event", payload=event))
 
-    async def handle_hash_request(self, session_id: str, payload: HashRequestPayload) -> AppProcessServerResponse:
-        return await self.dispatch_message(session_id, HashRequest(
-            type="hashRequest",
-            payload=payload
-        ))
+    async def handle_hash_request(
+        self, session_id: str, payload: HashRequestPayload
+    ) -> AppProcessServerResponse:
+        return await self.dispatch_message(
+            session_id, HashRequest(type="hashRequest", payload=payload)
+        )
 
     async def handle_state_enquiry(self, session_id: str) -> AppProcessServerResponse:
-        return await self.dispatch_message(session_id, StateEnquiryRequest(
-            type="stateEnquiry"
-        ))
+        return await self.dispatch_message(session_id, StateEnquiryRequest(type="stateEnquiry"))
 
     async def handle_state_content(self, session_id: str) -> AppProcessServerResponse:
         """
@@ -857,11 +876,9 @@ class AppRunner:
 
         It is only accessible through tests
         """
-        return await self.dispatch_message(session_id, StateContentRequest(
-            type="stateContent"
-        ))
+        return await self.dispatch_message(session_id, StateContentRequest(type="stateContent"))
 
-    def save_code(self, session_id: str, code: str, path: List[str] = ['main.py']) -> None:
+    def save_code(self, session_id: str, code: str, path: List[str] = ["main.py"]) -> None:
         if self.mode != "edit":
             raise PermissionError("Cannot save code in non-edit mode.")
 
@@ -916,12 +933,15 @@ class AppRunner:
         if self.run_code is None:
             raise ValueError("Cannot start app process. Code hasn't been set.")
         if self.bmc_components is None:
-            raise ValueError(
-                "Cannot start app process. Components haven't been set.")
+            raise ValueError("Cannot start app process. Components haven't been set.")
         self.is_app_process_server_ready.clear()
         client_conn, server_conn = multiprocessing.Pipe(duplex=True)
-        self.client_conn = cast(multiprocessing.connection.Connection, client_conn)  # for mypy type checking on windows
-        self.server_conn = cast(multiprocessing.connection.Connection, server_conn)  # for mypy type checking on windows
+        self.client_conn = cast(
+            multiprocessing.connection.Connection, client_conn
+        )  # for mypy type checking on windows
+        self.server_conn = cast(
+            multiprocessing.connection.Connection, server_conn
+        )  # for mypy type checking on windows
 
         self.app_process = AppProcess(
             client_conn=self.client_conn,
@@ -931,13 +951,15 @@ class AppRunner:
             run_code=self.run_code,
             bmc_components=self.bmc_components,
             is_app_process_server_ready=self.is_app_process_server_ready,
-            is_app_process_server_failed=self.is_app_process_server_failed)
+            is_app_process_server_failed=self.is_app_process_server_failed,
+        )
         self.app_process.start()
         self.app_process_listener = AppProcessListener(
             self.client_conn,
             self.is_app_process_server_ready,
             self.response_packets,
-            self.response_events)
+            self.response_events,
+        )
         self.app_process_listener.start()
         self.is_app_process_server_ready.wait()
         if self.mode == "run" and self.is_app_process_server_failed.is_set():
@@ -950,7 +972,6 @@ class AppRunner:
         self.update_code(None, self.load_persisted_script())
 
     def update_code(self, session_id: Optional[str], run_code: str) -> None:
-
         """
         Updates the running code and notifies the update.
         In order to notify of the update, the event loop and asyncio.Condition need
@@ -966,24 +987,29 @@ class AppRunner:
         self._clean_process()
         self._start_app_process()
         self.is_app_process_server_ready.wait()
-        
-        if self.code_update_loop is not None and self.code_update_condition is not None:
-            future = asyncio.run_coroutine_threadsafe(self.notify_of_code_update(), self.code_update_loop)
-            future.result(AppRunner.MAX_WAIT_NOTIFY_SECONDS)
+        self.queue_announcement("codeUpdate", None)
 
-    async def notify_of_code_update(self):
-        await self.code_update_condition.acquire()
-        try:
-            self.code_update_condition.notify_all()
-        finally:
-            self.code_update_condition.release()
+    def queue_announcement(self, type, payload):
+        async def announce(type: str, payload: Any):
+            if self.announcement_queue is None:
+                return
+            await self.announcement_queue.put({"type": type, "payload": payload})
+
+        if self.serve_loop is not None and self.announcement_queue is not None:
+            try:
+                future = asyncio.run_coroutine_threadsafe(announce(type, payload), self.serve_loop)
+                future.result(AppRunner.MAX_WAIT_NOTIFY_SECONDS)
+            except (
+                RuntimeError,
+                concurrent.futures.CancelledError,
+                concurrent.futures.TimeoutError,
+            ):
+                # Ignore errors that occur during pytest runs where serve_loop may be closed
+                pass
 
     def set_userinfo(self, session_id: str, userinfo: dict) -> None:
         def run_async_in_thread():
-            message = AppProcessServerRequest(
-                type="setUserinfo",
-                payload=userinfo
-            )
+            message = AppProcessServerRequest(type="setUserinfo", payload=userinfo)
 
             asyncio.run(self.dispatch_message(session_id, message))
 

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -550,6 +550,7 @@ class AppProcessListener(threading.Thread):
         self.is_app_process_server_ready = is_app_process_server_ready
         self.response_packets = response_packets
         self.response_events = response_events
+        self.logger = logging.getLogger("writer")
 
     def run(self) -> None:
         self.is_app_process_server_ready.wait()

--- a/tests/backend/test_app_runner.py
+++ b/tests/backend/test_app_runner.py
@@ -1,4 +1,3 @@
-
 import asyncio
 import threading
 
@@ -16,12 +15,11 @@ from tests.backend import test_app_dir
 
 
 class TestAppRunner:
-
     numberinput_instance_path = [
         {"componentId": "root", "instanceNumber": 0},
         {"componentId": "7730df5b-8731-4123-bacc-898e7347b124", "instanceNumber": 0},
         {"componentId": "6010765e-9ac3-4570-84bf-913ae404e03a", "instanceNumber": 0},
-        {"componentId": "c282ad31-2487-4296-a944-508c167c43be", "instanceNumber": 0}
+        {"componentId": "c282ad31-2487-4296-a944-508c167c43be", "instanceNumber": 0},
     ]
 
     async_handler_click_path = [
@@ -30,7 +28,7 @@ class TestAppRunner:
         {"componentId": "92a2c0c8-7ab4-4865-b7eb-ed437408c8f5", "instanceNumber": 0},
         {"componentId": "d1e01ce1-fab1-4a6e-91a1-1f45f9e57aa5", "instanceNumber": 0},
         {"componentId": "9c30af6d-4ee5-4782-9169-0f361d67fa76", "instanceNumber": 0},
-        {"componentId": "nyo5vc79sb031yz8", "instanceNumber": 0}
+        {"componentId": "nyo5vc79sb031yz8", "instanceNumber": 0},
     ]
     proposed_session_id = "c13a280fe17ec663047ec14de15cd93ad686fecf5f9a4dbf262d3a86de8cb577"
 
@@ -47,14 +45,16 @@ class TestAppRunner:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("setup_app_runner")
-    async def test_init_should_not_load_workflow_component_in_run_mode(self, setup_app_runner) -> None:
+    async def test_init_should_not_load_workflow_component_in_run_mode(
+        self, setup_app_runner
+    ) -> None:
         ar: AppRunner
-        with setup_app_runner(test_app_dir, "run", load = True) as ar:
-            response = await ar.init_session(InitSessionRequestPayload(
-                cookies={},
-                headers={},
-                proposedSessionId=self.proposed_session_id
-            ))
+        with setup_app_runner(test_app_dir, "run", load=True) as ar:
+            response = await ar.init_session(
+                InitSessionRequestPayload(
+                    cookies={}, headers={}, proposedSessionId=self.proposed_session_id
+                )
+            )
 
             assert response.payload.components.get("workflows_root") is None
 
@@ -62,57 +62,91 @@ class TestAppRunner:
     @pytest.mark.usefixtures("setup_app_runner")
     async def test_init_should_load_workflow_component_in_edit_mode(self, setup_app_runner) -> None:
         ar: AppRunner
-        with setup_app_runner(test_app_dir, "edit", load = True) as ar:
-            response = await ar.init_session(InitSessionRequestPayload(
-                cookies={},
-                headers={},
-                proposedSessionId=self.proposed_session_id
-            ))
+        with setup_app_runner(test_app_dir, "edit", load=True) as ar:
+            response = await ar.init_session(
+                InitSessionRequestPayload(
+                    cookies={}, headers={}, proposedSessionId=self.proposed_session_id
+                )
+            )
 
             assert response.payload.components.get("workflows_root") is not None
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("setup_app_runner")
-    async def test_backend_ui_event_should_not_load_workflow_component_in_run_mode(self, setup_app_runner) -> None:
+    async def test_backend_ui_event_should_not_load_workflow_component_in_run_mode(
+        self, setup_app_runner
+    ) -> None:
         ar: AppRunner
-        with setup_app_runner(test_app_dir, "run", load = True) as ar:
+        with setup_app_runner(test_app_dir, "run", load=True) as ar:
             await init_app_session(ar, session_id=self.proposed_session_id)
 
-            ev_req = EventRequest(type="event", payload=WriterEvent(
-                type="wf-click",
-                instancePath=[
-                    {"componentId": "root", "instanceNumber": 0},
-                    {"componentId": "bb4d0e86-619e-4367-a180-be28ab6059f4", "instanceNumber": 0},
-                    {"componentId": "92a2c0c8-7ab4-4865-b7eb-ed437408c8f5", "instanceNumber": 0},
-                    {"componentId": "d1e01ce1-fab1-4a6e-91a1-1f45f9e57aa5", "instanceNumber": 0},
-                    {"componentId": "9c30af6d-4ee5-4782-9169-0f361d67fa76", "instanceNumber": 0},
-                    {"componentId": "8ykyk5avd9ioyr6l", "instanceNumber": 0},
-                ],
-                payload={}
-            ))
+            ev_req = EventRequest(
+                type="event",
+                payload=WriterEvent(
+                    type="wf-click",
+                    instancePath=[
+                        {"componentId": "root", "instanceNumber": 0},
+                        {
+                            "componentId": "bb4d0e86-619e-4367-a180-be28ab6059f4",
+                            "instanceNumber": 0,
+                        },
+                        {
+                            "componentId": "92a2c0c8-7ab4-4865-b7eb-ed437408c8f5",
+                            "instanceNumber": 0,
+                        },
+                        {
+                            "componentId": "d1e01ce1-fab1-4a6e-91a1-1f45f9e57aa5",
+                            "instanceNumber": 0,
+                        },
+                        {
+                            "componentId": "9c30af6d-4ee5-4782-9169-0f361d67fa76",
+                            "instanceNumber": 0,
+                        },
+                        {"componentId": "8ykyk5avd9ioyr6l", "instanceNumber": 0},
+                    ],
+                    payload={},
+                ),
+            )
 
             rev = await ar.dispatch_message(self.proposed_session_id, ev_req)
             assert rev.payload.components.get("workflows_root") is None
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("setup_app_runner")
-    async def test_backend_ui_event_should_load_workflow_component_in_edit_mode(self, setup_app_runner) -> None:
+    async def test_backend_ui_event_should_load_workflow_component_in_edit_mode(
+        self, setup_app_runner
+    ) -> None:
         ar: AppRunner
-        with setup_app_runner(test_app_dir, "edit", load = True) as ar:
+        with setup_app_runner(test_app_dir, "edit", load=True) as ar:
             await init_app_session(ar, session_id=self.proposed_session_id)
 
-            ev_req = EventRequest(type="event", payload=WriterEvent(
-                type="wf-click",
-                instancePath=[
-                    {"componentId": "root", "instanceNumber": 0},
-                    {"componentId": "bb4d0e86-619e-4367-a180-be28ab6059f4", "instanceNumber": 0},
-                    {"componentId": "92a2c0c8-7ab4-4865-b7eb-ed437408c8f5", "instanceNumber": 0},
-                    {"componentId": "d1e01ce1-fab1-4a6e-91a1-1f45f9e57aa5", "instanceNumber": 0},
-                    {"componentId": "9c30af6d-4ee5-4782-9169-0f361d67fa76", "instanceNumber": 0},
-                    {"componentId": "8ykyk5avd9ioyr6l", "instanceNumber": 0},
-                ],
-                payload={}
-            ))
+            ev_req = EventRequest(
+                type="event",
+                payload=WriterEvent(
+                    type="wf-click",
+                    instancePath=[
+                        {"componentId": "root", "instanceNumber": 0},
+                        {
+                            "componentId": "bb4d0e86-619e-4367-a180-be28ab6059f4",
+                            "instanceNumber": 0,
+                        },
+                        {
+                            "componentId": "92a2c0c8-7ab4-4865-b7eb-ed437408c8f5",
+                            "instanceNumber": 0,
+                        },
+                        {
+                            "componentId": "d1e01ce1-fab1-4a6e-91a1-1f45f9e57aa5",
+                            "instanceNumber": 0,
+                        },
+                        {
+                            "componentId": "9c30af6d-4ee5-4782-9169-0f361d67fa76",
+                            "instanceNumber": 0,
+                        },
+                        {"componentId": "8ykyk5avd9ioyr6l", "instanceNumber": 0},
+                    ],
+                    payload={},
+                ),
+            )
 
             rev = await ar.dispatch_message(self.proposed_session_id, ev_req)
             assert rev.payload.components.get("workflows_root") is not None
@@ -120,70 +154,73 @@ class TestAppRunner:
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("setup_app_runner")
     async def test_pre_session(self, setup_app_runner) -> None:
-        with setup_app_runner(test_app_dir, "run", load = True) as ar:
+        with setup_app_runner(test_app_dir, "run", load=True) as ar:
             er = EventRequest(
                 type="event",
                 payload=WriterEvent(
                     type="virus",
                     instancePath=self.numberinput_instance_path,
-                    payload={
-                        "virus": "yes"
-                    }
-                )
+                    payload={"virus": "yes"},
+                ),
             )
-            r = await ar.dispatch_message(None,  er)
+            r = await ar.dispatch_message(None, er)
             assert r.status == "error"
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("setup_app_runner")
     async def test_valid_session_invalid_event(self, setup_app_runner) -> None:
-        with setup_app_runner(test_app_dir, "run", load = True) as ar:
+        with setup_app_runner(test_app_dir, "run", load=True) as ar:
             await init_app_session(ar, session_id=self.proposed_session_id)
-            er = EventRequest(type="event", payload=WriterEvent(
-                type="virus",
-                instancePath=self.numberinput_instance_path,
-                payload={
-                    "virus": "yes"
-                }
-            ))
-            rev = await ar.dispatch_message(None,  er)
+            er = EventRequest(
+                type="event",
+                payload=WriterEvent(
+                    type="virus",
+                    instancePath=self.numberinput_instance_path,
+                    payload={"virus": "yes"},
+                ),
+            )
+            rev = await ar.dispatch_message(None, er)
             assert rev.status == "error"
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("setup_app_runner")
     async def test_valid_event(self, setup_app_runner) -> None:
-        with setup_app_runner(test_app_dir, "run", load = True) as ar:
+        with setup_app_runner(test_app_dir, "run", load=True) as ar:
             await init_app_session(ar, session_id=self.proposed_session_id)
-            ev_req = EventRequest(type="event", payload=WriterEvent(
-                type="wf-number-change",
-                instancePath=self.numberinput_instance_path,
-                payload="129673"
-            ))
+            ev_req = EventRequest(
+                type="event",
+                payload=WriterEvent(
+                    type="wf-number-change",
+                    instancePath=self.numberinput_instance_path,
+                    payload="129673",
+                ),
+            )
             ev_res = await ar.dispatch_message(self.proposed_session_id, ev_req)
             assert ev_res.status == "ok"
             assert ev_res.payload.result.get("ok")
-            assert ev_res.payload.mutations.get(
-                "+inspected_payload") == "129673.0"
-            assert ev_res.payload.mutations.get(
-                "+b.pet_count") == 129673
+            assert ev_res.payload.mutations.get("+inspected_payload") == "129673.0"
+            assert ev_res.payload.mutations.get("+b.pet_count") == 129673
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("setup_app_runner")
     async def test_async_handler(self, setup_app_runner) -> None:
-        with setup_app_runner(test_app_dir, "run", load = True) as ar:
+        with setup_app_runner(test_app_dir, "run", load=True) as ar:
             await init_app_session(ar, session_id=self.proposed_session_id)
             # Firing an event to bypass "initial" state mutations
-            ev_req = EventRequest(type="event", payload=WriterEvent(
-                type="wf-number-change",
-                instancePath=self.numberinput_instance_path,
-                payload="129673"
-            ))
+            ev_req = EventRequest(
+                type="event",
+                payload=WriterEvent(
+                    type="wf-number-change",
+                    instancePath=self.numberinput_instance_path,
+                    payload="129673",
+                ),
+            )
             ev_res = await ar.dispatch_message(self.proposed_session_id, ev_req)
 
-            ev_req = EventRequest(type="event", payload=WriterEvent(
-                type="wf-click",
-                instancePath=self.async_handler_click_path
-            ))
+            ev_req = EventRequest(
+                type="event",
+                payload=WriterEvent(type="wf-click", instancePath=self.async_handler_click_path),
+            )
             ev_res = await ar.dispatch_message(self.proposed_session_id, ev_req)
             assert ev_res.status == "ok"
             assert ev_res.payload.result.get("ok")
@@ -192,18 +229,19 @@ class TestAppRunner:
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("setup_app_runner")
     async def test_bad_event_handler(self, setup_app_runner) -> None:
-        with setup_app_runner(test_app_dir, "run", load = True) as ar:
+        with setup_app_runner(test_app_dir, "run", load=True) as ar:
             await init_app_session(ar, session_id=self.proposed_session_id)
             bad_button_instance_path = [
                 {"componentId": "root", "instanceNumber": 0},
                 {"componentId": "28a2212b-bc58-4398-8a72-2554e5296490", "instanceNumber": 0},
-                {"componentId": "232d749a-5e0c-4802-bbe1-f8cae06db112", "instanceNumber": 0}
+                {"componentId": "232d749a-5e0c-4802-bbe1-f8cae06db112", "instanceNumber": 0},
             ]
-            ev_req = EventRequest(type="event", payload=WriterEvent(
-                type="click",
-                instancePath=bad_button_instance_path,
-                payload={}
-            ))
+            ev_req = EventRequest(
+                type="event",
+                payload=WriterEvent(
+                    type="click", instancePath=bad_button_instance_path, payload={}
+                ),
+            )
             ev_res = await ar.dispatch_message(self.proposed_session_id, ev_req)
             print(repr(ev_res))
             assert ev_res.status == "ok"
@@ -212,14 +250,14 @@ class TestAppRunner:
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("setup_app_runner")
     async def test_unsafe_event(self, setup_app_runner) -> None:
-        with setup_app_runner(test_app_dir, "run", load = True) as ar:
+        with setup_app_runner(test_app_dir, "run", load=True) as ar:
             await init_app_session(ar, session_id=self.proposed_session_id)
-            ev_req = EventRequest(type="event", payload=WriterEvent(
-                type="wf-built-run",
-                handler="nineninenine",
-                instancePath=None,
-                payload=None
-            ))
+            ev_req = EventRequest(
+                type="event",
+                payload=WriterEvent(
+                    type="wf-built-run", handler="nineninenine", instancePath=None, payload=None
+                ),
+            )
             ev_res = await ar.dispatch_message(self.proposed_session_id, ev_req)
             assert ev_res.status == "ok"
             assert not ev_res.payload.result.get("ok")
@@ -227,15 +265,18 @@ class TestAppRunner:
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("setup_app_runner")
     async def test_safe_global_event(self, setup_app_runner) -> None:
-        with setup_app_runner(test_app_dir, "run", load = True) as ar:
+        with setup_app_runner(test_app_dir, "run", load=True) as ar:
             await init_app_session(ar, session_id=self.proposed_session_id)
-            ev_req = EventRequest(type="event", payload=WriterEvent(
-                type="wf-built-run",
-                isSafe=True,
-                handler="nineninenine",
-                instancePath=None,
-                payload=None
-            ))
+            ev_req = EventRequest(
+                type="event",
+                payload=WriterEvent(
+                    type="wf-built-run",
+                    isSafe=True,
+                    handler="nineninenine",
+                    instancePath=None,
+                    payload=None,
+                ),
+            )
             ev_res = await ar.dispatch_message(self.proposed_session_id, ev_req)
             assert ev_res.status == "ok"
             assert ev_res.payload.result.get("result") == 999
@@ -252,12 +293,7 @@ class TestAppRunner:
         app_runner.update_code(None, "print('188542')")
 
     async def wait_for_code_update(self, app_runner: AppRunner) -> None:
-        await app_runner.code_update_condition.acquire()
-        try:
-            await app_runner.code_update_condition.wait()
-        finally:
-            app_runner.code_update_condition.release()
-        return True
+        await app_runner.announcement_queue.get()
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("setup_app_runner")
@@ -268,18 +304,14 @@ class TestAppRunner:
             wait_update_task = asyncio.create_task(self.wait_for_code_update(ar))
             loader_thread = threading.Thread(target=self.run_loader_thread, args=(ar,))
             loader_thread.start()
-            code_update_result = await wait_update_task
+            await wait_update_task
             loader_thread.join()
-
-            assert code_update_result == True
 
             si = InitSessionRequest(
                 type="sessionInit",
                 payload=InitSessionRequestPayload(
-                    cookies={},
-                    headers={},
-                    proposedSessionId=self.proposed_session_id
-                )
+                    cookies={}, headers={}, proposedSessionId=self.proposed_session_id
+                ),
             )
             si_res = await ar.dispatch_message(None, si)
             mail = list(si_res.payload.model_dump().get("mail"))
@@ -288,22 +320,29 @@ class TestAppRunner:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("setup_app_runner")
-    async def test_handle_event_should_return_result_of_event_handler_execution(self, setup_app_runner):
+    async def test_handle_event_should_return_result_of_event_handler_execution(
+        self, setup_app_runner
+    ):
         """
         Tests that an event handler should result the result of function execution in
         payload.result['result'].
         """
         # Given
         ar: AppRunner
-        with setup_app_runner(test_app_dir, 'run', load=True) as ar:
+        with setup_app_runner(test_app_dir, "run", load=True) as ar:
             session_id = await init_app_session(ar)
 
             # When
-            res = await ar.handle_event(session_id, WriterEvent(
-                type='click',
-                instancePath=[{'componentId': '5c0df6e8-4dd8-4485-a244-8e9e7f4b4675', 'instanceNumber': 0}],
-                payload={})
+            res = await ar.handle_event(
+                session_id,
+                WriterEvent(
+                    type="click",
+                    instancePath=[
+                        {"componentId": "5c0df6e8-4dd8-4485-a244-8e9e7f4b4675", "instanceNumber": 0}
+                    ],
+                    payload={},
+                ),
             )
 
             # Then
-            assert res.payload.result['result'] is not None
+            assert res.payload.result["result"] is not None


### PR DESCRIPTION
This PR switches [asyncio.Condition](https://docs.python.org/3/library/asyncio-sync.html#asyncio.Condition) for [asyncio.Queue](https://docs.python.org/3/library/asyncio-queue.html) when dealing with announcements, providing a more flexible architecture that also allows for announcement payloads to be sent.

This enabled using the announcement payload to send mail, making it possible to send mail when outside the app process. For example, for system notification purposes.

This feature was applied to send `pip install` logs. 