### PR TITLE
fix: create a new list from `SyncCursorPage` in order to retrieve all apps

### DIFF
--- a/src/writer/ai/__init__.py
+++ b/src/writer/ai/__init__.py
@@ -2259,7 +2259,10 @@ class Apps:
         config = config or {}
 
         response = client.applications.list(**config)
-        return response.data
+
+        # Creating a new list in order to trigger SyncCursorPage
+        # to fetch all applications available
+        return [app for app in response.data]
 
     def retrieve(
             self,


### PR DESCRIPTION
Uses a list comprehension to loop through `SyncCursorPage` output and trigger it to retrieve all available apps.