### PR TITLE
fix(ui): improve node selection in blueprint - WF-226

### DIFF
--- a/src/ui/src/components/workflows/WorkflowsWorkflow.vue
+++ b/src/ui/src/components/workflows/WorkflowsWorkflow.vue
@@ -201,23 +201,20 @@ const activeCanvasMove = shallowRef<{
 } | null>(null);
 
 function refreshArrows() {
-	const newArrows = [];
-	nodes.value
-		.filter((node) => node.outs?.length > 0)
-		.forEach((node) => {
-			const fromNodeId = node.id;
-			node.outs.forEach((out) => {
-				const arrow = calculateArrow(
-					fromNodeId,
-					out.outId,
-					undefined,
-					out.toNodeId,
-				);
-				if (!arrow) return;
-				newArrows.push(arrow);
-			});
-		});
-	arrows.value = newArrows;
+	arrows.value = nodes.value.reduce((acc, node) => {
+		if (!node.outs?.length) return acc;
+
+		for (const out of node.outs) {
+			const arrow = calculateArrow(
+				node.id,
+				out.outId,
+				undefined,
+				out.toNodeId,
+			);
+			if (arrow) acc.push(arrow);
+		}
+		return acc;
+	}, []);
 }
 
 const isUnselectable = computed(() => {


### PR DESCRIPTION
once `isPerfected` is `true`, we don't select the node. So we considerate a small movement as a missclick (the user click but drag few pixels)

I also took the opportunity to replace some `ref` by `shallowRef` to improve the performance.