### PR TITLE
fix: autogen X-Agent-Token header retrieval

### DIFF
--- a/src/writer/autogen.py
+++ b/src/writer/autogen.py
@@ -267,6 +267,13 @@ def generate_blueprint(description: str, token_header: Optional[str] = None):
     tools = _get_tools()
     print(json.dumps(tools))
 
+    if token_header:
+        extra_headers = {
+            "X-Agent-Token": token_header
+        }
+    else:
+        extra_headers = {}
+
     for i in range(MAX_ITERATIONS):
         if i > 0:
             messages += [
@@ -281,9 +288,7 @@ def generate_blueprint(description: str, token_header: Optional[str] = None):
             tool_choice="required",
             tools=tools,
             stream=False,  # type: ignore
-            extra_headers={
-                "X-Agent-Token": token_header
-            }
+            extra_headers=extra_headers
         )
 
         response_message = response.choices[0].message


### PR DESCRIPTION
Fixes the error when trying to use the Autogen in local environment, without `X-Agent-Token` present.