### PR TITLE
feat(ui): copy component in clipboard to share it - WF-271

### DIFF
--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -93,6 +93,7 @@ import { WDS_CSS_PROPERTIES } from "@/wds/tokens";
 import { SelectionStatus } from "./builderManager";
 import BuilderToasts from "./BuilderToasts.vue";
 import { useWriterTracking } from "@/composables/useWriterTracking";
+import { useToasts } from "./useToast";
 
 const BuilderSettings = defineAsyncComponent({
 	loader: () => import("./settings/BuilderSettings.vue"),
@@ -151,10 +152,12 @@ const {
 	goToParent,
 } = useComponentActions(wf, ssbm, tracking);
 
+const toasts = useToasts();
+
 const builderMode = computed(() => ssbm.getMode());
 const selectedId = computed(() => ssbm.firstSelectedId.value);
 
-function handleKeydown(ev: KeyboardEvent): void {
+async function handleKeydown(ev: KeyboardEvent) {
 	if (ev.key == "Escape") {
 		ssbm.setSelection(null);
 		return;
@@ -204,7 +207,11 @@ function handleKeydown(ev: KeyboardEvent): void {
 	}
 	if (ev.key == "v" && isModifierKeyActive) {
 		if (!isPasteAllowed(selectedId)) return;
-		pasteComponent(selectedId);
+		try {
+			await pasteComponent(selectedId);
+		} catch (error) {
+			toasts.pushToast({ type: "error", message: String(error) });
+		}
 		return;
 	}
 	if (ev.key == "c" && isModifierKeyActive) {

--- a/src/ui/src/builder/BuilderToasts.vue
+++ b/src/ui/src/builder/BuilderToasts.vue
@@ -27,7 +27,7 @@ const { toasts, removeToast } = useToasts();
 	position: fixed;
 	bottom: 12px;
 	right: 12px;
-	z-index: 1;
+	z-index: 5;
 }
 
 .BuilderToasts__toast {

--- a/src/ui/src/builder/builderManager.ts
+++ b/src/ui/src/builder/builderManager.ts
@@ -1,5 +1,5 @@
 import { computed, readonly, ref, Ref } from "vue";
-import { Component, ClipboardOperation } from "@/writerTypes";
+import { Component } from "@/writerTypes";
 import { useLocalStorageJSON } from "@/composables/useLocalStorageJSON";
 import { useLogger } from "@/composables/useLogger.js";
 
@@ -73,10 +73,6 @@ type State = {
 		instancePath: string;
 		source: SelectionSource;
 	}[];
-	clipboard: {
-		operation: ClipboardOperation;
-		jsonSubtree: string;
-	};
 	mutationTransactionsSnapshot: {
 		undo: ComponentMutationTransaction;
 		redo: ComponentMutationTransaction;
@@ -91,7 +87,6 @@ export function generateBuilderManager() {
 	const initState: State = {
 		mode: modeCache.value ?? "ui",
 		selection: [],
-		clipboard: null,
 		mutationTransactionsSnapshot: {
 			undo: null,
 			redo: null,
@@ -213,14 +208,6 @@ export function generateBuilderManager() {
 		() => state.value.selection[0]?.componentId,
 	);
 
-	const setClipboard = (clipboard: State["clipboard"]) => {
-		state.value.clipboard = clipboard;
-	};
-
-	const getClipboard = () => {
-		return state.value.clipboard;
-	};
-
 	const openMutationTransaction = (
 		transactionId: string,
 		transactionDesc: string,
@@ -293,7 +280,7 @@ export function generateBuilderManager() {
 				activeMutationTransaction.id,
 			);
 			return;
-		};
+		}
 		activeMutationTransaction.timestamp = Date.now();
 		mutationTransactions.push(activeMutationTransaction);
 		activeMutationTransaction = null;
@@ -414,8 +401,6 @@ export function generateBuilderManager() {
 		appendSelection,
 		handleSelectionFromEvent,
 		selection: computed(() => state.value.selection),
-		setClipboard,
-		getClipboard,
 		mutationTransactions: readonly(mutationTransactions),
 		openMutationTransaction,
 		registerPreMutation,

--- a/src/ui/src/builder/panels/BuilderLogBlueprintExecutionTrace.vue
+++ b/src/ui/src/builder/panels/BuilderLogBlueprintExecutionTrace.vue
@@ -132,7 +132,7 @@
 <script setup lang="ts">
 import injectionKeys from "@/injectionKeys";
 import { BlueprintExecutionLog } from "../builderManager";
-import { computed, inject, nextTick, onMounted, toRaw } from "vue";
+import { computed, inject, nextTick, onMounted } from "vue";
 import SharedJsonViewer from "@/components/shared/SharedJsonViewer/SharedJsonViewer.vue";
 import WdsButton from "@/wds/WdsButton.vue";
 import { Component } from "@/writerTypes";

--- a/src/ui/src/builder/settings/BuilderSettingsActions.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsActions.vue
@@ -92,7 +92,7 @@
 			:data-writer-tooltip="`Paste (${getModifierKeyName()}V)`"
 			data-writer-tooltip-placement="left"
 			:disabled="!isPasteEnabled"
-			@click="isPasteEnabled ? pasteComponent(selectedId) : undefined"
+			@click="handlePasteComponent"
 		>
 			<i class="material-symbols-outlined">content_paste</i>
 		</WdsButton>
@@ -173,6 +173,7 @@ import WdsButton from "@/wds/WdsButton.vue";
 import WdsModal from "@/wds/WdsModal.vue";
 import { SelectionStatus } from "../builderManager";
 import { useWriterTracking } from "@/composables/useWriterTracking";
+import { useToasts } from "../useToast";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -196,6 +197,16 @@ const {
 	removeComponentsSubtree,
 	goToParent,
 } = useComponentActions(wf, ssbm, tracking);
+
+const toasts = useToasts();
+
+async function handlePasteComponent() {
+	try {
+		await pasteComponent(selectedId.value);
+	} catch (error) {
+		toasts.pushToast({ type: "error", message: String(error) });
+	}
+}
 
 function deleteSelectedComponents() {
 	if (!shortcutsInfo.value.isDeleteEnabled) return;

--- a/src/ui/src/builder/settings/BuilderSettingsActions.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsActions.vue
@@ -91,12 +91,8 @@
 			size="small"
 			:data-writer-tooltip="`Paste (${getModifierKeyName()}V)`"
 			data-writer-tooltip-placement="left"
-			:disabled="!shortcutsInfo?.isPasteEnabled"
-			@click="
-				shortcutsInfo?.isPasteEnabled
-					? pasteComponent(selectedId)
-					: undefined
-			"
+			:disabled="!isPasteEnabled"
+			@click="isPasteEnabled ? pasteComponent(selectedId) : undefined"
 		>
 			<i class="material-symbols-outlined">content_paste</i>
 		</WdsButton>
@@ -223,10 +219,14 @@ const shortcutsInfo: Ref<{
 	isMoveDownEnabled: boolean;
 	isCopyEnabled: boolean;
 	isCutEnabled: boolean;
-	isPasteEnabled: boolean;
 	isGoToParentEnabled: boolean;
 	isDeleteEnabled: boolean;
 }> = ref(null);
+
+const isPasteEnabled = computed(() => {
+	if (!ssbm.firstSelectedId.value) return false;
+	return isPasteAllowed(ssbm.firstSelectedId.value);
+});
 
 const validChildrenTypes = computed(() => {
 	const types = wf.getContainableTypes(selectedId.value);
@@ -268,7 +268,6 @@ function reprocessShorcutsInfo(): void {
 		isMoveDownEnabled,
 		isCopyEnabled: isCopyAllowed(selectedId.value),
 		isCutEnabled: isCutAllowed(selectedId.value),
-		isPasteEnabled: isPasteAllowed(selectedId.value),
 		isGoToParentEnabled: isGoToParentAllowed(selectedId.value),
 		isDeleteEnabled: isDeleteAllowed(selectedId.value),
 	};

--- a/src/ui/src/builder/useComponentClipboard.ts
+++ b/src/ui/src/builder/useComponentClipboard.ts
@@ -1,0 +1,68 @@
+import { useLogger } from "@/composables/useLogger";
+import { Component } from "@/writerTypes";
+import { computed, onMounted, onUnmounted, shallowRef } from "vue";
+
+type ClipboardData = {
+	type: "writer/clipboard";
+	components: Component[];
+};
+
+function isClipboardData(data: unknown): data is ClipboardData {
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		"type" in data &&
+		data.type === "writer/clipboard" &&
+		"components" in data &&
+		Array.isArray(data.components)
+	);
+}
+
+let intervalId: ReturnType<typeof setInterval> | undefined;
+
+export function useComponentClipboard() {
+	const components = shallowRef<Component[]>([]);
+	const logger = useLogger();
+
+	onMounted(async () => {
+		components.value = await get();
+
+		if (intervalId) return;
+
+		intervalId = setInterval(async () => {
+			components.value = await get();
+		}, 1_000);
+	});
+
+	onUnmounted(() => {
+		if (intervalId) clearInterval(intervalId);
+	});
+
+	async function get(): Promise<Component[]> {
+		try {
+			const text = await navigator.clipboard.readText();
+			const data = JSON.parse(text);
+			return isClipboardData(data) ? data.components : [];
+		} catch {
+			return [];
+		}
+	}
+
+	return computed<Component[]>({
+		get() {
+			return components.value;
+		},
+		set(value) {
+			components.value = value;
+			try {
+				const data: ClipboardData = {
+					type: "writer/clipboard",
+					components: value,
+				};
+				navigator.clipboard.writeText(JSON.stringify(data));
+			} catch (e) {
+				logger.warn("Failed to write components in the clipboard", e);
+			}
+		},
+	});
+}

--- a/src/ui/src/components/blueprints/base/BlueprintToolbar.vue
+++ b/src/ui/src/components/blueprints/base/BlueprintToolbar.vue
@@ -5,7 +5,6 @@ import WdsButtonSplit from "@/wds/WdsButtonSplit.vue";
 import injectionKeys from "@/injectionKeys";
 import { computed, inject, shallowRef, toRaw, useTemplateRef } from "vue";
 import BlueprintToolbarBlocksDropdown from "./BlueprintToolbarBlocksDropdown.vue";
-import { useWriterTracking } from "@/composables/useWriterTracking";
 
 defineEmits({
 	autogenClick: () => true,
@@ -16,8 +15,6 @@ const wfbm = inject(injectionKeys.builderManager);
 const blueprintComponentId = inject(injectionKeys.componentId);
 
 const runBlueprintBtn = useTemplateRef("runBlueprintBtn");
-
-const tracking = useWriterTracking(wf);
 
 const { run: handleRun, isRunning } = useBlueprintRun(wf, blueprintComponentId);
 

--- a/src/ui/src/wds/WdsCheckbox.vue
+++ b/src/ui/src/wds/WdsCheckbox.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, defineProps, useId } from "vue";
+import { computed, useId } from "vue";
 
 const props = defineProps({
 	label: { type: String, required: false, default: undefined },

--- a/src/ui/src/writerTypes.ts
+++ b/src/ui/src/writerTypes.ts
@@ -68,9 +68,9 @@ export type WriterComponentDefinitionField = {
 	/** Which control (text, textarea, etc) to use if not the default for the type */
 	control?: FieldControl;
 	options?:
-	| Record<string, string>
-	| string // For predefined functions
-	| ((wf?: Core, componentId?: ComponentId) => Record<string, string>); // List of values to be provided as autocomplete options
+		| Record<string, string>
+		| string // For predefined functions
+		| ((wf?: Core, componentId?: ComponentId) => Record<string, string>); // List of values to be provided as autocomplete options
 	/** Data type for the field */
 	type: FieldType;
 	/** Category (Layout, Content, etc) */
@@ -123,11 +123,6 @@ export type WriterComponentDefinition = {
 };
 
 export type BuilderManager = ReturnType<typeof generateBuilderManager>;
-
-export const enum ClipboardOperation {
-	Cut = "cut",
-	Copy = "copy",
-}
 
 export const enum FieldType {
 	Text = "Text",


### PR DESCRIPTION
Use the browser clipboard instead of Vue.js state when copying a component.

This allow the user to copy a component from an agent, and paste it to another agent.