### PR TITLE
fix: Undo reliability issues

### DIFF
--- a/src/ui/src/builder/builderManager.ts
+++ b/src/ui/src/builder/builderManager.ts
@@ -1,6 +1,7 @@
 import { computed, readonly, ref, Ref } from "vue";
 import { Component, ClipboardOperation } from "@/writerTypes";
 import { useLocalStorageJSON } from "@/composables/useLocalStorageJSON";
+import { useLogger } from "@/composables/useLogger.js";
 
 export const CANDIDATE_CONFIRMATION_DELAY_MS = 1500;
 
@@ -17,6 +18,7 @@ const MAX_LOG_ENTRIES = 100;
 
 export const panelIds = ["code", "log"];
 export type PanelId = (typeof panelIds)[number];
+const logger = useLogger();
 
 export type BlueprintExecutionLog = {
 	summary: {
@@ -284,7 +286,14 @@ export function generateBuilderManager() {
 	};
 
 	const closeMutationTransaction = (transactionId: string) => {
-		if (activeMutationTransaction.id !== transactionId) return;
+		if (activeMutationTransaction.id !== transactionId) {
+			logger.warn(
+				"Mutation transaction mismatch.",
+				transactionId,
+				activeMutationTransaction.id,
+			);
+			return;
+		};
 		activeMutationTransaction.timestamp = Date.now();
 		mutationTransactions.push(activeMutationTransaction);
 		activeMutationTransaction = null;

--- a/src/ui/src/builder/builderManager.ts
+++ b/src/ui/src/builder/builderManager.ts
@@ -1,4 +1,4 @@
-import { computed, ref, Ref } from "vue";
+import { computed, readonly, ref, Ref } from "vue";
 import { Component, ClipboardOperation } from "@/writerTypes";
 import { useLocalStorageJSON } from "@/composables/useLocalStorageJSON";
 
@@ -407,6 +407,7 @@ export function generateBuilderManager() {
 		selection: computed(() => state.value.selection),
 		setClipboard,
 		getClipboard,
+		mutationTransactions: readonly(mutationTransactions),
 		openMutationTransaction,
 		registerPreMutation,
 		registerPostMutation,

--- a/src/ui/src/builder/useComponentActions.ts
+++ b/src/ui/src/builder/useComponentActions.ts
@@ -825,15 +825,16 @@ export function useComponentActions(wf: Core, ssbm: BuilderManager) {
 	function changeCoordinatesMultiple(
 		coordinates: Record<Component["id"], { x: number; y: number }>,
 	) {
-		const transactionId = "change-multiple-coordinates";
+		const entries = Object.entries(coordinates);
+		if (entries.length == 0) return;
+
+		const transactionId = `change-multiple-coordinates-${Object.keys(coordinates).join(",")}`;
 		ssbm.openMutationTransaction(
 			transactionId,
 			"Change coordinates",
 			false,
 		);
 
-		const entries = Object.entries(coordinates);
-		if (entries.length == 0) return;
 		entries.forEach(([componentId, { x, y }]) => {
 			const component = wf.getComponentById(componentId);
 			if (!component) return;
@@ -965,7 +966,10 @@ export function useComponentActions(wf: Core, ssbm: BuilderManager) {
 	): Component["id"] {
 		const component = wf.getComponentById(componentId);
 		if (!component || component.type == "root") return null;
-		if (component.type == "page" || component.type == "blueprints_blueprint")
+		if (
+			component.type == "page" ||
+			component.type == "blueprints_blueprint"
+		)
 			return componentId;
 		return getContainingPageId(component.parentId);
 	}

--- a/src/ui/src/main.ts
+++ b/src/ui/src/main.ts
@@ -22,10 +22,12 @@ const logger = useLogger();
 async function load() {
 	await wf.init();
 	const mode = wf.mode.value;
-	const ssbm = mode == "edit" ? generateBuilderManager() : undefined;
+	const wfbm = mode == "edit" ? generateBuilderManager() : undefined;
 
-	if (ssbm) {
-		wf.addMailSubscription("logEntry", ssbm.handleLogEntry);
+	if (wfbm) {
+		wf.addMailSubscription("logEntry", wfbm.handleLogEntry);
+		// eslint-disable-next-line no-undef
+		globalThis.wfbm = wfbm;
 	}
 
 	logger.log(`Mounting app in mode ${mode}...`);
@@ -38,7 +40,7 @@ async function load() {
 	const app = createApp(componentRenderer || builderApp);
 	app.use(VueDOMPurifyHTML);
 	app.provide(injectionKeys.core, wf);
-	app.provide(injectionKeys.builderManager, ssbm);
+	app.provide(injectionKeys.builderManager, wfbm);
 	setCaptureTabsDirective(app);
 
 	app.mount("#app");


### PR DESCRIPTION
@madeindjs I fixed the undo reliability issues. Basically the `change-multiple-coordinates` transaction remained open when there were no entries. This ended up really disrupting undo/redo, especially because change coordinates is called on every `mouseup`.

I also added some stuff that was useful for debugging this and a warning that'd have caught this. Please take a look.