### PR TITLE
fix(ui): autocomplete with closing `}` - WF-372

### DIFF
--- a/src/ui/src/builder/settings/BuilderTemplateInput.vue
+++ b/src/ui/src/builder/settings/BuilderTemplateInput.vue
@@ -100,7 +100,7 @@ const props = defineProps({
 	type: {
 		type: String as PropType<"state" | "template">,
 		required: false,
-		default: undefined,
+		default: "template",
 	},
 	options: {
 		type: Object as PropType<Record<string, string>>,
@@ -169,8 +169,12 @@ function handleComplete(selectedText: string) {
 	if (full === null) return;
 	const keyword = full.at(-1);
 	const regexKeyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "$"; // escape the keyword to handle properly on a regex
-	const replaced = text.replace(new RegExp(regexKeyword), selectedText);
-	newValue = replaced + newValue.slice(selectionEnd);
+	const replaced = text.replace(
+		new RegExp(regexKeyword),
+		`${selectedText}${props.type === "template" ? "}" : ""}`,
+	);
+	const afterText = newValue.slice(selectionEnd).replace(/^(\})+/, ""); // merge the closing bracket to avoid duplicates
+	newValue = replaced.concat(afterText);
 	emit("input", { target: { value: newValue } });
 	emit("update:value", newValue);
 	autocompleteOptions.value = [];

--- a/tests/e2e/tests/stateAutocompletion.spec.ts
+++ b/tests/e2e/tests/stateAutocompletion.spec.ts
@@ -30,7 +30,7 @@ test.describe("state autocompletion", () => {
 			page.locator('.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.prop:text-matches("string")').click();
 			await expect(page
 				.locator('.BuilderFieldsText[data-automation-key="text"] textarea'))
-				.toHaveValue("@{types.string");
+				.toHaveValue("@{types.string}");
 		});
 		test("counter", async ({ page }) => {
 			await setTextField(page, "@{counter");
@@ -84,7 +84,7 @@ test.describe("state autocompletion", () => {
 			await expect(assistedKeyField.locator(`.fieldStateAutocomplete span.prop`)).toHaveText(["none", "string", "integer", "float"]);
 			await expect(assistedKeyField.locator(`.fieldStateAutocomplete span.type`)).toHaveText(["null", "string", "number", "number"]);
 			await assistedKeyField.locator(`.fieldStateAutocomplete span.prop:text-matches("string")`).click();
-			await expect(assistedKeyFieldInput).toHaveValue("@{types.string");
+			await expect(assistedKeyFieldInput).toHaveValue("@{types.string}");
 
 			// value
 
@@ -95,7 +95,7 @@ test.describe("state autocompletion", () => {
 			await expect(assistedValueField.locator(`.fieldStateAutocomplete span.prop`)).toHaveText(["none", "string", "integer", "float"]);
 			await expect(assistedValueField.locator(`.fieldStateAutocomplete span.type`)).toHaveText(["null", "string", "number", "number"]);
 			await assistedValueField.locator(`.fieldStateAutocomplete span.prop:text-matches("string")`).click();
-			await expect(assistedKeyValueInput).toHaveValue("@{types.string");
+			await expect(assistedKeyValueInput).toHaveValue("@{types.string}");
 		});
 	});
 
@@ -114,7 +114,7 @@ test.describe("state autocompletion", () => {
 			page.locator(`${FIELD} .fieldStateAutocomplete span.prop:text-matches("string")`).click();
 			await expect(page
 				.locator(`${FIELD} .BuilderTemplateInput input`))
-				.toHaveValue("@{types.string");
+				.toHaveValue("@{types.string}");
 		});
 	}
 


### PR DESCRIPTION
Close the bracket when autocomplete, example when typing `@{po`, autocomplete with `@{post}`.