### PR TITLE
fix(ui): handle unknown component in Blueprint - WF-193

### DIFF
--- a/src/ui/src/components/core/input/CoreCheckboxInput.vue
+++ b/src/ui/src/components/core/input/CoreCheckboxInput.vue
@@ -36,7 +36,7 @@
 </template>
 
 <script lang="ts">
-import { ComponentPublicInstance, inject, onMounted } from "vue";
+import { ComponentPublicInstance, inject } from "vue";
 import { ref } from "vue";
 import { FieldCategory, FieldType } from "@/writerTypes";
 import {

--- a/src/ui/src/components/workflows/WorkflowsWorkflow.vue
+++ b/src/ui/src/components/workflows/WorkflowsWorkflow.vue
@@ -906,30 +906,4 @@ svg {
 	width: 100%;
 	height: 100%;
 }
-
-/* customize the `RenderError` component to make it looks like a node */
-.nodeContainer :deep(.RenderError) {
-	position: absolute;
-	width: 240px;
-	border-radius: 8px;
-	box-shadow: var(--wdsShadowBox);
-	padding: 12px;
-	background-color: var(--builderBackgroundColor);
-	border: 2px solid transparent;
-	font-size: 14px;
-}
-.nodeContainer :deep(.RenderError.selected) {
-	background-color: var(--builderBackgroundColor);
-	border: 2px solid var(--wdsColorBlue4);
-	font-size: 14px;
-}
-.nodeContainer :deep(.RenderError:hover) {
-	border: 2px solid var(--wdsColorBlue2);
-}
-
-.nodeContainer :deep(.RenderError h2) {
-	color: var(--builderErrorColor);
-	font-size: 14px;
-	font-weight: 500;
-}
 </style>

--- a/src/ui/src/components/workflows/WorkflowsWorkflow.vue
+++ b/src/ui/src/components/workflows/WorkflowsWorkflow.vue
@@ -906,4 +906,30 @@ svg {
 	width: 100%;
 	height: 100%;
 }
+
+/* customize the `RenderError` component to make it looks like a node */
+.nodeContainer :deep(.RenderError) {
+	position: absolute;
+	width: 240px;
+	border-radius: 8px;
+	box-shadow: var(--wdsShadowBox);
+	padding: 12px;
+	background-color: var(--builderBackgroundColor);
+	border: 2px solid transparent;
+	font-size: 14px;
+}
+.nodeContainer :deep(.RenderError.selected) {
+	background-color: var(--builderBackgroundColor);
+	border: 2px solid var(--wdsColorBlue4);
+	font-size: 14px;
+}
+.nodeContainer :deep(.RenderError:hover) {
+	border: 2px solid var(--wdsColorBlue2);
+}
+
+.nodeContainer :deep(.RenderError h2) {
+	color: var(--builderErrorColor);
+	font-size: 14px;
+	font-weight: 500;
+}
 </style>

--- a/src/ui/src/renderer/ComponentProxy.vue
+++ b/src/ui/src/renderer/ComponentProxy.vue
@@ -184,7 +184,7 @@ export default {
 
 		// keep track on style fields changed to remove the "selected" state if a style change (it helps the user to see his modifications)
 		const styleFields = computed(() => {
-			return Object.entries(componentDefinitionFields.value)
+			return Object.entries(componentDefinitionFields.value ?? {})
 				.filter(([, value]) => value.category === FieldCategory.Style)
 				.reduce<Record<string, unknown>>((acc, [key]) => {
 					acc[key] = evaluatedFields[key].value;

--- a/src/ui/src/renderer/ComponentProxy.vue
+++ b/src/ui/src/renderer/ComponentProxy.vue
@@ -13,7 +13,6 @@ import ComponentProxy from "./ComponentProxy.vue";
 import RenderError from "./RenderError.vue";
 import { flattenInstancePath } from "./instancePath";
 import { useEvaluator } from "./useEvaluator";
-import WorkflowsNode from "@/components/workflows/abstract/WorkflowsNode.vue";
 
 export default {
 	props: {
@@ -339,14 +338,6 @@ export default {
 			};
 
 			const vnodeProps = getRootElProps();
-
-			const isWorkflowNode =
-				wf.getComponentById(component.value.parentId)?.type ===
-				"workflows_workflow";
-
-			if (template.writer?.category === "Fallback" && isWorkflowNode) {
-				return h(WorkflowsNode, vnodeProps, { default: defaultSlotFn });
-			}
 
 			if (
 				!isParentSuitable(

--- a/src/ui/src/renderer/ComponentProxy.vue
+++ b/src/ui/src/renderer/ComponentProxy.vue
@@ -13,6 +13,7 @@ import ComponentProxy from "./ComponentProxy.vue";
 import RenderError from "./RenderError.vue";
 import { flattenInstancePath } from "./instancePath";
 import { useEvaluator } from "./useEvaluator";
+import WorkflowsNode from "@/components/workflows/abstract/WorkflowsNode.vue";
 
 export default {
 	props: {
@@ -337,9 +338,15 @@ export default {
 				return vnodes;
 			};
 
-			const vnodeProps = {
-				...getRootElProps(),
-			};
+			const vnodeProps = getRootElProps();
+
+			const isWorkflowNode =
+				wf.getComponentById(component.value.parentId)?.type ===
+				"workflows_workflow";
+
+			if (template.writer?.category === "Fallback" && isWorkflowNode) {
+				return h(WorkflowsNode, vnodeProps, { default: defaultSlotFn });
+			}
 
 			if (
 				!isParentSuitable(

--- a/src/ui/src/renderer/RenderError.vue
+++ b/src/ui/src/renderer/RenderError.vue
@@ -1,23 +1,40 @@
 <template>
-	<div class="RenderError">
+	<WorkflowsNode v-if="isWorkflowNode" :draggable="false" />
+	<div v-else class="RenderError" :draggable="draggable">
 		<div class="title">
-			<h2>Error rendering {{ props.componentType }}</h2>
+			<h2>Error rendering {{ componentType }}</h2>
 		</div>
 		<div class="message">
-			{{ props.message }}
+			{{ message }}
 		</div>
 	</div>
 </template>
 
 <script setup lang="ts">
+import injectionKeys from "@/injectionKeys";
 import { Component } from "@/writerTypes";
+import { computed, inject, PropType } from "vue";
 
-interface Props {
-	componentType: Component["type"];
-	message: string;
-}
+import WorkflowsNode from "@/components/workflows/abstract/WorkflowsNode.vue";
 
-const props = defineProps<Props>();
+defineProps({
+	componentType: {
+		type: String as PropType<Component["type"]>,
+		required: true,
+	},
+	message: { type: String, required: true },
+	draggable: { type: Boolean, required: false },
+});
+
+const wf = inject(injectionKeys.core);
+const componentId = inject(injectionKeys.componentId);
+
+const component = computed(() => wf.getComponentById(componentId));
+const parent = computed(() => wf.getComponentById(component.value?.parentId));
+
+const isWorkflowNode = computed(
+	() => parent.value?.type === "workflows_workflow",
+);
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
Customize `RenderError.vue` to display a `WorkflowsNode` component for invalid workflow blocks.

It also renders the `outs` of the nodes. 

![image](https://github.com/user-attachments/assets/56f704f7-1e95-4976-8801-5bf82a44711d)