### PR TITLE
fix(ui): makes blueprint assets absolute instead of relative

### DIFF
--- a/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
+++ b/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
@@ -235,7 +235,8 @@ function handleOutMousedown(ev: DragEvent, outId: string) {
 
 const possibleImageUrls = computed(() => {
 	if (["success", "error"].includes(completionStyle.value)) {
-		return [`/status/${completionStyle.value}.svg`];
+		const path = `/status/${completionStyle.value}.svg`;
+		return [convertAbsolutePathtoFullURL(path)];
 	}
 
 	const paths = [


### PR DESCRIPTION
Use `convertAbsolutePathtoFullURL` to import `/status/success.svg` from the origin of the app instead of the root of the URL.