### PR TITLE
feat(ui): introduce blueprint snap grid - WF-297

### DIFF
--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -536,7 +536,15 @@ function clearActiveOperations() {
 }
 
 function saveNodeMove() {
-	changeCoordinatesMultiple(temporaryNodeCoordinates.value);
+	changeCoordinatesMultiple(
+		Object.entries(temporaryNodeCoordinates.value).reduce(
+			(acc, [id, point]) => {
+				acc[id] = computePointInTheGrid(point);
+				return acc;
+			},
+			{},
+		),
+	);
 	temporaryNodeCoordinates.value = {};
 }
 
@@ -565,7 +573,7 @@ function moveNode(ev: MouseEvent) {
 
 	const distance = computeDistance(
 		{ x: component.x, y: component.y },
-		computePointInTheGrid({ x: newX, y: newY }),
+		{ x: newX, y: newY },
 	);
 
 	if (distance > 10) {
@@ -584,7 +592,7 @@ function moveNode(ev: MouseEvent) {
 		// if the user moves a node that is not selected, we don't move other selected nodes
 		temporaryNodeCoordinates.value = {
 			...temporaryNodeCoordinates.value,
-			[nodeId]: computePointInTheGrid({ x: newX, y: newY }),
+			[nodeId]: { x: newX, y: newY },
 		};
 		return;
 	}
@@ -596,17 +604,17 @@ function moveNode(ev: MouseEvent) {
 			(c) => c.id !== nodeId && c.x !== undefined && c.y !== undefined,
 		)
 		.reduce<Record<string, Point>>((acc, component) => {
-			acc[component.id] = computePointInTheGrid({
+			acc[component.id] = {
 				x: component.x + translationX,
 				y: component.y + translationY,
-			});
+			};
 			return acc;
 		}, {});
 
 	temporaryNodeCoordinates.value = {
 		...temporaryNodeCoordinates.value,
 		...otherSelectedComponents,
-		[nodeId]: computePointInTheGrid({ x: newX, y: newY }),
+		[nodeId]: { x: newX, y: newY },
 	};
 }
 

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -12,30 +12,6 @@
 	>
 		<div ref="nodeContainerEl" class="nodeContainer">
 			<svg>
-				<defs>
-					<pattern
-						id="grid"
-						:width="GRID_TICK"
-						:height="GRID_TICK"
-						patternUnits="userSpaceOnUse"
-					>
-						<circle
-							:cx="GRID_TICK / 2"
-							:cy="GRID_TICK / 2"
-							r="1"
-							:fill="WdsColor.Gray2"
-						/>
-						<path
-							v-if="false"
-							d="M 16 0 L 0 0 0 16"
-							fill="none"
-							:stroke="WdsColor.Gray3"
-							stroke-width="0.5"
-						/>
-					</pattern>
-				</defs>
-
-				<rect width="100%" height="100%" fill="url(#grid)" />
 				<BlueprintArrow
 					v-for="(arrow, arrowId) in arrows"
 					:key="arrowId"

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -25,7 +25,7 @@
 							:cx="GRID_TICK / 2"
 							:cy="GRID_TICK / 2"
 							r="1"
-							:fill="WdsColor.Gray2"
+							:fill="WdsColor.Gray3"
 						/>
 					</pattern>
 				</defs>
@@ -978,7 +978,7 @@ onUnmounted(() => {
 	display: flex;
 	width: 100%;
 	min-height: 100%;
-	background: var(--builderSubtleSeparatorColor);
+	background: var(--wdsColorGray0);
 	flex: 1 0 auto;
 	flex-direction: row;
 	align-items: stretch;

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -12,6 +12,25 @@
 	>
 		<div ref="nodeContainerEl" class="nodeContainer">
 			<svg>
+				<defs>
+					<pattern
+						id="grid"
+						:width="GRID_TICK"
+						:height="GRID_TICK"
+						patternUnits="userSpaceOnUse"
+						:x="-renderOffset.x - GRID_TICK / 2"
+						:y="-renderOffset.y - GRID_TICK / 2"
+					>
+						<circle
+							:cx="GRID_TICK / 2"
+							:cy="GRID_TICK / 2"
+							r="1"
+							:fill="WdsColor.Gray2"
+						/>
+					</pattern>
+				</defs>
+
+				<rect width="100%" height="100%" fill="url(#grid)" fil />
 				<BlueprintArrow
 					v-for="(arrow, arrowId) in arrows"
 					:key="arrowId"
@@ -87,6 +106,7 @@ import WdsModal from "@/wds/WdsModal.vue";
 import BlueprintsAutogen from "./BlueprintsAutogen.vue";
 import { useLogger } from "@/composables/useLogger";
 import { mathCeilToMultiple } from "@/utils/math";
+import { WdsColor } from "@/wds/tokens";
 
 const { log } = useLogger();
 

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -86,6 +86,7 @@ import { isModifierKeyActive } from "@/core/detectPlatform";
 import WdsModal from "@/wds/WdsModal.vue";
 import BlueprintsAutogen from "./BlueprintsAutogen.vue";
 import { useLogger } from "@/composables/useLogger";
+import { mathCeilToMultiple } from "@/utils/math";
 
 const { log } = useLogger();
 
@@ -290,10 +291,14 @@ function getNodeRectange(nodeId: Component["id"]): Rectangle {
 	if (!canvasBCR) return;
 
 	return {
-		x: Math.round((bcr.x - canvasBCR.x) * zoomRatio.value),
-		y: Math.round((bcr.y - canvasBCR.y) * zoomRatio.value),
-		width: Math.floor(bcr.width * zoomRatio.value),
-		height: Math.floor(bcr.height * zoomRatio.value),
+		x: Math.round(
+			renderOffset.value.x + (bcr.x - canvasBCR.x) * zoomRatio.value,
+		),
+		y: Math.round(
+			renderOffset.value.y + (bcr.y - canvasBCR.y) * zoomRatio.value,
+		),
+		width: mathCeilToMultiple(bcr.width * zoomRatio.value, GRID_TICK) - 1,
+		height: mathCeilToMultiple(bcr.height * zoomRatio.value, GRID_TICK) - 1,
 	};
 }
 

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -178,6 +178,7 @@ import {
 	Point,
 	positionateRectangleWithoutColision,
 	Rectangle,
+	translatePoint,
 } from "@/utils/geometry";
 
 const BlueprintToolbar = defineAsyncComponent({
@@ -571,6 +572,7 @@ function changeCoordinatesMultipleWithCheck(
 			const { x, y } = positionateRectangleWithoutColision(
 				rectange,
 				otherRectangles,
+				GRID_TICK,
 			);
 
 			acc[id] = { x, y };
@@ -605,8 +607,7 @@ function moveNode(ev: MouseEvent) {
 		activeNodeMove.value = { ...activeNodeMove.value, isPerfected: true };
 	}
 
-	const translationX = newX - component.x;
-	const translationY = newY - component.y;
+	const trans = { x: newX - component.x, y: newY - component.y };
 
 	const isMovingNodeSelected = wfbm.selection.value.some(
 		(c) => c.componentId === nodeId,
@@ -628,10 +629,10 @@ function moveNode(ev: MouseEvent) {
 			(c) => c.id !== nodeId && c.x !== undefined && c.y !== undefined,
 		)
 		.reduce<Record<string, Point>>((acc, component) => {
-			acc[component.id] = {
-				x: component.x + translationX,
-				y: component.y + translationY,
-			};
+			acc[component.id] = translatePoint(
+				{ x: component.x, y: component.y },
+				trans,
+			);
 			return acc;
 		}, {});
 
@@ -921,11 +922,7 @@ function handleKeydown(event: KeyboardEvent) {
 		.map((s) => wf.getComponentById(s.componentId))
 		.filter((c) => c?.x && c?.y)
 		.reduce<Record<Component["id"], Point>>((acc, c) => {
-			acc[c.id] = {
-				x: c.x + vector.x,
-				y: c.y + vector.y,
-			};
-
+			acc[c.id] = translatePoint({ x: c.x, y: c.y }, vector);
 			return acc;
 		}, {});
 

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -313,11 +313,10 @@ function calculateAutoArrangeDimensions(columns: Map<number, Set<Component>>) {
 			const nodeBCR = getNodeBoundingClientRect(node.id);
 			if (!nodeBCR) return;
 			nodeDimensions.set(node.id, {
-				height: nodeBCR.height * (1 / zoomLevel.value),
+				height: nodeBCR.height * zoomRatio.value,
 			});
-			height +=
-				nodeBCR.height * (1 / zoomLevel.value) + AUTOARRANGE_ROW_GAP_PX;
-			width = Math.max(width, nodeBCR.width * (1 / zoomLevel.value));
+			height += nodeBCR.height * zoomRatio.value + AUTOARRANGE_ROW_GAP_PX;
+			width = Math.max(width, nodeBCR.width * zoomRatio.value);
 		});
 		columnDimensions.set(layer, {
 			height: height - AUTOARRANGE_ROW_GAP_PX,
@@ -401,8 +400,8 @@ function handleNodeMousedown(ev: MouseEvent, nodeId: Component["id"]) {
 	const nodeEl = document.querySelector(`[data-writer-id="${nodeId}"]`);
 	const nodeBCR = nodeEl.getBoundingClientRect();
 
-	const x = (ev.pageX - nodeBCR.x) * (1 / zoomLevel.value);
-	const y = (ev.pageY - nodeBCR.y) * (1 / zoomLevel.value);
+	const x = (ev.pageX - nodeBCR.x) * zoomRatio.value;
+	const y = (ev.pageY - nodeBCR.y) * zoomRatio.value;
 
 	activeNodeMove.value = {
 		nodeId,
@@ -418,6 +417,7 @@ function handleNodeOutMousedown(
 	activeConnection.value = { fromNodeId, fromOutId };
 }
 
+const zoomRatio = computed(() => 1 / zoomLevel.value);
 function getAdjustedCoordinates(ev: MouseEvent) {
 	const canvasBCR = rootEl.value.getBoundingClientRect();
 	const x =
@@ -472,21 +472,21 @@ function calculateArrow(
 	if (!canvasBCR) {
 		return;
 	}
-	x2 = (toCoordinates?.x - canvasBCR.x) * (1 / zoomLevel.value);
-	y2 = (toCoordinates?.y - canvasBCR.y) * (1 / zoomLevel.value);
+	x2 = (toCoordinates?.x - canvasBCR.x) * zoomRatio.value;
+	y2 = (toCoordinates?.y - canvasBCR.y) * zoomRatio.value;
 	const fromEl = document.querySelector(
 		`[data-writer-id="${fromNodeId}"] [data-writer-socket-id="${fromOutId}"]`,
 	);
 	if (!fromEl) return;
 	const fromBCR = fromEl.getBoundingClientRect();
-	x1 = (fromBCR.x - canvasBCR.x + fromBCR.width / 2) * (1 / zoomLevel.value);
-	y1 = (fromBCR.y - canvasBCR.y + fromBCR.height / 2) * (1 / zoomLevel.value);
+	x1 = (fromBCR.x - canvasBCR.x + fromBCR.width / 2) * zoomRatio.value;
+	y1 = (fromBCR.y - canvasBCR.y + fromBCR.height / 2) * zoomRatio.value;
 	if (!fromEl) return;
 	if (typeof toNodeId !== "undefined") {
 		const toEl = document.querySelector(`[data-writer-id="${toNodeId}"]`);
 		const toBCR = toEl.getBoundingClientRect();
-		x2 = (toBCR.x - canvasBCR.x) * (1 / zoomLevel.value);
-		y2 = (toBCR.y - canvasBCR.y + toBCR.height / 2) * (1 / zoomLevel.value);
+		x2 = (toBCR.x - canvasBCR.x) * zoomRatio.value;
+		y2 = (toBCR.y - canvasBCR.y + toBCR.height / 2) * zoomRatio.value;
 	}
 
 	return {
@@ -651,8 +651,8 @@ function moveCanvas(ev: MouseEvent) {
 	activeCanvasMove.value = { isPerfected: true, offset: { x, y } };
 
 	changeRenderOffset(
-		renderOffset.value.x + (prevX - x) * 1 * (1 / zoomLevel.value),
-		renderOffset.value.y + (prevY - y) * 1 * (1 / zoomLevel.value),
+		renderOffset.value.x + (prevX - x) * 1 * zoomRatio.value,
+		renderOffset.value.y + (prevY - y) * 1 * zoomRatio.value,
 	);
 }
 
@@ -783,8 +783,8 @@ function changeRenderOffset(x: number, y: number) {
 
 function handleWheelScroll(ev: WheelEvent) {
 	changeRenderOffset(
-		renderOffset.value.x + ev.deltaX * (1 / zoomLevel.value),
-		renderOffset.value.y + ev.deltaY * (1 / zoomLevel.value),
+		renderOffset.value.x + ev.deltaX * zoomRatio.value,
+		renderOffset.value.y + ev.deltaY * zoomRatio.value,
 	);
 }
 
@@ -809,12 +809,12 @@ function handleWheelZoom(ev: WheelEvent) {
 		w:
 			canvasBCR.width *
 			(1 / preZoom) *
-			(1 / zoomLevel.value) *
+			zoomRatio.value *
 			(zoomLevel.value - preZoom),
 		h:
 			canvasBCR.height *
 			(1 / preZoom) *
-			(1 / zoomLevel.value) *
+			zoomRatio.value *
 			(zoomLevel.value - preZoom),
 	};
 
@@ -854,13 +854,11 @@ async function resetZoom() {
 			return {
 				maxY: Math.max(
 					acc.maxY,
-					(rect.bottom - y) * (1 / zoomLevel.value) +
-						renderOffset.value.y,
+					(rect.bottom - y) * zoomRatio.value + renderOffset.value.y,
 				),
 				maxX: Math.max(
 					acc.maxX,
-					(rect.right - x) * (1 / zoomLevel.value) +
-						renderOffset.value.x,
+					(rect.right - x) * zoomRatio.value + renderOffset.value.x,
 				),
 			};
 		},

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -295,6 +295,13 @@ function organizeNodesInColumns() {
 	return columns;
 }
 
+function getNodeBoundingClientRect(nodeId: Component["id"]) {
+	const selector = `[data-writer-id="${nodeId}"]`;
+	const nodeEl = nodeContainerEl.value.querySelector(selector);
+	if (!nodeEl) return;
+	return nodeEl.getBoundingClientRect();
+}
+
 function calculateAutoArrangeDimensions(columns: Map<number, Set<Component>>) {
 	const columnDimensions: Map<number, { height: number; width: number }> =
 		new Map();
@@ -303,11 +310,8 @@ function calculateAutoArrangeDimensions(columns: Map<number, Set<Component>>) {
 		let height = 0;
 		let width = 0;
 		nodes.forEach((node) => {
-			const nodeEl = nodeContainerEl.value.querySelector(
-				`[data-writer-id="${node.id}"]`,
-			);
-			if (!nodeEl) return;
-			const nodeBCR = nodeEl.getBoundingClientRect();
+			const nodeBCR = getNodeBoundingClientRect(node.id);
+			if (!nodeBCR) return;
 			nodeDimensions.set(node.id, {
 				height: nodeBCR.height * (1 / zoomLevel.value),
 			});
@@ -700,10 +704,10 @@ function createNode(type: string, { x, y }: Point) {
 }
 
 function findAndCenterBlock(componentId: Component["id"]) {
-	const el = rootEl.value.querySelector(`[data-writer-id="${componentId}"]`);
+	const componentBCR = getNodeBoundingClientRect(componentId);
 	const canvasBCR = rootEl.value?.getBoundingClientRect();
-	if (!el || !canvasBCR) return;
-	const { width, height } = el.getBoundingClientRect();
+	if (!componentBCR || !canvasBCR) return;
+	const { width, height } = componentBCR;
 	const component = wf.getComponentById(componentId);
 	if (!component) return;
 

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -384,7 +384,7 @@ function autoArrange(ySortStrategyKey: "currentY" | "socketPosition") {
 		const { width, height } = columnDimensions.get(i);
 		let y = (maxColumnHeight - height) / 2 + AUTOARRANGE_ROW_GAP_PX;
 		nodes.forEach((node) => {
-			coordinates[node.id] = { x, y };
+			coordinates[node.id] = computePointInTheGrid({ x, y });
 			y += nodeDimensions.get(node.id).height + AUTOARRANGE_ROW_GAP_PX;
 		});
 		x += width + AUTOARRANGE_COLUMN_GAP_PX;
@@ -544,10 +544,13 @@ function computeDistance(a: Point, b: Point): number {
 	return Math.sqrt(Math.pow(b.x - a.x, 2) + Math.pow(b.y - a.y, 2));
 }
 
+function computePointAxisInTheGrid(xOrY: number): number {
+	return xOrY - (xOrY % GRID_TICK) + GRID_TICK / 2;
+}
 function computePointInTheGrid({ x, y }: Point): Point {
 	return {
-		x: x - (x % GRID_TICK) + GRID_TICK / 2,
-		y: y - (y % GRID_TICK) + GRID_TICK / 2,
+		x: computePointAxisInTheGrid(x),
+		y: computePointAxisInTheGrid(y),
 	};
 }
 

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -896,7 +896,7 @@ function handleKeydown(event: KeyboardEvent) {
 
 	const coordinates = wfbm.selection.value
 		.map((s) => wf.getComponentById(s.componentId))
-		.filter((c) => c?.x && c?.y)
+		.filter((c) => c?.x !== undefined && c?.y !== undefined)
 		.reduce<Record<Component["id"], Point>>((acc, c) => {
 			acc[c.id] = translatePoint({ x: c.x, y: c.y }, vector);
 			return acc;

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -882,7 +882,12 @@ watch(wfbm.firstSelectedItem, (newSelection) => {
 });
 
 function handleKeydown(event: KeyboardEvent) {
-	function getVector(): Point | undefined {
+	if (!wfbm.selection.value.length) return;
+
+	const target = event.target as HTMLElement;
+	if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return;
+
+	function getDirection(): Point | undefined {
 		switch (event.key) {
 			case "ArrowDown":
 				return { x: 0, y: GRID_TICK };
@@ -894,17 +899,16 @@ function handleKeydown(event: KeyboardEvent) {
 				return { x: GRID_TICK, y: 0 };
 		}
 	}
-	const vector = getVector();
-	if (vector === undefined) return;
+	const direction = getDirection();
+	if (direction === undefined) return;
 
-	if (!wfbm.selection.value.length) return;
 	event.preventDefault();
 
 	const coordinates = wfbm.selection.value
 		.map((s) => wf.getComponentById(s.componentId))
 		.filter((c) => c?.x !== undefined && c?.y !== undefined)
 		.reduce<Record<Component["id"], Point>>((acc, c) => {
-			acc[c.id] = translatePoint({ x: c.x, y: c.y }, vector);
+			acc[c.id] = translatePoint({ x: c.x, y: c.y }, direction);
 			return acc;
 		}, {});
 
@@ -920,7 +924,7 @@ onMounted(async () => {
 	rootEl.value?.addEventListener("wheel", handleWheel, {
 		signal: abort.signal,
 	});
-	// TODO: bind to other things than document (triggered when input)
+
 	document.addEventListener("keydown", handleKeydown, {
 		signal: abort.signal,
 	});

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -30,7 +30,13 @@
 					</pattern>
 				</defs>
 
-				<rect width="100%" height="100%" fill="url(#grid)" fil />
+				<rect
+					v-if="displayGrid"
+					width="100%"
+					height="100%"
+					fill="url(#grid)"
+					fil
+				/>
 				<BlueprintArrow
 					v-for="(arrow, arrowId) in arrows"
 					:key="arrowId"
@@ -228,6 +234,17 @@ const activeCanvasMove = shallowRef<{
 	offset: Point;
 	isPerfected: boolean;
 } | null>(null);
+
+const displayGrid = useDisplayGridSetting();
+
+function useDisplayGridSetting() {
+	const key = "blueprint__hideGrid";
+	const displayGrid = ref(localStorage.getItem(key) === null);
+	watch(displayGrid, (v) =>
+		v ? localStorage.removeItem(key) : localStorage.setItem(key, "1"),
+	);
+	return displayGrid;
+}
 
 function refreshArrows() {
 	arrows.value = nodes.value.reduce((acc, node) => {
@@ -919,6 +936,17 @@ watch(wfbm.firstSelectedItem, (newSelection) => {
 });
 
 function handleKeydown(event: KeyboardEvent) {
+	const isModifiedKey = isModifierKeyActive(event);
+
+	// toggle grid with "cmd + `" (like Figma)
+	if (
+		isModifiedKey &&
+		(event.code === "Backquote" || event.code === "Backslash")
+	) {
+		displayGrid.value = !displayGrid.value;
+		return;
+	}
+
 	if (!wfbm.selection.value.length) return;
 
 	const target = event.target as HTMLElement;

--- a/src/ui/src/utils/geometry.spec.ts
+++ b/src/ui/src/utils/geometry.spec.ts
@@ -38,7 +38,7 @@ describe(doRectanglesOverlap.name, () => {
 describe(computePointInTheGrid.name, () => {
 	it("should round the axis", () => {
 		expect(computePointInTheGrid({ x: 0.6, y: 1.4 }, 1)).toStrictEqual({
-			x: 0,
+			x: 1,
 			y: 1,
 		});
 	});

--- a/src/ui/src/utils/geometry.spec.ts
+++ b/src/ui/src/utils/geometry.spec.ts
@@ -14,8 +14,17 @@ describe(doRectanglesOverlap.name, () => {
 		{ x: 19, y: 19, width: 10, height: 10 },
 		{ x: 12, y: 12, width: 2, height: 2 },
 		{ x: 0, y: 0, width: 30, height: 30 },
+		{ x: 15, y: 15, width: 10, height: 15 },
 	])("should overlap for %s", (rect) => {
 		expect(doRectanglesOverlap(initialRect, rect)).toBe(true);
+	});
+	it("should overlap for", () => {
+		expect(
+			doRectanglesOverlap(
+				{ width: 240, height: 124, x: 48, y: 120 },
+				{ width: 240, height: 167, x: 72, y: 96 },
+			),
+		).toBe(true);
 	});
 
 	it.each([

--- a/src/ui/src/utils/geometry.spec.ts
+++ b/src/ui/src/utils/geometry.spec.ts
@@ -1,51 +1,28 @@
 import { describe, expect, it } from "vitest";
 import {
 	Rectangle,
-	areRectanglesColliding,
+	doRectanglesOverlap,
 	computePointInTheGrid,
 	positionateRectangleWithoutColision,
 } from "./geometry";
 
-describe(areRectanglesColliding.name, () => {
-	it("should overlap on y and y", () => {
-		expect(
-			areRectanglesColliding(
-				{ x: 0, y: 0, width: 10, height: 10 },
-				{ x: 9, y: 9, width: 10, height: 10 },
-			),
-		).toBe(true);
+describe(doRectanglesOverlap.name, () => {
+	const initialRect: Rectangle = { x: 10, y: 10, width: 10, height: 10 };
+
+	it.each([
+		{ x: 0, y: 0, width: 10, height: 10 },
+		{ x: 19, y: 19, width: 10, height: 10 },
+		{ x: 12, y: 12, width: 2, height: 2 },
+		{ x: 0, y: 0, width: 30, height: 30 },
+	])("should overlap for %s", (rect) => {
+		expect(doRectanglesOverlap(initialRect, rect)).toBe(true);
 	});
-	it("should overlap on x", () => {
-		expect(
-			areRectanglesColliding(
-				{ x: 7, y: 10, width: 10, height: 10 },
-				{ x: 0, y: 0, width: 10, height: 10 },
-			),
-		).toBe(true);
-	});
-	it("should overlap with width", () => {
-		expect(
-			areRectanglesColliding(
-				{ x: 10, y: 10, width: 10, height: 10 },
-				{ x: 5, y: 5, width: 10, height: 10 },
-			),
-		).toBe(true);
-	});
-	it("should overlap when contains the other", () => {
-		expect(
-			areRectanglesColliding(
-				{ x: 10, y: 10, width: 10, height: 10 },
-				{ x: 0, y: 0, width: 30, height: 30 },
-			),
-		).toBe(true);
-	});
-	it("should not overlap", () => {
-		expect(
-			areRectanglesColliding(
-				{ x: 0, y: 0, width: 10, height: 10 },
-				{ x: 20, y: 20, width: 10, height: 10 },
-			),
-		).toBe(false);
+
+	it.each([
+		{ x: 0, y: 0, width: 1, height: 1 },
+		{ x: 30, y: 30, width: 10, height: 10 },
+	])("should not overlap for %s", (rect) => {
+		expect(doRectanglesOverlap(initialRect, rect)).toBe(false);
 	});
 });
 
@@ -66,26 +43,26 @@ describe(computePointInTheGrid.name, () => {
 });
 
 describe(positionateRectangleWithoutColision.name, () => {
-	const rectangles: Rectangle[] = [{ x: 0, y: 0, width: 10, height: 10 }];
+	const rectangles: Rectangle[] = [{ x: 10, y: 10, width: 10, height: 10 }];
 
 	it.each([
 		{
 			input: { x: 20, y: 20, width: 10, height: 10 },
-			expected: { x: 20, y: 20, width: 10, height: 10 },
+			expected: { x: 20, y: 21, width: 10, height: 10 },
 		},
 		{
 			input: { x: 9, y: 9, width: 10, height: 10 },
-			expected: { x: 11, y: 11, width: 10, height: 10 },
+			expected: { x: 9, y: 21, width: 10, height: 10 },
 		},
 		{
 			input: { x: 1, y: 1, width: 10, height: 10 },
-			expected: { x: 11, y: 11, width: 10, height: 10 },
+			expected: { x: 1, y: 21, width: 10, height: 10 },
 		},
 		{
 			input: { x: 0, y: 10, width: 10, height: 10 },
-			expected: { x: 11, y: 11, width: 10, height: 10 },
+			expected: { x: 0, y: 21, width: 10, height: 10 },
 		},
-	])("should positionate the rectange", ({ input, expected }) => {
+	])("should positionate the rectange $input", ({ input, expected }) => {
 		expect(
 			positionateRectangleWithoutColision(input, rectangles, 1),
 		).toStrictEqual(expected);

--- a/src/ui/src/utils/geometry.spec.ts
+++ b/src/ui/src/utils/geometry.spec.ts
@@ -3,7 +3,7 @@ import {
 	Rectangle,
 	doRectanglesOverlap,
 	computePointInTheGrid,
-	positionateRectangleWithoutColision,
+	positionateRectangleWithoutOverlap,
 } from "./geometry";
 
 describe(doRectanglesOverlap.name, () => {
@@ -51,7 +51,7 @@ describe(computePointInTheGrid.name, () => {
 	});
 });
 
-describe(positionateRectangleWithoutColision.name, () => {
+describe(positionateRectangleWithoutOverlap.name, () => {
 	const rectangles: Rectangle[] = [{ x: 10, y: 10, width: 10, height: 10 }];
 
 	it.each([
@@ -73,7 +73,7 @@ describe(positionateRectangleWithoutColision.name, () => {
 		},
 	])("should positionate the rectange $input", ({ input, expected }) => {
 		expect(
-			positionateRectangleWithoutColision(input, rectangles, 1),
+			positionateRectangleWithoutOverlap(input, rectangles, 1),
 		).toStrictEqual(expected);
 	});
 });

--- a/src/ui/src/utils/geometry.spec.ts
+++ b/src/ui/src/utils/geometry.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+	Rectangle,
+	areRectanglesColliding,
+	computePointInTheGrid,
+	positionateRectangleWithoutColision,
+} from "./geometry";
+
+describe(areRectanglesColliding.name, () => {
+	it("should overlap on y and y", () => {
+		expect(
+			areRectanglesColliding(
+				{ x: 0, y: 0, width: 10, height: 10 },
+				{ x: 9, y: 9, width: 10, height: 10 },
+			),
+		).toBe(true);
+	});
+	it("should overlap on x", () => {
+		expect(
+			areRectanglesColliding(
+				{ x: 7, y: 10, width: 10, height: 10 },
+				{ x: 0, y: 0, width: 10, height: 10 },
+			),
+		).toBe(true);
+	});
+	it("should overlap with width", () => {
+		expect(
+			areRectanglesColliding(
+				{ x: 10, y: 10, width: 10, height: 10 },
+				{ x: 5, y: 5, width: 10, height: 10 },
+			),
+		).toBe(true);
+	});
+	it("should overlap when contains the other", () => {
+		expect(
+			areRectanglesColliding(
+				{ x: 10, y: 10, width: 10, height: 10 },
+				{ x: 0, y: 0, width: 30, height: 30 },
+			),
+		).toBe(true);
+	});
+	it("should not overlap", () => {
+		expect(
+			areRectanglesColliding(
+				{ x: 0, y: 0, width: 10, height: 10 },
+				{ x: 20, y: 20, width: 10, height: 10 },
+			),
+		).toBe(false);
+	});
+});
+
+describe(computePointInTheGrid.name, () => {
+	it("should round the axis", () => {
+		expect(computePointInTheGrid({ x: 0.6, y: 1.4 }, 1)).toStrictEqual({
+			x: 0,
+			y: 1,
+		});
+	});
+
+	it("should not round the axis", () => {
+		expect(computePointInTheGrid({ x: 0, y: 1 }, 1)).toStrictEqual({
+			x: 0,
+			y: 1,
+		});
+	});
+});
+
+describe(positionateRectangleWithoutColision.name, () => {
+	const rectangles: Rectangle[] = [{ x: 0, y: 0, width: 10, height: 10 }];
+
+	it.each([
+		{
+			input: { x: 20, y: 20, width: 10, height: 10 },
+			expected: { x: 20, y: 20, width: 10, height: 10 },
+		},
+		{
+			input: { x: 9, y: 9, width: 10, height: 10 },
+			expected: { x: 11, y: 11, width: 10, height: 10 },
+		},
+		{
+			input: { x: 1, y: 1, width: 10, height: 10 },
+			expected: { x: 11, y: 11, width: 10, height: 10 },
+		},
+		{
+			input: { x: 0, y: 10, width: 10, height: 10 },
+			expected: { x: 11, y: 11, width: 10, height: 10 },
+		},
+	])("should positionate the rectange", ({ input, expected }) => {
+		expect(
+			positionateRectangleWithoutColision(input, rectangles, 1),
+		).toStrictEqual(expected);
+	});
+});

--- a/src/ui/src/utils/geometry.ts
+++ b/src/ui/src/utils/geometry.ts
@@ -26,30 +26,30 @@ function getRectangeCenterPoint(rect: Rectangle): Point {
 function isInRange(value: number, min: number, max: number) {
 	return value >= min && value <= max;
 }
-
-function computeRectanglePoints(
-	rect: Rectangle,
-): [x1: number, x2: number, y1: number, y2: number] {
-	return [rect.x, rect.x + rect.width, rect.y, rect.y + rect.height];
-}
-
-export function isRectangleInside(a: Rectangle, b: Rectangle): boolean {
-	const [aX1, aX2, aY1, aY2] = computeRectanglePoints(a);
-	const [bX1, bX2, bY1, bY2] = computeRectanglePoints(b);
-	const isXContained = isInRange(aX1, bX1, bX2) && isInRange(aX2, bX1, bX2);
-	const isYContained = isInRange(aY1, bY1, bY2) && isInRange(aY2, bY1, bY2);
-	return isXContained && isYContained;
+function doRangeOverlap(a1: number, a2: number, b1: number, b2: number) {
+	return (
+		isInRange(a1, b1, b2) ||
+		isInRange(a2, b1, b2) ||
+		isInRange(b1, a1, a2) ||
+		isInRange(b2, a1, a2)
+	);
 }
 
 export function doRectanglesOverlap(a: Rectangle, b: Rectangle): boolean {
-	const [aX1, aX2, aY1, aY2] = computeRectanglePoints(a);
-	const [bX1, bX2, bY1, bY2] = computeRectanglePoints(b);
+	const isXOverlaping = doRangeOverlap(
+		a.x,
+		a.x + a.width,
+		b.x,
+		b.x + b.width,
+	);
+	const isYOverlaping = doRangeOverlap(
+		a.y,
+		a.y + a.height,
+		b.y,
+		b.y + b.height,
+	);
 
-	const isXOverlaping = isInRange(bX1, aX1, aX2) || isInRange(bX2, aX1, aX2);
-	const isYOverlaping = isInRange(bY1, aY1, aY2) || isInRange(bY2, aY1, aY2);
-	if (isXOverlaping && isYOverlaping) return true;
-
-	return isRectangleInside(a, b) || isRectangleInside(b, a);
+	return isXOverlaping && isYOverlaping;
 }
 
 /**

--- a/src/ui/src/utils/geometry.ts
+++ b/src/ui/src/utils/geometry.ts
@@ -1,3 +1,5 @@
+import { mathRoundToMultiple } from "./math";
+
 export type Point = { x: number; y: number };
 
 export function computeDistance(a: Point, b: Point) {
@@ -8,8 +10,8 @@ export function computePointInTheGrid(
 	gridTick: number,
 ): Point {
 	return {
-		x: x - (x % gridTick),
-		y: y - (y % gridTick),
+		x: mathRoundToMultiple(x, gridTick),
+		y: mathRoundToMultiple(y, gridTick),
 	};
 }
 

--- a/src/ui/src/utils/geometry.ts
+++ b/src/ui/src/utils/geometry.ts
@@ -27,26 +27,29 @@ function isInRange(value: number, min: number, max: number) {
 	return value >= min && value <= max;
 }
 
-export function areRectanglesColliding(a: Rectangle, b: Rectangle): boolean {
-	return (
-		isInRange(a.x, b.x, b.x + b.width) ||
-		isInRange(b.x, a.x, a.x + a.width) ||
-		isInRange(a.y, b.y, b.y + b.height) ||
-		isInRange(b.y, a.y, a.y + a.height)
-	);
+function computeRectanglePoints(
+	rect: Rectangle,
+): [x1: number, x2: number, y1: number, y2: number] {
+	return [rect.x, rect.x + rect.width, rect.y, rect.y + rect.height];
+}
 
-	if (isInRange(a.x, b.x, b.x + b.width)) return true;
-	if (isInRange(b.x, a.x, a.x + a.width)) return true;
-	if (isInRange(a.y, b.y, b.y + b.height)) return true;
-	if (isInRange(b.y, a.y, a.y + a.height)) return true;
-	return false;
-	// if (isInRange(b.x, a.x, a.x + a.width)) return true;
-	return !(
-		a.x + a.width <= b.x ||
-		a.x >= b.x + b.width ||
-		a.y + a.height <= b.y ||
-		a.y >= b.y + b.height
-	);
+export function isRectangleInside(a: Rectangle, b: Rectangle): boolean {
+	const [aX1, aX2, aY1, aY2] = computeRectanglePoints(a);
+	const [bX1, bX2, bY1, bY2] = computeRectanglePoints(b);
+	const isXContained = isInRange(aX1, bX1, bX2) && isInRange(aX2, bX1, bX2);
+	const isYContained = isInRange(aY1, bY1, bY2) && isInRange(aY2, bY1, bY2);
+	return isXContained && isYContained;
+}
+
+export function doRectanglesOverlap(a: Rectangle, b: Rectangle): boolean {
+	const [aX1, aX2, aY1, aY2] = computeRectanglePoints(a);
+	const [bX1, bX2, bY1, bY2] = computeRectanglePoints(b);
+
+	const isXOverlaping = isInRange(bX1, aX1, aX2) || isInRange(bX2, aX1, aX2);
+	const isYOverlaping = isInRange(bY1, aY1, aY2) || isInRange(bY2, aY1, aY2);
+	if (isXOverlaping && isYOverlaping) return true;
+
+	return isRectangleInside(a, b) || isRectangleInside(b, a);
 }
 
 /**
@@ -78,7 +81,7 @@ export function positionateRectangleWithoutColision(
 	function isPointValid(point: Point) {
 		if (point.x < 0 || point.y < 0) return false;
 		const rect = buildRectangleFromPoint(point);
-		return !otherRectangles.some((r) => areRectanglesColliding(rect, r));
+		return !otherRectangles.some((r) => doRectanglesOverlap(rect, r));
 	}
 
 	function addQueue(p: Point) {

--- a/src/ui/src/utils/geometry.ts
+++ b/src/ui/src/utils/geometry.ts
@@ -55,7 +55,7 @@ export function doRectanglesOverlap(a: Rectangle, b: Rectangle): boolean {
 /**
  *
  */
-export function positionateRectangleWithoutColision(
+export function positionateRectangleWithoutOverlap(
 	target: Rectangle,
 	otherRectangles: Rectangle[],
 	gridTick: number,

--- a/src/ui/src/utils/geometry.ts
+++ b/src/ui/src/utils/geometry.ts
@@ -7,16 +7,40 @@ export function computePointInTheGrid(
 	{ x, y }: Point,
 	gridTick: number,
 ): Point {
-	const halfTick = gridTick / 2;
 	return {
-		x: x - (x % gridTick) + halfTick,
-		y: y - (y % gridTick) + halfTick,
+		x: x - (x % gridTick),
+		y: y - (y % gridTick),
 	};
+}
+
+export function translatePoint({ x, y }: Point, { x: tx, y: ty }: Point) {
+	return { x: x + tx, y: y + ty };
 }
 
 export type Rectangle = Point & { width: number; height: number };
 
-export function areRectangesColliding(a: Rectangle, b: Rectangle): boolean {
+function getRectangeCenterPoint(rect: Rectangle): Point {
+	return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+}
+
+function isInRange(value: number, min: number, max: number) {
+	return value >= min && value <= max;
+}
+
+export function areRectanglesColliding(a: Rectangle, b: Rectangle): boolean {
+	return (
+		isInRange(a.x, b.x, b.x + b.width) ||
+		isInRange(b.x, a.x, a.x + a.width) ||
+		isInRange(a.y, b.y, b.y + b.height) ||
+		isInRange(b.y, a.y, a.y + a.height)
+	);
+
+	if (isInRange(a.x, b.x, b.x + b.width)) return true;
+	if (isInRange(b.x, a.x, a.x + a.width)) return true;
+	if (isInRange(a.y, b.y, b.y + b.height)) return true;
+	if (isInRange(b.y, a.y, a.y + a.height)) return true;
+	return false;
+	// if (isInRange(b.x, a.x, a.x + a.width)) return true;
 	return !(
 		a.x + a.width <= b.x ||
 		a.x >= b.x + b.width ||
@@ -25,34 +49,74 @@ export function areRectangesColliding(a: Rectangle, b: Rectangle): boolean {
 	);
 }
 
+/**
+ *
+ */
 export function positionateRectangleWithoutColision(
 	target: Rectangle,
 	otherRectangles: Rectangle[],
-): Point {
-	const collidingRect = otherRectangles.find((rect) =>
-		areRectangesColliding(target, rect),
-	);
+	gridTick: number,
+): Rectangle {
+	const directions: Point[] = [
+		{ x: -gridTick, y: -gridTick },
+		{ x: -gridTick, y: 0 },
+		{ x: -gridTick, y: gridTick },
+		{ x: 0, y: -gridTick },
+		{ x: 0, y: gridTick },
+		{ x: gridTick, y: -gridTick },
+		{ x: gridTick, y: 0 },
+		{ x: gridTick, y: gridTick },
+	];
+	const visited = new Set();
+	const queue: Point[] = [];
+	const solutions: Point[] = [];
 
-	if (!collidingRect) return target;
-
-	const newPosition: Rectangle = { ...target };
-
-	const left = collidingRect.x - newPosition.x;
-	const right = newPosition.x - (collidingRect.x + collidingRect.width);
-	const top = collidingRect.y - newPosition.y;
-	const bottom = newPosition.y - (collidingRect.y + collidingRect.height);
-
-	const minDistance = Math.min(left, right, top, bottom);
-
-	if (minDistance === left) {
-		newPosition.x = collidingRect.x - newPosition.width;
-	} else if (minDistance === right) {
-		newPosition.x = collidingRect.x + collidingRect.width;
-	} else if (minDistance === top) {
-		newPosition.y = collidingRect.y - newPosition.height;
-	} else if (minDistance === bottom) {
-		newPosition.y = collidingRect.y + collidingRect.height;
+	function buildRectangleFromPoint({ x, y }: Point): Rectangle {
+		return { width: target.width, height: target.height, x, y };
 	}
 
-	return positionateRectangleWithoutColision(newPosition, otherRectangles);
+	function isPointValid(point: Point) {
+		if (point.x < 0 || point.y < 0) return false;
+		const rect = buildRectangleFromPoint(point);
+		return !otherRectangles.some((r) => areRectanglesColliding(rect, r));
+	}
+
+	function addQueue(p: Point) {
+		const key = `${p.x},${p.y}`;
+		if (visited.has(key)) return;
+		queue.push(p);
+		visited.add(key);
+	}
+
+	addQueue({ x: target.x, y: target.y });
+
+	while (queue.length) {
+		const point = queue.shift();
+		if (point === undefined) return undefined;
+
+		if (isPointValid(point)) {
+			solutions.push(point);
+		}
+
+		if (solutions.length === 0) {
+			for (const direction of directions) {
+				addQueue(translatePoint(point, direction));
+			}
+		}
+	}
+
+	const targetCenter = getRectangeCenterPoint(target);
+
+	const getDistanceFromTarget = (p: Point) =>
+		computeDistance(
+			targetCenter,
+			getRectangeCenterPoint(buildRectangleFromPoint(p)),
+		);
+
+	const point = solutions
+		.sort((a, b) => getDistanceFromTarget(a) - getDistanceFromTarget(b))
+		.shift();
+	if (point) return buildRectangleFromPoint(point);
+
+	return;
 }

--- a/src/ui/src/utils/geometry.ts
+++ b/src/ui/src/utils/geometry.ts
@@ -53,7 +53,9 @@ export function doRectanglesOverlap(a: Rectangle, b: Rectangle): boolean {
 }
 
 /**
+ * Find the correct position for a given rectangle, avoiding placing the rectangle on top of another.
  *
+ * It'll try the first position, and then move in every direction until it finds the best spot.
  */
 export function positionateRectangleWithoutOverlap(
 	target: Rectangle,
@@ -119,7 +121,6 @@ export function positionateRectangleWithoutOverlap(
 	const point = solutions
 		.sort((a, b) => getDistanceFromTarget(a) - getDistanceFromTarget(b))
 		.shift();
-	if (point) return buildRectangleFromPoint(point);
 
-	return;
+	return point ? buildRectangleFromPoint(point) : undefined;
 }

--- a/src/ui/src/utils/geometry.ts
+++ b/src/ui/src/utils/geometry.ts
@@ -1,0 +1,58 @@
+export type Point = { x: number; y: number };
+
+export function computeDistance(a: Point, b: Point) {
+	return Math.hypot(b.x - a.x, b.y - a.y);
+}
+export function computePointInTheGrid(
+	{ x, y }: Point,
+	gridTick: number,
+): Point {
+	const halfTick = gridTick / 2;
+	return {
+		x: x - (x % gridTick) + halfTick,
+		y: y - (y % gridTick) + halfTick,
+	};
+}
+
+export type Rectangle = Point & { width: number; height: number };
+
+export function areRectangesColliding(a: Rectangle, b: Rectangle): boolean {
+	return !(
+		a.x + a.width <= b.x ||
+		a.x >= b.x + b.width ||
+		a.y + a.height <= b.y ||
+		a.y >= b.y + b.height
+	);
+}
+
+export function positionateRectangleWithoutColision(
+	target: Rectangle,
+	otherRectangles: Rectangle[],
+): Point {
+	const collidingRect = otherRectangles.find((rect) =>
+		areRectangesColliding(target, rect),
+	);
+
+	if (!collidingRect) return target;
+
+	const newPosition: Rectangle = { ...target };
+
+	const left = collidingRect.x - newPosition.x;
+	const right = newPosition.x - (collidingRect.x + collidingRect.width);
+	const top = collidingRect.y - newPosition.y;
+	const bottom = newPosition.y - (collidingRect.y + collidingRect.height);
+
+	const minDistance = Math.min(left, right, top, bottom);
+
+	if (minDistance === left) {
+		newPosition.x = collidingRect.x - newPosition.width;
+	} else if (minDistance === right) {
+		newPosition.x = collidingRect.x + collidingRect.width;
+	} else if (minDistance === top) {
+		newPosition.y = collidingRect.y - newPosition.height;
+	} else if (minDistance === bottom) {
+		newPosition.y = collidingRect.y + collidingRect.height;
+	}
+
+	return positionateRectangleWithoutColision(newPosition, otherRectangles);
+}

--- a/src/ui/src/utils/math.ts
+++ b/src/ui/src/utils/math.ts
@@ -1,3 +1,6 @@
 export function mathCeilToMultiple(nb: number, multiple: number) {
 	return Math.ceil(nb / multiple) * multiple;
 }
+export function mathRoundToMultiple(nb: number, multiple: number) {
+	return Math.round(nb / multiple) * multiple;
+}

--- a/src/ui/src/utils/math.ts
+++ b/src/ui/src/utils/math.ts
@@ -1,0 +1,3 @@
+export function mathCeilToMultiple(nb: number, multiple: number) {
+	return Math.ceil(nb / multiple) * multiple;
+}


### PR DESCRIPTION
Improve experience for positioning blueprint nodes:

1. introduce an internal grid in Blueprint canvas 
2. Introduce key listen to move the selected component
3. Prevents user from overlaying two nodes 

https://github.com/user-attachments/assets/7010ad56-a05a-4e8d-9be3-ad9974c4edf2

