### PR TITLE
chore(ui): use dynamic import for `floating-ui`

### DIFF
--- a/src/ui/src/builder/settings/BuilderFieldsAlign.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsAlign.vue
@@ -36,6 +36,7 @@
 import {
 	computed,
 	ComputedRef,
+	defineAsyncComponent,
 	inject,
 	nextTick,
 	onBeforeUnmount,
@@ -49,13 +50,18 @@ import {
 import { Component } from "@/writerTypes";
 import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "@/injectionKeys";
-import BuilderSelect from "../BuilderSelect.vue";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
 import WdsTabs from "@/wds/WdsTabs.vue";
 import {
 	BuilderFieldCssMode as Mode,
 	BUILDER_FIELD_CSS_TAB_OPTIONS as tabs,
 } from "./constants/builderFieldsCssTabs";
+import BuilderAsyncLoader from "../BuilderAsyncLoader.vue";
+
+const BuilderSelect = defineAsyncComponent({
+	loader: () => import("../BuilderSelect.vue"),
+	loadingComponent: BuilderAsyncLoader,
+});
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);

--- a/src/ui/src/builder/settings/BuilderFieldsPadding.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsPadding.vue
@@ -105,6 +105,7 @@
 <script setup lang="ts">
 import {
 	computed,
+	defineAsyncComponent,
 	inject,
 	nextTick,
 	onBeforeUnmount,
@@ -118,7 +119,6 @@ import {
 import { Component } from "@/writerTypes";
 import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "@/injectionKeys";
-import BuilderSelect from "../BuilderSelect.vue";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
 import WdsTextInput from "@/wds/WdsTextInput.vue";
 import WdsTabs from "@/wds/WdsTabs.vue";
@@ -126,6 +126,12 @@ import {
 	BuilderFieldCssMode as Mode,
 	BUILDER_FIELD_CSS_TAB_OPTIONS as tabs,
 } from "./constants/builderFieldsCssTabs";
+import BuilderAsyncLoader from "../BuilderAsyncLoader.vue";
+
+const BuilderSelect = defineAsyncComponent({
+	loader: () => import("../BuilderSelect.vue"),
+	loadingComponent: BuilderAsyncLoader,
+});
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);

--- a/src/ui/src/builder/settings/BuilderFieldsTools.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsTools.vue
@@ -84,7 +84,12 @@ import BuilderModal, { ModalAction } from "../BuilderModal.vue";
 import WdsTextInput from "@/wds/WdsTextInput.vue";
 import WdsDropdownInput from "@/wds/WdsDropdownInput.vue";
 import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
-import BuilderGraphSelect from "../BuilderGraphSelect.vue";
+import BuilderAsyncLoader from "../BuilderAsyncLoader.vue";
+
+const BuilderGraphSelect = defineAsyncComponent({
+	loader: () => import("../BuilderGraphSelect.vue"),
+	loadingComponent: BuilderAsyncLoader,
+});
 
 const BuilderEmbeddedCodeEditor = defineAsyncComponent(
 	() => import("../BuilderEmbeddedCodeEditor.vue"),

--- a/src/ui/src/builder/settings/BuilderFieldsWidth.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsWidth.vue
@@ -44,6 +44,7 @@
 <script setup lang="ts">
 import {
 	computed,
+	defineAsyncComponent,
 	inject,
 	nextTick,
 	onBeforeUnmount,
@@ -57,7 +58,6 @@ import {
 import { Component } from "@/writerTypes";
 import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "@/injectionKeys";
-import BuilderSelect from "../BuilderSelect.vue";
 import BuilderTemplateInput from "./BuilderTemplateInput.vue";
 import WdsTextInput from "@/wds/WdsTextInput.vue";
 import WdsTabs from "@/wds/WdsTabs.vue";
@@ -65,6 +65,12 @@ import {
 	BuilderFieldCssMode as Mode,
 	BUILDER_FIELD_CSS_TAB_OPTIONS as tabs,
 } from "./constants/builderFieldsCssTabs";
+import BuilderAsyncLoader from "../BuilderAsyncLoader.vue";
+
+const BuilderSelect = defineAsyncComponent({
+	loader: () => import("../BuilderSelect.vue"),
+	loadingComponent: BuilderAsyncLoader,
+});
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);

--- a/src/ui/src/builder/settings/BuilderSettingsHandlers.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsHandlers.vue
@@ -20,8 +20,8 @@
 </template>
 
 <script setup lang="ts">
-// TODO: rename this component
 import { computed, ComputedRef, inject } from "vue";
+
 import injectionKeys from "@/injectionKeys";
 import { WriterComponentDefinition } from "@/writerTypes";
 import BuilderSettingsHandlersWorkflow from "./BuilderSettingsHandlersWorkflow.vue";


### PR DESCRIPTION
Fix warning of Vite build saying

```
(!) src/ui/src/builder/BuilderGraphSelect.vue is dynamically imported by AAA but also statically imported by BBB, dynamic import will not move module into another chunk.
```
This will force to bundle `@floating-ui/vue` to be split into a separated chunk and saves 14kb

```diff
-../writer/static/assets/BuilderApp-DVqlivId.js                                         60.40 kB │ gzip:    21.46 kB
-../writer/static/assets/BuilderSettings-oWe5fV87.js                                    79.92 kB │ gzip:    22.79 kB
+../writer/static/assets/BuilderApp-CljhirPm.js                                         45.20 kB │ gzip:    15.55 kB
+../writer/static/assets/BuilderSettings-BHSMljIi.js                                    75.66 kB │ gzip:    21.22 kB
+../writer/static/assets/floating-ui.vue-cwTPNt4R.js                                    14.01 kB │ gzip:     5.51 kB
```