### PR TITLE
fix(ui): adapt `CoreButton` selected & disabled state - WF-191

### DIFF
--- a/src/ui/src/components/core/other/CoreButton.spec.ts
+++ b/src/ui/src/components/core/other/CoreButton.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import CoreButton from "./CoreButton.vue";
+import WdsButton from "@/wds/WdsButton.vue";
+import { shallowMount } from "@vue/test-utils";
+import injectionKeys from "@/injectionKeys";
+import { ref } from "vue";
+import { mockProvides } from "@/tests/mocks";
+
+describe("CoreButton", () => {
+	describe("isDisabled", () => {
+		it("should disable the button in preview mode", () => {
+			const wrapper = shallowMount(CoreButton, {
+				slots: {
+					default: "slot",
+				},
+				global: {
+					provide: {
+						...mockProvides,
+						[injectionKeys.isBeingEdited as symbol]: false,
+						[injectionKeys.isDisabled as symbol]: ref(false),
+						[injectionKeys.evaluatedFields as symbol]: {
+							isDisabled: ref(true),
+							text: ref("hello"),
+						},
+					},
+				},
+			});
+
+			const button = wrapper.getComponent(WdsButton);
+
+			expect(button.attributes()).toStrictEqual(
+				expect.objectContaining({
+					disabled: "true",
+					"aria-disabled": "true",
+				}),
+			);
+		});
+
+		it("should not disable the button in edit mode", () => {
+			const wrapper = shallowMount(CoreButton, {
+				slots: {
+					default: "slot",
+				},
+				global: {
+					provide: {
+						...mockProvides,
+						[injectionKeys.isBeingEdited as symbol]: true,
+						[injectionKeys.isDisabled as symbol]: ref(false),
+						[injectionKeys.evaluatedFields as symbol]: {
+							isDisabled: ref(true),
+							text: ref("hello"),
+						},
+					},
+				},
+			});
+
+			const button = wrapper.getComponent(WdsButton);
+
+			expect(button.attributes()).toStrictEqual(
+				expect.objectContaining({
+					disabled: "false",
+					"aria-disabled": "true",
+				}),
+			);
+		});
+	});
+});

--- a/src/ui/src/components/core/other/CoreButton.vue
+++ b/src/ui/src/components/core/other/CoreButton.vue
@@ -7,6 +7,7 @@
 		ref="rootInstance"
 		class="CoreButton"
 		:aria-disabled="isDisabled"
+		:disabled="!isBeingEdited && isDisabled"
 		@click="handleClick"
 	>
 		<i v-if="fields.icon.value" class="material-symbols-outlined">{{
@@ -86,6 +87,7 @@ import injectionKeys from "@/injectionKeys";
 const rootInstance = ref<ComponentPublicInstance | null>(null);
 const fields = inject(injectionKeys.evaluatedFields);
 const isDisabled = inject(injectionKeys.isDisabled);
+const isBeingEdited = inject(injectionKeys.isBeingEdited);
 
 watch(
 	fields.isDisabled,
@@ -108,10 +110,8 @@ function handleClick(ev: MouseEvent) {
 @import "@/renderer/sharedStyles.css";
 @import "@/renderer/colorTransformations.css";
 
-.CoreButton.disabled {
-	border: 1px solid var(--separatorColor);
-	cursor: default;
-	opacity: 0.4;
-	filter: contrast(90%);
+.CoreButton.selected {
+	color: var(--wdsColorBlue5);
+	opacity: 1;
 }
 </style>

--- a/src/ui/src/components/core/other/CoreHtml.spec.ts
+++ b/src/ui/src/components/core/other/CoreHtml.spec.ts
@@ -6,7 +6,7 @@ import injectionKeys from "@/injectionKeys";
 import { ref } from "vue";
 import { mockProvides } from "@/tests/mocks";
 
-describe("CoreCheckboxInput", () => {
+describe("CoreHtml", () => {
 	it("should filter invalid Attributes props", async () => {
 		const wrapper = mount(CoreHtml, {
 			slots: {

--- a/src/ui/src/components/core/other/__snapshots__/CoreHtml.spec.ts.snap
+++ b/src/ui/src/components/core/other/__snapshots__/CoreHtml.spec.ts.snap
@@ -15,3 +15,19 @@ exports[`CoreCheckboxInput > should filter invalid Attributes props 1`] = `
   </div>
 </div>
 `;
+
+exports[`CoreHtml > should filter invalid Attributes props 1`] = `
+<div
+  class="CoreHTML"
+  data-writer-container=""
+  style="color: red;"
+  valid="valid"
+>
+  
+  slot
+  
+  <div>
+    inside
+  </div>
+</div>
+`;

--- a/src/ui/src/wds/WdsButton.vue
+++ b/src/ui/src/wds/WdsButton.vue
@@ -84,7 +84,8 @@ const className = computed(() => [
 	border-color: var(--intensifiedButtonColor);
 	background: var(--intensifiedButtonColor);
 }
-.WdsButton--primary:disabled {
+.WdsButton--primary:disabled,
+.WdsButton--primary[aria-disabled="true"] {
 	border-color: var(--wdsColorBlue6);
 	background-color: var(--wdsColorBlue6);
 	opacity: 40%;
@@ -103,7 +104,8 @@ const className = computed(() => [
 	border-color: var(--wdsColorGray6);
 	background: var(--wdsColorGray6);
 }
-.WdsButton--secondary:disabled {
+.WdsButton--secondary:disabled,
+.WdsButton--secondary[aria-disabled="true"] {
 	border-color: var(--wdsColorGray6);
 	background: var(--wdsColorGray6);
 	opacity: 40%;
@@ -121,7 +123,8 @@ const className = computed(() => [
 .WdsButton--tertiary:focus {
 	color: var(--wdsColorGray4);
 }
-.WdsButton--tertiary:disabled {
+.WdsButton--tertiary:disabled,
+.WdsButton--tertiary[aria-disabled="true"] {
 	color: var(--wdsColorGray4);
 	opacity: 50%;
 }
@@ -139,7 +142,8 @@ const className = computed(() => [
 	border-color: var(--wdsColorBlue3);
 	background: var(--wdsColorBlue3);
 }
-.WdsButton--special:disabled {
+.WdsButton--special:disabled,
+.WdsButton--special[aria-disabled="true"] {
 	border-color: var(--wdsColorBlue2);
 	background-color: var(--wdsColorBlue2);
 	opacity: 0.4;
@@ -164,7 +168,8 @@ const className = computed(() => [
 	background: var(--builderSubtleSeparatorColor);
 }
 
-.WdsButton--neutral:disabled {
+.WdsButton--neutral:disabled,
+.WdsButton--neutral[aria-disabled="true"] {
 	opacity: 0.4;
 }
 


### PR DESCRIPTION
The `CoreButton` was using the default selected background from the editor which makes text barely visible.

It was also a good opportunity to properly disable the button when the property `isDisabled` is set.

| edit mode | preview mode |
|--|---|
|  ![Screenshot 2025-03-12 at 12 30 38](https://github.com/user-attachments/assets/94a44db3-06cd-4052-8187-c7b35eee5337) | ![Screenshot 2025-03-12 at 12 30 48](https://github.com/user-attachments/assets/e03770a1-f0fc-47c0-b524-de489f0156c9) |
