### PR TITLE
fix: don't access WFBM explicitly when checking for active mode

### DIFF
--- a/src/ui/src/renderer/ComponentRenderer.vue
+++ b/src/ui/src/renderer/ComponentRenderer.vue
@@ -174,7 +174,7 @@ function addMailSubscriptions() {
 		el.click();
 	});
 	wf.addMailSubscription("pageChange", async (pageKey: string) => {
-		if (wfbm.getMode() === "workflows") {
+		if (wfbm?.getMode() === "workflows") {
 			wfbm.setMode("ui");
 		}
 		await nextTick();


### PR DESCRIPTION
Prevents an error when trying to change pages in run mode.