### PR TITLE
fix: retry deepcopy of execution environment if failing due to concurrent modification

### DIFF
--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -147,8 +147,37 @@ class BlueprintRunner:
         hashed_id = hashlib.sha256(raw_id.encode()).hexdigest()[:24]
         return hashed_id
 
+    def _safe_snapshot(self, data):
+        """
+        Safely create a snapshot of the data to avoid issues with
+        concurrent modifications.
+        This is a workaround for the issue where the execution environment
+        is being modified concurrently, causing a RuntimeError during deepcopy.
+        """
+        retries = 3
+        for attempt in range(retries):
+            try:
+                return copy.deepcopy(data)
+            except RuntimeError as e:
+                if "dictionary changed size" in str(e):
+                    # Execution environment is being modified concurrently.
+                    # Retry the deepcopy operation.
+                    # Another option would be to use a lock, but that
+                    # could lead to deadlocks.
+                    logging.warning(
+                        "Retrying deepcopy due to concurrent "
+                        f"mutation (attempt {attempt+1})"
+                        )
+                    time.sleep(0.01)
+                else:
+                    raise  # Unrelated RuntimeError — re-raise
+        logging.error(
+            "Failed to create a stable snapshot of data after 3 attempts."
+            )
+        return {}  # As a last resort — still risky, but at least log it
+
     def _summarize_data_for_log(self, data):
-        data = copy.deepcopy(data)
+        data = self._safe_snapshot(data)
         MAX_ROWS = 100
         if isinstance(data, list):
             return [self._summarize_data_for_log(item) for item in data[:MAX_ROWS]]


### PR DESCRIPTION
A `RuntimeError` was intermittently raised during event handling:
<details>
<summary>Full traceback</summary>

```
A runtime exception was raised when processing event 'wf-click'.
Traceback (most recent call last):
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/site-packages/writer/blueprints.py", line 34, in _get_executor
    yield current_app_process.executor
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/site-packages/writer/blueprints.py", line 291, in execute_dag
    update_log("Executing...")
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/site-packages/writer/blueprints.py", line 263, in update_log
    self._generate_run_log(tools, title, entry_type, msg=message, run_id=run_id)
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/site-packages/writer/blueprints.py", line 206, in _generate_run_log
    "executionEnvironment": self._summarize_data_for_log(
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/site-packages/writer/blueprints.py", line 151, in _summarize_data_for_log
    data = copy.deepcopy(data)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/copy.py", line 146, in deepcopy
    y = copier(x, memo)
        ^^^^^^^^^^^^^^^
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/copy.py", line 231, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/copy.py", line 271, in _reconstruct
    state = deepcopy(state, memo)
            ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/copy.py", line 146, in deepcopy
    y = copier(x, memo)
        ^^^^^^^^^^^^^^^
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/copy.py", line 230, in _deepcopy_dict
    for key, value in x.items():
RuntimeError: dictionary changed size during iteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/site-packages/writer/core.py", line 1765, in _handle_component_event
    self.blueprint_runner.execute_ui_trigger(target_id, ev.type, calling_arguments)
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/site-packages/writer/blueprints.py", line 55, in execute_ui_trigger
    self.run_branch(trigger.id, None, execution_environment, "UI trigger execution")
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/site-packages/writer/blueprints.py", line 114, in run_branch
    return self.execute_dag(nodes, execution_environment, title)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/site-packages/writer/blueprints.py", line 281, in execute_dag
    with self._get_executor() as executor:
  File "/Users/usr/.pyenv/versions/3.11.0/lib/python3.11/contextlib.py", line 190, in __exit__
    raise RuntimeError("generator didn't stop after throw()")
RuntimeError: generator didn't stop after throw()
```
</details>

The issue occurs during a call to `copy.deepcopy(data)` inside the `_summarize_data_for_log` method of `blueprints.py`, specifically when attempting to snapshot the `execution_environment` for logging. The root cause appears to be that the dictionary was being modified concurrently, leading to unsafe iteration during deep copying.

This PR introduces a safer snapshot mechanism to prevent crashes due to concurrent mutations:
- Added a `_safe_snapshot` method in BlueprintRunner:
    - Retries `copy.deepcopy` up to 3 times if a `RuntimeError` caused by concurrent dictionary mutation occurs.
    - Logs each retry attempt and a final error if snapshotting fails.
    - Falls back to returning an empty dict only as a last resort (with logging).
    - Replaced direct call to `copy.deepcopy` in `_summarize_data_for_log` with `_safe_snapshot`.

⸻

**Tradeoffs and considerations**

- This avoids using locks, which could introduce deadlocks or performance issues.
- The fallback to {} is considered safe in this context, but logging ensures visibility into snapshot failures.
- This is a pragmatic mitigation. A more structural long-term fix might involve:
    - Capturing the snapshot earlier (e.g. in `run_branch`) before any asynchronous mutations occur.
    - Using immutable state or dedicated logging-safe representations.