### PR TITLE
fix(ui): prevent CORS issue on Dataframe data loading - WF-383

### DIFF
--- a/src/ui/src/components/core/content/CoreDataframe.vue
+++ b/src/ui/src/components/core/content/CoreDataframe.vue
@@ -319,6 +319,7 @@ export default {
 import injectionKeys from "@/injectionKeys";
 import type * as aq from "arquero";
 import type { Table } from "apache-arrow";
+import { dataUrlToBase64, base64ToArrayBuffer } from "@/utils/base64";
 
 /**
  * If the table is massive, only a certain amount of rows is rendered at a time,
@@ -559,12 +560,10 @@ async function loadData() {
 	isLoadingData.value = true;
 	const aq = await import("arquero");
 	const { tableFromIPC } = await import("apache-arrow");
-	const url = fields.dataframe.value;
 
 	try {
-		const res = await fetch(url);
-		const blob = await res.blob();
-		const buffer = await blob.arrayBuffer();
+		const base64 = dataUrlToBase64(fields.dataframe.value);
+		const buffer = base64ToArrayBuffer(base64);
 		const arrowTable = tableFromIPC(buffer);
 		tableIndex.value = getIndexFromArrowTable(arrowTable);
 		const aqTable = aq.fromArrow(arrowTable);

--- a/src/ui/src/utils/base64.ts
+++ b/src/ui/src/utils/base64.ts
@@ -1,0 +1,15 @@
+export function dataUrlToBase64(url: string) {
+	const base64 = url.split(",")?.[1];
+	if (!base64) throw Error(`Could not extract base64 from data url: ${url}`);
+	return base64;
+}
+
+export function base64ToArrayBuffer(base64: string) {
+	const binaryString = window.atob(base64);
+	const len = binaryString.length;
+	const bytes = new Uint8Array(len);
+	for (let i = 0; i < len; i++) {
+		bytes[i] = binaryString.charCodeAt(i);
+	}
+	return bytes.buffer;
+}


### PR DESCRIPTION
In `CoreDataframe`, we decode the data URL to binary data using `fetch`. This causes an issue in environments where there are strict CORS rules.

So we now decode the data URL ourselves to avoid using `fetch`.