### PR TITLE
feat(ui): align UI select state across UI / Blueprint  - WF-240

### DIFF
--- a/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
+++ b/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
@@ -325,6 +325,9 @@ watch(isEngaged, () => {
 	);
 }
 
+.BlueprintsNode.selected {
+	outline: unset !important;
+}
 .BlueprintsNode.selected.component .extraBorder {
 	background: var(--wdsColorBlue4);
 }

--- a/src/ui/src/components/core/content/CoreDataframe.vue
+++ b/src/ui/src/components/core/content/CoreDataframe.vue
@@ -709,6 +709,9 @@ onUnmounted(() => {
 .CoreDataframe.selected {
 	--dataframeBackgroundColor: var(--builderSelectedColor) !important;
 }
+.CoreDataframe.selected .CoreDataframe__tableWrapper {
+	border-radius: 8px;
+}
 
 .CoreDataframe {
 	font-size: 0.8rem;

--- a/src/ui/src/components/core/layout/CoreStep.vue
+++ b/src/ui/src/components/core/layout/CoreStep.vue
@@ -1,19 +1,13 @@
 <template>
 	<div
-		v-show="
-			stepContainerDirectChildInstanceItem?.instanceNumber ==
-				STEP_BIT_INSTANCE_NUMBER ||
-			(stepContainerDirectChildInstanceItem?.instanceNumber ==
-				CONTENT_DISPLAYING_INSTANCE_NUMBER &&
-				isStepActive)
-		"
+		v-show="isStepBitInstance || (isContentInstance && isStepActive)"
 		class="CoreStep"
+		:class="{
+			'CoreStep--bit': isStepBitInstance,
+		}"
 	>
 		<button
-			v-if="
-				stepContainerDirectChildInstanceItem?.instanceNumber ==
-				STEP_BIT_INSTANCE_NUMBER
-			"
+			v-if="isStepBitInstance"
 			class="bit"
 			:disabled="!isBeingEdited"
 			:class="{
@@ -43,10 +37,7 @@
 			<div class="label">{{ fields.name.value }}</div>
 		</button>
 		<BaseContainer
-			v-if="
-				stepContainerDirectChildInstanceItem?.instanceNumber ==
-				CONTENT_DISPLAYING_INSTANCE_NUMBER
-			"
+			v-if="isContentInstance"
 			v-show="isStepActive"
 			class="container"
 			:content-h-align="fields.contentHAlign.value"
@@ -231,6 +222,18 @@ const stepContainerDirectChildInstanceItem = computed(() => {
 	return instancePath.at(i);
 });
 
+const isStepBitInstance = computed(
+	() =>
+		stepContainerDirectChildInstanceItem.value?.instanceNumber ==
+		STEP_BIT_INSTANCE_NUMBER,
+);
+
+const isContentInstance = computed(
+	() =>
+		stepContainerDirectChildInstanceItem.value?.instanceNumber ==
+		CONTENT_DISPLAYING_INSTANCE_NUMBER,
+);
+
 /*
 Activate the step if a component inside it was selected.
 */
@@ -246,10 +249,7 @@ active step's in the parent Step Container.
 */
 const isStepActive = computed(() => {
 	let contentDisplayingInstancePath: InstancePath;
-	if (
-		stepContainerDirectChildInstanceItem?.value.instanceNumber ==
-		STEP_BIT_INSTANCE_NUMBER
-	) {
+	if (isStepBitInstance.value) {
 		contentDisplayingInstancePath = getMatchingStepInstancePath();
 	} else {
 		contentDisplayingInstancePath = instancePath;
@@ -282,11 +282,7 @@ watch(fields.isCompleted, (value: boolean, oldValue: boolean) => {
 });
 
 onBeforeMount(() => {
-	if (
-		stepContainerDirectChildInstanceItem?.value.instanceNumber ==
-		STEP_BIT_INSTANCE_NUMBER
-	)
-		return;
+	if (isStepBitInstance.value) return;
 
 	// Register steps in the Step Container
 
@@ -405,8 +401,11 @@ button.bit.active:focus {
 	background: transparent;
 }
 
+.CoreStep--bit.selected {
+	outline: unset !important;
+}
+
 .label {
 	padding: 8px 16px 0 16px;
 }
 </style>
-../base/BaseContainer.vue

--- a/src/ui/src/components/core/layout/CoreTab.vue
+++ b/src/ui/src/components/core/layout/CoreTab.vue
@@ -1,7 +1,13 @@
 <template>
-	<div v-show="isVisible" class="CoreTab">
+	<div
+		v-show="isVisible"
+		class="CoreTab"
+		:class="{
+			'CoreTab--bit': isTabBitInstance,
+		}"
+	>
 		<button
-			v-if="isTabBit"
+			v-if="isTabBitInstance"
 			class="bit"
 			:class="{ active: isTabActive }"
 			tabindex="0"
@@ -10,7 +16,7 @@
 			{{ fields.name.value }}
 		</button>
 		<BaseContainer
-			v-if="isContentDisplaying"
+			v-if="isContentInstance"
 			v-show="isTabActive"
 			class="container"
 			:content-h-align="fields.contentHAlign.value"
@@ -107,16 +113,18 @@ const instanceNumber = computed<number | undefined>(
 	() => tabContainerDirectChildInstanceItem?.value.instanceNumber,
 );
 
-const isTabBit = computed(
+const isTabBitInstance = computed(
 	() => instanceNumber.value === TAB_BIT_INSTANCE_NUMBER,
 );
-const isContentDisplaying = computed(
+const isContentInstance = computed(
 	() => instanceNumber.value === CONTENT_DISPLAYING_INSTANCE_NUMBER,
 );
 
 const isVisible = computed(() => {
 	if (!isComponentVisible(componentId)) return false;
-	return isTabBit.value || (isContentDisplaying.value && isTabActive.value);
+	return (
+		isTabBitInstance.value || (isContentInstance.value && isTabActive.value)
+	);
 });
 
 const getTabContainerData = () => {
@@ -166,7 +174,7 @@ watch(selectedId, (newSelectedId) => {
 
 const isTabActive = computed(() => {
 	let contentDisplayingInstancePath: InstancePath;
-	if (isTabBit.value) {
+	if (isTabBitInstance.value) {
 		contentDisplayingInstancePath = getMatchingTabInstancePath();
 	} else {
 		contentDisplayingInstancePath = instancePath;
@@ -180,7 +188,7 @@ const isTabActive = computed(() => {
 });
 
 onBeforeMount(() => {
-	if (isTabBit.value) return;
+	if (isTabBitInstance.value) return;
 	const tabContainerData = getTabContainerData();
 	const activeTab = tabContainerData.value?.activeTab;
 	if (activeTab) return;
@@ -223,5 +231,10 @@ button.bit.active {
 	font-weight: 500;
 	color: var(--primaryTextColor);
 	border-bottom: 2px solid var(--primaryTextColor);
+}
+
+.CoreTab--bit.selected {
+	outline: unset !important;
+	background-color: unset;
 }
 </style>

--- a/src/ui/src/renderer/sharedStyles.css
+++ b/src/ui/src/renderer/sharedStyles.css
@@ -69,6 +69,9 @@ input[type="color"] {
 
 .component.selected {
 	background-color: var(--builderSelectedColor);
+	outline: 2px solid var(--builderAccentColor);
+	outline-offset: 1px;
+	border-radius: 8px;
 }
 
 [data-writer-slot-of-id] {


### PR DESCRIPTION
Adapt the selected state in UI buider to have an outline instead of a simple background color change.

It makes the UX more clear and consistent with Blueprint mode.

![image](https://github.com/user-attachments/assets/c51fd7ea-5fe7-42f7-a1cf-b6339fc93ca3)