### PR TITLE
feat: `AppListPaginator` for `writer.ai.apps.list(...)`

### DIFF
--- a/tests/backend/test_ai.py
+++ b/tests/backend/test_ai.py
@@ -780,7 +780,7 @@ def test_apps_list(
 ):
     result = apps.list()
 
-    assert isinstance(result, list)
+    assert isinstance(result, apps.AppListPaginator)
     assert len(result) == 2
     assert result[0]["id"] == "app1"
     assert result[1]["name"] == "Test App 2"


### PR DESCRIPTION
Modifies output of `writer.ai.apps.list(...)` to a new class, `AppListPaginator`, that allows quick access to relevant properties of `SyncCursorPage`, and allows to seamlessly iterate over apps received in the current page.