### PR TITLE
feat(ui): introduce the App name renamer field - WF-355

### DIFF
--- a/src/ui/src/builder/BuilderHeader.vue
+++ b/src/ui/src/builder/BuilderHeader.vue
@@ -1,6 +1,19 @@
 <template>
 	<div class="BuilderHeader">
-		<img src="../assets/logo.svg" alt="Writer Framework logo" />
+		<div v-if="canDeploy" class="BuilderHeader__appTitle">
+			<a
+				:href="writerDeployUrl.toString()"
+				class="BuilderHeader__appTitle__goBack"
+			>
+				<i class="material-symbols-outlined">arrow_back</i>
+			</a>
+			<input
+				v-model="applicationName"
+				type="text"
+				class="BuilderHeader__appTitle__input"
+			/>
+		</div>
+		<img v-else src="../assets/logo.svg" alt="Writer Framework logo" />
 		<BuilderSwitcher />
 		<div class="gap"></div>
 		<div class="BuilderHeader__toolbar">
@@ -104,6 +117,8 @@ const {
 	publishApplication,
 	hasBeenPublished,
 	lastDeployedAt,
+	name: applicationName,
+	writerDeployUrl,
 } = useApplicationCloud(wf);
 
 const undoRedoSnapshot = computed(() => getUndoRedoSnapshot());
@@ -200,6 +215,34 @@ function showStateExplorer() {
 	gap: 16px;
 	padding-top: 1px;
 	border-bottom: 1px solid var(--builderAreaSeparatorColor);
+}
+
+.BuilderHeader__appTitle {
+	height: 100%;
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	width: calc(var(--builderSidebarWidth) - 16px);
+	padding-right: 16px;
+	border-right: 1px solid var(--wdsColorGray5);
+}
+.BuilderHeader__appTitle__goBack {
+	text-decoration: none;
+}
+.BuilderHeader__appTitle__input {
+	background-color: transparent;
+	width: 100%;
+	border: none;
+	font-weight: 500;
+	font-size: 18px;
+	border-radius: 4px;
+	padding: 4px;
+	height: 32px;
+}
+.BuilderHeader__appTitle__input:hover,
+.BuilderHeader__appTitle__input:focus {
+	outline: none;
+	background-color: var(--wdsColorGray5);
 }
 
 .BuilderHeader__toolbar {

--- a/src/ui/src/builder/panels/BuilderCodePanel.vue
+++ b/src/ui/src/builder/panels/BuilderCodePanel.vue
@@ -178,7 +178,7 @@ function useKeydownCmdS(callback: () => void | Promise<void>) {
 			{ signal: abortController.signal },
 		);
 	});
-	onUnmounted(abortController.abort);
+	onUnmounted(() => abortController.abort());
 }
 useKeydownCmdS(handleSave);
 

--- a/src/ui/src/composables/useDebouncer.spec.ts
+++ b/src/ui/src/composables/useDebouncer.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, vi, expect, beforeAll, afterAll } from "vitest";
+import { useDebouncer } from "./useDebouncer";
+
+describe(useDebouncer.name, () => {
+	beforeAll(() => {
+		vi.useFakeTimers();
+	});
+
+	afterAll(() => {
+		vi.useRealTimers();
+	});
+
+	it("should call the callback one time", () => {
+		const callback = vi.fn();
+
+		const callbackDebounced = useDebouncer(callback, 1_000);
+
+		callbackDebounced();
+		callbackDebounced();
+		vi.advanceTimersByTime(1_000);
+		expect(callback).toHaveBeenCalledTimes(1);
+
+		callbackDebounced();
+		vi.advanceTimersByTime(500);
+		expect(callback).toHaveBeenCalledTimes(1);
+
+		callbackDebounced();
+		vi.advanceTimersByTime(1_000);
+		expect(callback).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/ui/src/composables/useDebouncer.ts
+++ b/src/ui/src/composables/useDebouncer.ts
@@ -1,0 +1,7 @@
+export function useDebouncer(callback: () => void | Promise<void>, ms: number) {
+	let id: ReturnType<typeof setTimeout>;
+	return () => {
+		if (id) clearTimeout(id);
+		id = setTimeout(callback, ms);
+	};
+}

--- a/src/ui/src/tests/mocks.ts
+++ b/src/ui/src/tests/mocks.ts
@@ -38,12 +38,14 @@ export function buildMockCore() {
 	const writerApplication = shallowRef<
 		{ id: string; organizationId: string } | undefined
 	>();
+	const mode = shallowRef<"run" | "edit">(null);
 
 	core.userFunctions = userFunctions;
 	core.userState = userState;
 	core.sourceFiles = sourceFiles;
 	core.featureFlags = featureFlags;
 	core.writerApplication = writerApplication;
+	core.mode = mode;
 
 	vi.spyOn(core, "sendComponentUpdate").mockImplementation(async () => {});
 
@@ -54,6 +56,7 @@ export function buildMockCore() {
 		userFunctions,
 		featureFlags,
 		writerApplication,
+		mode,
 	};
 }
 

--- a/src/ui/src/writerApi.ts
+++ b/src/ui/src/writerApi.ts
@@ -48,7 +48,51 @@ export class WriterApi {
 		const data = await res.json();
 		return data;
 	}
+
+	async updateApplicationMetadata(
+		orgId: number,
+		appId: string,
+		body: Partial<
+			Omit<
+				WriterApiApplicationMetadata,
+				| "id"
+				| "applicationId"
+				| "createdBy"
+				| "createdBy"
+				| "updatedAt"
+				| "updatedBy"
+			>
+		>,
+	): Promise<WriterApiApplicationMetadata> {
+		const url = new URL(
+			`/api/template/organization/${orgId}/application/${appId}/metadata`,
+			this.#baseUrl,
+		);
+
+		const res = await fetch(url, {
+			method: "PUT",
+			body: JSON.stringify(body),
+			signal: this.#signal,
+			credentials: "include",
+		});
+		if (!res.ok) throw Error(await res.text());
+
+		const data = await res.json();
+		return data;
+	}
 }
+
+type WriterApiApplicationMetadata = {
+	id: string;
+	applicationId: string;
+	name: string;
+	description: string | null;
+	shortDescription: string | null;
+	guideUrl: string | null;
+	tutorialUrl: string | null;
+	icon: string | null;
+	idAlias: string | null;
+} & WriterApiBlamable;
 
 type WriterApiUser = {
 	id: number;


### PR DESCRIPTION
Add an input field in the navbar to update the Agent name through the endpoint

```http
PUT /api/template/organization/{orgId}/application/{appId}/metadata
```

The logic in `useApplicationCloud` will handle synchronization with the special block `root` and update the field `appName`.

![image](https://github.com/user-attachments/assets/b55d3430-b7a3-4cc9-af52-73745c8f4a15)
