### PR TITLE
feat(ui): introduce new layout - WF-375

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2541,9 +2541,13 @@
 			}
 		},
 		"node_modules/@fontsource-variable/material-symbols-outlined": {
-			"version": "5.0.34",
-			"resolved": "https://registry.npmjs.org/@fontsource-variable/material-symbols-outlined/-/material-symbols-outlined-5.0.34.tgz",
-			"integrity": "sha512-dC6BoXU93VMjNlfbn4YRdqsSOFp6Smue2KZgZJ8wy2x0OeyA73hgJyb5i6mV6JZnuaiJHMwqTfwJQ3FtSPKFnw=="
+			"version": "5.2.10",
+			"resolved": "https://registry.npmjs.org/@fontsource-variable/material-symbols-outlined/-/material-symbols-outlined-5.2.10.tgz",
+			"integrity": "sha512-DNH54yyImIFDGL4r2jv3imDP95QaQI1gxmdN/Pd0fSfSuHko0YWLx3JVWEIGSsJvtGCEiURdiHpva6w5UJ7jDg==",
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
+			}
 		},
 		"node_modules/@fontsource/poppins": {
 			"version": "5.0.14",
@@ -18846,7 +18850,7 @@
 			"dependencies": {
 				"@apache-arrow/ts": "^15.0.2",
 				"@floating-ui/vue": "^1.1.5",
-				"@fontsource-variable/material-symbols-outlined": "^5.0.34",
+				"@fontsource-variable/material-symbols-outlined": "^5.2.10",
 				"@fontsource/poppins": "^5.0.14",
 				"@googlemaps/js-api-loader": "^1.16.6",
 				"@monaco-editor/loader": "^1.3.3",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"@apache-arrow/ts": "^15.0.2",
 		"@floating-ui/vue": "^1.1.5",
-		"@fontsource-variable/material-symbols-outlined": "^5.0.34",
+		"@fontsource-variable/material-symbols-outlined": "^5.2.10",
 		"@fontsource/poppins": "^5.0.14",
 		"@googlemaps/js-api-loader": "^1.16.6",
 		"@monaco-editor/loader": "^1.3.3",

--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -5,9 +5,7 @@
 			:class="{ openPanels: ssbm.openPanels.value.size > 0 }"
 		>
 			<BuilderHeader class="builderHeader"></BuilderHeader>
-			<div v-if="builderMode !== 'preview'" class="sidebar">
-				<BuilderSidebar></BuilderSidebar>
-			</div>
+			<BuilderSidebar class="sidebar" />
 			<div class="builderMain">
 				<div class="rendererWrapper">
 					<ComponentRenderer
@@ -89,6 +87,7 @@ import BuilderHeader from "./BuilderHeader.vue";
 import BuilderTooltip from "./BuilderTooltip.vue";
 import BuilderAsyncLoader from "./BuilderAsyncLoader.vue";
 import BuilderPanelSwitcher from "./panels/BuilderPanelSwitcher.vue";
+import BuilderSidebar from "./sidebar/BuilderSidebar.vue";
 import { WDS_CSS_PROPERTIES } from "@/wds/tokens";
 import { SelectionStatus } from "./builderManager";
 import BuilderToasts from "./BuilderToasts.vue";
@@ -97,10 +96,6 @@ import { useToasts } from "./useToast";
 
 const BuilderSettings = defineAsyncComponent({
 	loader: () => import("./settings/BuilderSettings.vue"),
-	loadingComponent: BuilderAsyncLoader,
-});
-const BuilderSidebar = defineAsyncComponent({
-	loader: () => import("./sidebar/BuilderSidebar.vue"),
 	loadingComponent: BuilderAsyncLoader,
 });
 const ComponentRenderer = defineAsyncComponent({
@@ -398,11 +393,7 @@ onUnmounted(() => abort.abort());
 .mainGrid {
 	width: 100vw;
 	height: 100vh;
-	grid-template-columns:
-		v-bind(
-			"ssbm.getMode() !== 'preview' ? 'var(--builderSidebarWidth)' : '0px'"
-		)
-		1fr;
+	grid-template-columns: auto 1fr;
 	grid-template-rows:
 		var(--builderTopBarHeight)
 		1fr

--- a/src/ui/src/builder/BuilderHeader.vue
+++ b/src/ui/src/builder/BuilderHeader.vue
@@ -14,36 +14,6 @@
 			<WdsButton
 				variant="secondary"
 				size="smallIcon"
-				data-automation-key="undo"
-				:data-writer-tooltip="
-					undoRedoSnapshot.isUndoAvailable
-						? `Undo: ${undoRedoSnapshot.undoDesc}`
-						: 'Nothing to undo'
-				"
-				:disabled="!undoRedoSnapshot.isUndoAvailable"
-				data-writer-tooltip-placement="bottom"
-				@click="undo()"
-			>
-				<i class="material-symbols-outlined">undo</i>
-			</WdsButton>
-			<WdsButton
-				variant="secondary"
-				size="smallIcon"
-				data-automation-key="redo"
-				:data-writer-tooltip="
-					undoRedoSnapshot.isRedoAvailable
-						? `Redo: ${undoRedoSnapshot.redoDesc}`
-						: 'Nothing to redo'
-				"
-				:disabled="!undoRedoSnapshot.isRedoAvailable"
-				data-writer-tooltip-placement="bottom"
-				@click="redo()"
-			>
-				<i class="material-symbols-outlined">redo</i>
-			</WdsButton>
-			<WdsButton
-				variant="secondary"
-				size="smallIcon"
 				data-writer-tooltip="State Explorer"
 				data-writer-tooltip-placement="bottom"
 				@click="showStateExplorer"
@@ -92,7 +62,6 @@
 <script setup lang="ts">
 import { computed, inject, ref } from "vue";
 import BuilderSwitcher from "./BuilderSwitcher.vue";
-import { useComponentActions } from "./useComponentActions";
 import WdsModal, { ModalAction } from "@/wds/WdsModal.vue";
 import injectionKeys from "@/injectionKeys";
 import BuilderStateExplorer from "./BuilderStateExplorer.vue";
@@ -102,13 +71,10 @@ import WdsButton from "@/wds/WdsButton.vue";
 import { useWriterTracking } from "@/composables/useWriterTracking";
 
 const wf = inject(injectionKeys.core);
-const ssbm = inject(injectionKeys.builderManager);
 
 const isStateExplorerShown = ref(false);
 
 const tracking = useWriterTracking(wf);
-
-const { undo, redo, getUndoRedoSnapshot } = useComponentActions(wf, ssbm);
 
 const {
 	canDeploy,
@@ -118,8 +84,6 @@ const {
 	lastDeployedAt,
 	writerDeployUrl,
 } = useApplicationCloud(wf);
-
-const undoRedoSnapshot = computed(() => getUndoRedoSnapshot());
 
 const dateFormater = new Intl.DateTimeFormat(undefined, {
 	weekday: "long",

--- a/src/ui/src/builder/BuilderHeader.vue
+++ b/src/ui/src/builder/BuilderHeader.vue
@@ -11,6 +11,7 @@
 		<img v-else src="../assets/logo.svg" alt="Writer Framework logo" />
 		<BuilderSwitcher class="BuilderHeader__switcher" />
 		<div class="BuilderHeader__toolbar">
+			<hr />
 			<WdsButton
 				variant="secondary"
 				size="smallIcon"
@@ -18,7 +19,7 @@
 				data-writer-tooltip-placement="bottom"
 				@click="showStateExplorer"
 			>
-				<i class="material-symbols-outlined">mystery</i>
+				<i class="material-symbols-outlined">code</i>
 			</WdsButton>
 			<WdsButton
 				v-if="canDeploy"
@@ -193,6 +194,11 @@ function showStateExplorer() {
 	align-items: center;
 	justify-content: flex-end;
 	gap: 8px;
+}
+.BuilderHeader__toolbar hr {
+	border: none;
+	border-left: 1px solid var(--wdsColorGray6);
+	height: 26px;
 }
 
 .BuilderHeader__toolbar__deployModal__text {

--- a/src/ui/src/builder/BuilderHeader.vue
+++ b/src/ui/src/builder/BuilderHeader.vue
@@ -9,8 +9,7 @@
 			<img src="../assets/logo.svg" alt="Writer Framework logo" />
 		</a>
 		<img v-else src="../assets/logo.svg" alt="Writer Framework logo" />
-		<BuilderSwitcher />
-		<div class="gap"></div>
+		<BuilderSwitcher class="BuilderHeader__switcher" />
 		<div class="BuilderHeader__toolbar">
 			<WdsButton
 				variant="secondary"
@@ -208,10 +207,11 @@ function showStateExplorer() {
 @import "./sharedStyles.css";
 
 .BuilderHeader {
-	background: var(--builderHeaderBackgroundColor);
+	background: var(--wdsColorBlack);
 	color: var(--builderBackgroundColor);
 	padding: 0 12px 0 16px;
-	display: flex;
+	display: grid;
+	grid-template-columns: 1fr auto 1fr;
 	align-items: center;
 	gap: 16px;
 	padding-top: 1px;
@@ -227,6 +227,7 @@ function showStateExplorer() {
 .BuilderHeader__toolbar {
 	display: flex;
 	align-items: center;
+	justify-content: flex-end;
 	gap: 8px;
 }
 
@@ -236,10 +237,6 @@ function showStateExplorer() {
 
 .BuilderHeader img {
 	width: 28px;
-}
-
-.BuilderHeader .gap {
-	flex: 1 0 auto;
 }
 
 .panelToggler,

--- a/src/ui/src/builder/BuilderHeader.vue
+++ b/src/ui/src/builder/BuilderHeader.vue
@@ -1,14 +1,16 @@
 <template>
 	<div class="BuilderHeader">
-		<a
-			v-if="writerDeployUrl"
-			:href="writerDeployUrl.toString()"
-			target="_blank"
-			class="BuilderHeader__goBack"
-		>
-			<img src="../assets/logo.svg" alt="Writer Framework logo" />
-		</a>
-		<img v-else src="../assets/logo.svg" alt="Writer Framework logo" />
+		<div>
+			<a
+				v-if="writerDeployUrl"
+				:href="writerDeployUrl.toString()"
+				target="_blank"
+				class="BuilderHeader__goBack"
+			>
+				<img src="../assets/logo.svg" alt="Writer Framework logo" />
+			</a>
+			<img v-else src="../assets/logo.svg" alt="Writer Framework logo" />
+		</div>
 		<BuilderSwitcher class="BuilderHeader__switcher" />
 		<div class="BuilderHeader__toolbar">
 			<hr />
@@ -185,7 +187,7 @@ function showStateExplorer() {
 
 .BuilderHeader__goBack {
 	text-decoration: none;
-	display: flex;
+	display: inline-flex;
 	align-items: center;
 }
 

--- a/src/ui/src/builder/BuilderHeader.vue
+++ b/src/ui/src/builder/BuilderHeader.vue
@@ -209,7 +209,7 @@ function showStateExplorer() {
 .BuilderHeader {
 	background: var(--wdsColorBlack);
 	color: var(--builderBackgroundColor);
-	padding: 0 12px 0 16px;
+	padding: 0 12px 0 10px;
 	display: grid;
 	grid-template-columns: 1fr auto 1fr;
 	align-items: center;

--- a/src/ui/src/builder/BuilderSwitcher.vue
+++ b/src/ui/src/builder/BuilderSwitcher.vue
@@ -6,8 +6,8 @@
 			type="button"
 			@click="selectOption('ui')"
 		>
-			<i class="icon material-symbols-outlined"> brush </i>
-			UI
+			<i class="icon material-symbols-outlined">grid_3x3</i>
+			Interface
 		</button>
 		<button
 			data-automation-action="set-mode-blueprints"
@@ -24,7 +24,7 @@
 			type="button"
 			@click="selectOption('preview')"
 		>
-			<i class="icon material-symbols-outlined"> preview </i>
+			<i class="icon material-symbols-outlined">visibility</i>
 			Preview
 		</button>
 	</div>

--- a/src/ui/src/builder/BuilderSwitcher.vue
+++ b/src/ui/src/builder/BuilderSwitcher.vue
@@ -75,7 +75,8 @@ const activeId = computed(() => ssbm.getMode());
 
 .BuilderSwitcher {
 	display: flex;
-	gap: 0px;
+	align-items: center;
+	gap: 8px;
 	overflow: hidden;
 }
 
@@ -94,12 +95,15 @@ const activeId = computed(() => ssbm.getMode());
 	height: 32px;
 	border-radius: 4px;
 }
+.BuilderSwitcher button:hover {
+	background: var(--wdsColorGray5);
+}
 
 .BuilderSwitcher .icon {
 	margin-right: 8px;
 }
 
 .BuilderSwitcher .active {
-	background: var(--builderHeaderBackgroundHoleColor);
+	background: var(--wdsColorGray6);
 }
 </style>

--- a/src/ui/src/builder/BuilderTree.vue
+++ b/src/ui/src/builder/BuilderTree.vue
@@ -34,6 +34,7 @@
 				class="BuilderTree__main__name"
 				:class="{
 					'BuilderTree__main__name--disabled': disabled,
+					'BuilderTree__main__name--root': variant === 'root',
 				}"
 				:data-writer-tooltip="name"
 				data-writer-tooltip-strategy="overflow"
@@ -55,6 +56,9 @@
 			<div
 				v-show="!collapsed && hasChildren"
 				class="BuilderTree__children"
+				:class="{
+					'BuilderTree__children--noNestedSpace': noNestedSpace,
+				}"
 			>
 				<slot name="children" />
 			</div>
@@ -74,6 +78,15 @@ const SharedMoreDropdown = defineAsyncComponent(
 const props = defineProps({
 	name: { type: String, required: true },
 	query: { type: String, required: false, default: undefined },
+	variant: {
+		type: String as PropType<"root">,
+		required: false,
+		default: undefined,
+	},
+	noNestedSpace: {
+		type: Boolean,
+		required: false,
+	},
 	dataAutomationKey: { type: String, required: false, default: undefined },
 	hasChildren: { type: Boolean },
 	draggable: { type: Boolean },
@@ -179,5 +192,13 @@ function toggleCollapse(newCollapse?: boolean) {
 	flex-grow: 1;
 	display: flex;
 	justify-content: flex-end;
+}
+
+.BuilderTree__main__name--root {
+	font-weight: 500;
+	text-transform: uppercase;
+}
+.BuilderTree__children--noNestedSpace {
+	margin-left: unset;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderSettingsActions.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsActions.vue
@@ -101,7 +101,7 @@
 			class="actionButton"
 			variant="neutral"
 			size="small"
-			:data-writer-tooltip="`Go to parent (${getModifierKeyName()}Shift ↑)`"
+			:data-writer-tooltip="`Go to parent (${getModifierKeyName()}⇧↑)`"
 			data-writer-tooltip-placement="left"
 			:disabled="!shortcutsInfo?.isGoToParentEnabled"
 			@click="

--- a/src/ui/src/builder/sidebar/BuilderSidebar.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebar.vue
@@ -7,6 +7,7 @@
 					data-writer-tooltip-placement="right"
 					:data-writer-tooltip="PANE_TITLE.layers"
 					:active="activePane === 'layers'"
+					data-automation-action="sidebar-layers"
 					@click="changeActivePane('layers')"
 				/>
 				<BuilderSidebarButton
@@ -14,6 +15,7 @@
 					data-writer-tooltip-placement="right"
 					:data-writer-tooltip="PANE_TITLE.add"
 					:active="activePane === 'add'"
+					data-automation-action="sidebar-add"
 					@click="changeActivePane('add')"
 				/>
 			</div>

--- a/src/ui/src/builder/sidebar/BuilderSidebar.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebar.vue
@@ -47,13 +47,12 @@
 				/>
 			</div>
 			<div class="BuilderSidebar__toolbar__bottom">
-				<a
-					class="BuilderSidebar__toolbar__bottom__help"
+				<BuilderSidebarButton
 					href="https://dev.writer.com/framework/"
-					target="_blank"
-				>
-					<span class="material-symbols-outlined">help</span>
-				</a>
+					icon="help"
+					data-writer-tooltip-placement="right"
+					data-writer-tooltip="Docs"
+				/>
 			</div>
 		</div>
 		<div v-if="activePane && !isPreview" class="BuilderSidebar__pane">
@@ -170,21 +169,6 @@ function changeActivePane(value: Pane) {
 	border: none;
 	border-top: 1px solid var(--wdsColorGray6);
 	width: 100%;
-}
-
-.BuilderSidebar__toolbar__bottom__help {
-	text-decoration: none;
-	border-radius: 8px;
-	background-color: transparent;
-	color: white;
-	border: none;
-	height: 32px;
-	width: 32px;
-	font-size: 16px;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	justify-content: center;
 }
 
 .BuilderSidebar__pane {

--- a/src/ui/src/builder/sidebar/BuilderSidebar.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebar.vue
@@ -1,24 +1,122 @@
 <template>
 	<div class="BuilderSidebar">
-		<BuilderSidebarToolkit></BuilderSidebarToolkit>
-		<BuilderSidebarComponentTree></BuilderSidebarComponentTree>
+		<div class="BuilderSidebar__toolbar">
+			<template v-if="!isPreview">
+				<BuilderSidebarButton
+					icon="stacks"
+					:active="activePane === 'layers'"
+					@click="changeActivePane('layers')"
+				/>
+				<BuilderSidebarButton
+					icon="dashboard_customize"
+					:active="activePane === 'add'"
+					@click="changeActivePane('add')"
+				/>
+			</template>
+		</div>
+		<div v-if="activePane && !isPreview" class="BuilderSidebar__pane">
+			<div class="BuilderSidebar__pane__header">
+				<h2>{{ PANE_TITLE[activePane] }}</h2>
+				<WdsButton
+					variant="neutral"
+					size="smallIcon"
+					@click="activePane = undefined"
+				>
+					<span class="material-symbols-outlined">
+						left_panel_close
+					</span>
+				</WdsButton>
+			</div>
+			<BuilderSidebarToolkit v-if="activePane === 'add'" />
+			<BuilderSidebarComponentTree v-if="activePane === 'layers'" />
+		</div>
 	</div>
 </template>
 
 <script setup lang="ts">
-// import BuilderSidebarToolbar from "./BuilderSidebarToolbar.vue";
-import BuilderSidebarToolkit from "./BuilderSidebarToolkit.vue";
-import BuilderSidebarComponentTree from "./BuilderSidebarComponentTree.vue";
+import WdsButton from "@/wds/WdsButton.vue";
+import BuilderAsyncLoader from "../BuilderAsyncLoader.vue";
+import BuilderSidebarButton from "./BuilderSidebarButton.vue";
+import { computed, defineAsyncComponent, inject, ref, watch } from "vue";
+import injectionKeys from "@/injectionKeys";
+import { useLocalStorageJSON } from "@/composables/useLocalStorageJSON";
+
+const BuilderSidebarToolkit = defineAsyncComponent({
+	loader: () => import("./BuilderSidebarToolkit.vue"),
+	loadingComponent: BuilderAsyncLoader,
+});
+const BuilderSidebarComponentTree = defineAsyncComponent({
+	loader: () => import("./BuilderSidebarComponentTree.vue"),
+	loadingComponent: BuilderAsyncLoader,
+});
+
+type Pane = "layers" | "add";
+
+function isPane(v: unknown): v is Pane {
+	return typeof v === "string" && ["layers", "add"].includes(v);
+}
+
+const wfbm = inject(injectionKeys.builderManager);
+
+const isPreview = computed(() => wfbm.mode.value === "preview");
+
+const activePaneLocalStorage = useLocalStorageJSON<Pane>("activePane", isPane);
+
+const activePane = ref<Pane>(
+	isPreview.value ? undefined : activePaneLocalStorage.value,
+);
+
+watch(activePane, () => (activePaneLocalStorage.value = activePane.value));
+watch(isPreview, () => {
+	if (isPreview.value) activePane.value === undefined;
+});
+
+const PANE_TITLE: Record<Pane, string> = {
+	layers: "Layers",
+	add: "Add block",
+};
+
+function changeActivePane(value: Pane) {
+	activePane.value = activePane.value === value ? undefined : value;
+}
+
+// v-if="builderMode !== 'preview'"
 </script>
 
 <style scoped>
 .BuilderSidebar {
 	display: grid;
-	grid-template-rows: 1fr 1fr;
-	height: 100%;
+	grid-template-columns: 48px;
+	grid-template-rows: 100%;
+}
+.BuilderSidebar:has(.BuilderSidebar__pane) {
+	grid-template-columns: 48px 240px;
 }
 
-.BuilderSidebar > *:not(:first-child) {
-	border-top: 1px solid var(--builderSeparatorColor);
+.BuilderSidebar__toolbar {
+	padding-top: 12px;
+	background: var(--wdsColorBlack);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: flex-start;
+	gap: 12px;
+}
+
+.BuilderSidebar__pane {
+	height: 100%;
+	display: grid;
+	grid-template-rows: auto 1fr;
+}
+.BuilderSidebar__pane__header {
+	padding: 16px 16px 0 16px;
+	display: grid;
+	grid-template-columns: 1fr auto;
+	align-items: center;
+}
+.BuilderSidebar__pane__header h2 {
+	color: var(--wdsColorGray6);
+	font-weight: 500;
+	font-size: 16px;
 }
 </style>

--- a/src/ui/src/builder/sidebar/BuilderSidebar.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebar.vue
@@ -5,7 +5,7 @@
 				<BuilderSidebarButton
 					icon="stacks"
 					data-writer-tooltip-placement="right"
-					:data-writer-tooltip="PANE_TITLE.layers"
+					:data-writer-tooltip="paneTitles.layers"
 					:active="activePane === 'layers'"
 					data-automation-action="sidebar-layers"
 					@click="changeActivePane('layers')"
@@ -13,7 +13,7 @@
 				<BuilderSidebarButton
 					icon="dashboard_customize"
 					data-writer-tooltip-placement="right"
-					:data-writer-tooltip="PANE_TITLE.add"
+					:data-writer-tooltip="paneTitles.add"
 					:active="activePane === 'add'"
 					data-automation-action="sidebar-add"
 					@click="changeActivePane('add')"
@@ -58,7 +58,7 @@
 		</div>
 		<div v-if="activePane && !isPreview" class="BuilderSidebar__pane">
 			<div class="BuilderSidebar__pane__header">
-				<h2>{{ PANE_TITLE[activePane] }}</h2>
+				<h2>{{ paneTitles[activePane] }}</h2>
 				<WdsButton
 					variant="neutral"
 					size="smallIcon"
@@ -118,10 +118,10 @@ watch(isPreview, () => {
 	if (isPreview.value) activePane.value === undefined;
 });
 
-const PANE_TITLE: Record<Pane, string> = {
-	layers: "Layers",
+const paneTitles = computed<Record<Pane, string>>(() => ({
+	layers: wfbm.mode.value === "ui" ? "Interface Layers" : "Blueprint Layers",
 	add: "Add block",
-};
+}));
 
 function changeActivePane(value: Pane) {
 	activePane.value = activePane.value === value ? undefined : value;

--- a/src/ui/src/builder/sidebar/BuilderSidebar.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebar.vue
@@ -5,7 +5,7 @@
 				<BuilderSidebarButton
 					icon="stacks"
 					data-writer-tooltip-placement="right"
-					:data-writer-tooltip="paneTitles.layers"
+					:data-writer-tooltip="`${paneTitles.layers} (${modifierKeyName}I)`"
 					:active="activePane === 'layers'"
 					data-automation-action="sidebar-layers"
 					@click="changeActivePane('layers')"
@@ -13,7 +13,7 @@
 				<BuilderSidebarButton
 					icon="dashboard_customize"
 					data-writer-tooltip-placement="right"
-					:data-writer-tooltip="paneTitles.add"
+					:data-writer-tooltip="`${paneTitles.add} (${modifierKeyName}B)`"
 					:active="activePane === 'add'"
 					data-automation-action="sidebar-add"
 					@click="changeActivePane('add')"
@@ -25,22 +25,14 @@
 					icon="undo"
 					data-automation-key="undo"
 					data-writer-tooltip-placement="right"
-					:data-writer-tooltip="
-						undoRedoSnapshot.isUndoAvailable
-							? `Undo: ${undoRedoSnapshot.undoDesc}`
-							: 'Nothing to undo'
-					"
+					:data-writer-tooltip="`Undo (${modifierKeyName}Z)`"
 					:disabled="!undoRedoSnapshot.isUndoAvailable"
 					@click="undo()"
 				/>
 				<BuilderSidebarButton
 					data-automation-key="redo"
 					data-writer-tooltip-placement="right"
-					:data-writer-tooltip="
-						undoRedoSnapshot.isRedoAvailable
-							? `Redo: ${undoRedoSnapshot.redoDesc}`
-							: 'Nothing to redo'
-					"
+					:data-writer-tooltip="`Redo (${modifierKeyName}Y)`"
 					icon="redo"
 					:disabled="!undoRedoSnapshot.isRedoAvailable"
 					@click="redo()"
@@ -78,10 +70,19 @@
 import WdsButton from "@/wds/WdsButton.vue";
 import BuilderAsyncLoader from "../BuilderAsyncLoader.vue";
 import BuilderSidebarButton from "./BuilderSidebarButton.vue";
-import { computed, defineAsyncComponent, inject, ref, watch } from "vue";
+import {
+	computed,
+	defineAsyncComponent,
+	inject,
+	onMounted,
+	onUnmounted,
+	ref,
+	watch,
+} from "vue";
 import injectionKeys from "@/injectionKeys";
 import { useLocalStorageJSON } from "@/composables/useLocalStorageJSON";
 import { useComponentActions } from "../useComponentActions";
+import { getModifierKeyName, isPlatformMac } from "@/core/detectPlatform";
 
 const BuilderSidebarToolkit = defineAsyncComponent({
 	loader: () => import("./BuilderSidebarToolkit.vue"),
@@ -121,6 +122,35 @@ const paneTitles = computed<Record<Pane, string>>(() => ({
 	layers: wfbm.mode.value === "ui" ? "Interface Layers" : "Blueprint Layers",
 	add: "Add block",
 }));
+
+const modifierKeyName = getModifierKeyName();
+
+async function handleKeydown(ev: KeyboardEvent) {
+	const isModifierKeyActive = isPlatformMac() ? ev.metaKey : ev.ctrlKey;
+	if (!isModifierKeyActive) return;
+
+	const targetEl = ev.target as HTMLElement;
+	if (targetEl.closest("textarea, input, select")) return;
+
+	switch (ev.key) {
+		case "i":
+			ev.preventDefault();
+			activePane.value = "layers";
+			break;
+		case "b":
+			ev.preventDefault();
+			activePane.value = "add";
+			break;
+	}
+}
+const abort = new AbortController();
+
+onMounted(() => {
+	document.addEventListener("keydown", handleKeydown, {
+		signal: abort.signal,
+	});
+});
+onUnmounted(() => abort.abort());
 
 function changeActivePane(value: Pane) {
 	activePane.value = activePane.value === value ? undefined : value;

--- a/src/ui/src/builder/sidebar/BuilderSidebarButton.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarButton.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+defineProps({
+	icon: { type: String, required: true },
+	active: { type: Boolean },
+});
+</script>
+
+<template>
+	<button
+		class="BuilderSidebarButton"
+		:class="{ 'BuilderSidebarButton--active': active }"
+		role="button"
+	>
+		<span class="material-symbols-outlined">{{ icon }}</span>
+	</button>
+</template>
+
+<style lang="css" scoped>
+.BuilderSidebarButton {
+	border-radius: 8px;
+	background-color: transparent;
+	color: white;
+	border: none;
+
+	height: 32px;
+	width: 32px;
+
+	font-size: 16px;
+
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+.BuilderSidebarButton:hover {
+	background: var(--wdsColorGray5);
+}
+
+.BuilderSidebarButton--active {
+	background: var(--wdsColorGray6);
+}
+</style>

--- a/src/ui/src/builder/sidebar/BuilderSidebarButton.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarButton.vue
@@ -2,6 +2,7 @@
 defineProps({
 	icon: { type: String, required: true },
 	active: { type: Boolean },
+	disabled: { type: Boolean },
 });
 </script>
 
@@ -10,6 +11,7 @@ defineProps({
 		class="BuilderSidebarButton"
 		:class="{ 'BuilderSidebarButton--active': active }"
 		role="button"
+		:disabled="disabled"
 	>
 		<span class="material-symbols-outlined">{{ icon }}</span>
 	</button>
@@ -31,6 +33,10 @@ defineProps({
 	display: flex;
 	align-items: center;
 	justify-content: center;
+}
+.BuilderSidebarButton[disabled] {
+	opacity: 50%;
+	cursor: not-allowed;
 }
 .BuilderSidebarButton:hover {
 	background: var(--wdsColorGray5);

--- a/src/ui/src/builder/sidebar/BuilderSidebarButton.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarButton.vue
@@ -3,11 +3,16 @@ defineProps({
 	icon: { type: String, required: true },
 	active: { type: Boolean },
 	disabled: { type: Boolean },
+	href: { type: String, required: false, default: undefined },
 });
 </script>
 
 <template>
+	<a v-if="href" class="BuilderSidebarButton" :href="href">
+		<span class="material-symbols-outlined">{{ icon }}</span>
+	</a>
 	<button
+		v-else
 		class="BuilderSidebarButton"
 		:class="{ 'BuilderSidebarButton--active': active }"
 		role="button"
@@ -33,6 +38,7 @@ defineProps({
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	text-decoration: none;
 }
 .BuilderSidebarButton[disabled] {
 	opacity: 50%;

--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
@@ -1,5 +1,5 @@
 <template>
-	<TreeBranch
+	<BuilderTree
 		ref="treeBranch"
 		class="BuilderSidebarComponentTreeBranch"
 		:component-id="componentId"
@@ -10,6 +10,10 @@
 		:draggable="isDraggingAllowed(componentId)"
 		:matched="matched"
 		:selected="selected"
+		:variant="
+			COMPONENT_TYPES_TOP_LEVEL.has(component.type) ? 'root' : undefined
+		"
+		:no-nested-space="COMPONENT_TYPES_ROOT.has(component.type)"
 		@select="select"
 		@dragover="handleDragOver"
 		@dragstart="handleDragStart"
@@ -48,7 +52,7 @@
 				@expand-branch="expand"
 			/>
 		</template>
-	</TreeBranch>
+	</BuilderTree>
 </template>
 
 <script setup lang="ts">
@@ -66,7 +70,7 @@ import { useEvaluator } from "@/renderer/useEvaluator";
 import { useDragDropComponent } from "../useDragDropComponent";
 import { useComponentActions } from "../useComponentActions";
 
-import TreeBranch from "../BuilderTree.vue";
+import BuilderTree from "../BuilderTree.vue";
 import { useComponentsTreeSearchForComponent } from "./composables/useComponentsTreeSearch";
 import { useComponentDescription } from "../useComponentDescription";
 import { useWriterTracking } from "@/composables/useWriterTracking";
@@ -76,7 +80,7 @@ const props = defineProps({
 	query: { type: String, required: false, default: "" },
 });
 
-const treeBranch = ref<ComponentPublicInstance<typeof TreeBranch>>();
+const treeBranch = ref<ComponentPublicInstance<typeof BuilderTree>>();
 
 const wf = inject(injectionKeys.core);
 const wfbm = inject(injectionKeys.builderManager);
@@ -98,6 +102,13 @@ const emit = defineEmits(["expandBranch"]);
 const q = computed(() => props.query?.toLocaleLowerCase() ?? "");
 
 const component = computed(() => wf.getComponentById(props.componentId));
+
+const COMPONENT_TYPES_ROOT = new Set(["root", "blueprints_root"]);
+const COMPONENT_TYPES_TOP_LEVEL = new Set([
+	...COMPONENT_TYPES_ROOT,
+	"page",
+	"blueprints_blueprint",
+]);
 
 const { hasMatchingChildren, matched } = useComponentsTreeSearchForComponent(
 	wf,

--- a/src/ui/src/builder/sidebar/BuilderSidebarPanel.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarPanel.vue
@@ -45,7 +45,7 @@ const searchRightText = computed(() => {
 	width: 100%;
 	position: relative;
 	overflow-x: auto;
-	overflow-y: scroll;
+	overflow-y: auto;
 }
 
 .BuilderSidebarPanel__inputContainer {

--- a/src/ui/src/builder/sidebar/BuilderSidebarToolkit.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarToolkit.vue
@@ -66,7 +66,7 @@ const displayedCategories = [
 ];
 
 const activeToolkit = computed(() => {
-	if (wfbm.getMode() == "blueprints") {
+	if (wfbm.mode.value == "blueprints") {
 		return "blueprints";
 	}
 	return "core";

--- a/src/ui/src/components/blueprints/base/BlueprintToolbar.vue
+++ b/src/ui/src/components/blueprints/base/BlueprintToolbar.vue
@@ -56,18 +56,20 @@ async function runBlueprint(componentId?: string) {
 <template>
 	<div ref="root" class="BlueprintToolbar" :data-writer-unselectable="true">
 		<WdsButton
-			variant="secondary"
+			variant="tertiary"
+			size="icon"
 			data-automation-action="run-autogen"
+			data-writer-tooltip="Autogen"
+			data-writer-tooltip-placement="bottom"
 			@click="$emit('autogenClick')"
 		>
-			<i class="material-symbols-outlined">bolt</i>
-			Autogen
+			<i class="material-symbols-outlined">wand_shine</i>
 		</WdsButton>
 		<WdsButtonSplit
 			v-if="triggerComponents.length"
 			ref="runBlueprintBtn"
 			class="BlueprintToolbar__runBlueprintDropdown"
-			variant="secondary"
+			variant="special"
 			:disabled="isRunning"
 			@main-click="runBlueprint()"
 			@dropdown-open="onDropdownOpen"
@@ -89,7 +91,7 @@ async function runBlueprint(componentId?: string) {
 			v-else
 			class="BlueprintToolbar__runBlueprint"
 			data-automation-action="run-blueprint"
-			variant="secondary"
+			variant="special"
 			:disabled="isRunning"
 			@click="runBlueprint()"
 		>

--- a/src/ui/src/wds/WdsButtonSplit.vue
+++ b/src/ui/src/wds/WdsButtonSplit.vue
@@ -90,7 +90,7 @@ defineExpose({ toggleDropdown });
 	box-shadow: var(--buttonShadow);
 	border: 1px solid transparent;
 	align-items: center;
-	height: 42px;
+	height: 40px;
 	gap: 8px;
 	padding-left: 12px;
 	padding-right: 12px;

--- a/tests/e2e/tests/blueprints.spec.ts
+++ b/tests/e2e/tests/blueprints.spec.ts
@@ -59,7 +59,9 @@ test.describe("Blueprints", () => {
 		await page
 			.locator(`[data-automation-action="set-mode-blueprints"]`)
 			.click();
+		await page.locator(`[data-automation-action="sidebar-layers"]`).click();
 		await page.locator(`[data-automation-action="add-blueprint"]`).click();
+		await page.locator(`[data-automation-action="sidebar-add"]`).click();
 
 		await page
 			.locator(
@@ -136,7 +138,9 @@ test.describe("Blueprints", () => {
 			await page
 				.locator(`[data-automation-action="set-mode-blueprints"]`)
 				.click();
+			await page.locator(`[data-automation-action="sidebar-layers"]`).click();
 			await page.locator(`[data-automation-action="add-blueprint"]`).click();
+			await page.locator(`[data-automation-action="sidebar-add"]`).click();
 
 			await page
 				.locator(

--- a/tests/e2e/tests/builderFieldValidation.spec.ts
+++ b/tests/e2e/tests/builderFieldValidation.spec.ts
@@ -19,6 +19,7 @@ test.describe("Builder field validation", () => {
 	});
 
 	test("should display error for invalid button fields", async ({ page }) => {
+		await page.locator(`[data-automation-action="sidebar-add"]`).click();
 		await page
 			.locator(`.BuilderSidebarToolkit [data-component-type="button"]`)
 			.dragTo(page.locator(".CoreSection"));
@@ -39,6 +40,7 @@ test.describe("Builder field validation", () => {
 	test("should display error for invalid multiselectinput fields", async ({
 		page,
 	}) => {
+		await page.locator(`[data-automation-action="sidebar-add"]`).click();
 		await page
 			.locator(
 				`.BuilderSidebarToolkit [data-component-type="multiselectinput"]`,

--- a/tests/e2e/tests/button.spec.ts
+++ b/tests/e2e/tests/button.spec.ts
@@ -5,22 +5,23 @@ test.describe("button", () => {
 	const COMPONENT_LOCATOR = `button.CoreButton.component`;
 	let url: string;
 
-	test.beforeAll(async ({request}) => {
+	test.beforeAll(async ({ request }) => {
 		const response = await request.post(`/preset/section`);
 		expect(response.ok()).toBeTruthy();
-		({url} = await response.json());
+		({ url } = await response.json());
 	});
 
-	test.afterAll(async ({request}) => {
+	test.afterAll(async ({ request }) => {
 		await request.delete(url);
 	});
 
 	test.beforeEach(async ({ page }) => {
-		await page.goto(url, {waitUntil: "domcontentloaded"});
+		await page.goto(url, { waitUntil: "domcontentloaded" });
 		test.setTimeout(5000);
 	});
 
 	test("configure", async ({ page }) => {
+		await page.locator(`[data-automation-action="sidebar-add"]`).click();
 		await page
 			.locator(`.BuilderSidebarToolkit [data-component-type="${TYPE}"]`)
 			.dragTo(page.locator(".CoreSection .ChildlessPlaceholder"));

--- a/tests/e2e/tests/components.spec.ts
+++ b/tests/e2e/tests/components.spec.ts
@@ -16,51 +16,61 @@ type ComponentTestData = {
 };
 
 const mapComponents = {
-	root: {ignore: true},
-	page: {ignore: true},
-	column: {ignore: true},
-	tab: {ignore: true},
-	step: {ignore: true},
-	dropdowninput: {locator: '.component.wf-type-dropdowninput label'},
-	section: {test: 'basic'},
-	columns: {test: 'basic'},
-	sidebar: {test: 'basic'},
-	fileinput: {locator: '.component.wf-type-fileinput label'},
-	dateinput: {locator: '.component.wf-type-dateinput label'},
-	timeinput: {locator: '.component.wf-type-timeinput label'},
-	sliderinput: {locator: '.component.wf-type-sliderinput label'},
-	rangeinput: {locator: '.component.wf-type-rangeinput label'},
-	numberinput: {locator: '.component.wf-type-numberinput label'},
-	textinput: {locator: '.component.wf-type-textinput label'},
-}
+	root: { ignore: true },
+	page: { ignore: true },
+	column: { ignore: true },
+	tab: { ignore: true },
+	step: { ignore: true },
+	dropdowninput: { locator: ".component.wf-type-dropdowninput label" },
+	section: { test: "basic" },
+	columns: { test: "basic" },
+	sidebar: { test: "basic" },
+	fileinput: { locator: ".component.wf-type-fileinput label" },
+	dateinput: { locator: ".component.wf-type-dateinput label" },
+	timeinput: { locator: ".component.wf-type-timeinput label" },
+	sliderinput: { locator: ".component.wf-type-sliderinput label" },
+	rangeinput: { locator: ".component.wf-type-rangeinput label" },
+	numberinput: { locator: ".component.wf-type-numberinput label" },
+	textinput: { locator: ".component.wf-type-textinput label" },
+};
 
 function findTest(component: Component) {
-	if(!component.allowedParentTypes || component.allowedParentTypes?.includes('column')) {
-		return 'full';
+	if (
+		!component.allowedParentTypes ||
+		component.allowedParentTypes?.includes("column")
+	) {
+		return "full";
 	}
-	if(!component.allowedParentTypes || component.allowedParentTypes?.includes('page')) {
-		return 'basic';
+	if (
+		!component.allowedParentTypes ||
+		component.allowedParentTypes?.includes("page")
+	) {
+		return "basic";
 	}
-	return 'none';
+	return "none";
 }
 
-const tests = components
-	.map((component: Component): ComponentTestData => ({
-		...component, 
+const tests = components.map(
+	(component: Component): ComponentTestData => ({
+		...component,
 		test: findTest(component),
-		locator: '.component.wf-type-' + component.type,
+		locator: ".component.wf-type-" + component.type,
 		...(mapComponents[component.type] || {}),
-	}))
+	}),
+);
 
 tests
 	.filter((component: ComponentTestData) => !component.ignore)
-	.filter((component: ComponentTestData) => !component.toolkit || component.toolkit == "core")
+	.filter(
+		(component: ComponentTestData) =>
+			!component.toolkit || component.toolkit == "core",
+	)
 	.forEach((component: ComponentTestData) => {
-		switch(component.test) {
-			case 'basic':
+		switch (component.test) {
+			case "basic":
 				basicTest(component);
 				break;
-			case 'full':
+			case "full":
 				fullTest(component);
 				break;
 			default:
@@ -68,7 +78,7 @@ tests
 		}
 	});
 
-function failTest({type}: ComponentTestData) {
+function failTest({ type }: ComponentTestData) {
 	test.describe(type, () => {
 		test("tests are not implemented", async () => {
 			expect(true).toBeFalsy();
@@ -76,8 +86,7 @@ function failTest({type}: ComponentTestData) {
 	});
 }
 
-
-function fullTest({type, locator}: ComponentTestData) {
+function fullTest({ type, locator }: ComponentTestData) {
 	test.describe(type, () => {
 		const TYPE = type;
 		const COMPONENT_LOCATOR = locator;
@@ -85,38 +94,39 @@ function fullTest({type, locator}: ComponentTestData) {
 		const COLUMN2 = ".CoreColumns .CoreColumn:nth-child(2 of .CoreColumn)";
 		let url: string;
 
-		test.beforeAll(async ({request}) => {
+		test.beforeAll(async ({ request }) => {
 			const response = await request.post(`/preset/2columns`);
 			expect(response.ok()).toBeTruthy();
-			({url} = await response.json());
+			({ url } = await response.json());
 		});
 
-		test.afterAll(async ({request}) => {
+		test.afterAll(async ({ request }) => {
 			await request.delete(url);
 		});
 
 		test.beforeEach(async ({ page }) => {
-			await page.goto(url, {waitUntil: "domcontentloaded"});
+			await page.goto(url, { waitUntil: "domcontentloaded" });
 		});
 
 		test("create, drag and drop and remove", async ({ page }) => {
+			await page.locator(`[data-automation-action="sidebar-add"]`).click();
 			await page
 				.locator(`.BuilderSidebarToolkit [data-component-type="${TYPE}"]`)
 				.dragTo(page.locator(COLUMN1));
-			await expect(
-				page.locator(COLUMN1 + " " + COMPONENT_LOCATOR),
-			).toHaveCount(1);
-			await expect(
-				page.locator(COLUMN2 + " " + COMPONENT_LOCATOR),
-			).toHaveCount(0);
+			await expect(page.locator(COLUMN1 + " " + COMPONENT_LOCATOR)).toHaveCount(
+				1,
+			);
+			await expect(page.locator(COLUMN2 + " " + COMPONENT_LOCATOR)).toHaveCount(
+				0,
+			);
 
 			await page.locator(COMPONENT_LOCATOR).dragTo(page.locator(COLUMN2));
-			await expect(
-				page.locator(COLUMN1 + " " + COMPONENT_LOCATOR),
-			).toHaveCount(0);
-			await expect(
-				page.locator(COLUMN2 + " " + COMPONENT_LOCATOR),
-			).toHaveCount(1);
+			await expect(page.locator(COLUMN1 + " " + COMPONENT_LOCATOR)).toHaveCount(
+				0,
+			);
+			await expect(page.locator(COLUMN2 + " " + COMPONENT_LOCATOR)).toHaveCount(
+				1,
+			);
 
 			await page.locator(COMPONENT_LOCATOR).click();
 			await page
@@ -130,34 +140,35 @@ function fullTest({type, locator}: ComponentTestData) {
 	});
 }
 
-function basicTest({type, locator}: ComponentTestData) {
+function basicTest({ type, locator }: ComponentTestData) {
 	test.describe(type, () => {
 		const TYPE = type;
 		const COMPONENT_LOCATOR = locator;
 		const TARGET = ".CorePage";
 		let url: string;
 
-		test.beforeAll(async ({request}) => {
+		test.beforeAll(async ({ request }) => {
 			const response = await request.post(`/preset/empty_page`);
 			expect(response.ok()).toBeTruthy();
-			({url} = await response.json());
+			({ url } = await response.json());
 		});
 
-		test.afterAll(async ({request}) => {
+		test.afterAll(async ({ request }) => {
 			await request.delete(url);
 		});
 
 		test.beforeEach(async ({ page }) => {
-			await page.goto(url, {waitUntil: "domcontentloaded"});
+			await page.goto(url, { waitUntil: "domcontentloaded" });
 		});
 
 		test("create and remove", async ({ page }) => {
+			await page.locator(`[data-automation-action="sidebar-add"]`).click();
 			await page
 				.locator(`.BuilderSidebarToolkit [data-component-type="${TYPE}"]`)
 				.dragTo(page.locator(TARGET));
-			await expect(
-				page.locator(TARGET + " " + COMPONENT_LOCATOR),
-			).toHaveCount(1);
+			await expect(page.locator(TARGET + " " + COMPONENT_LOCATOR)).toHaveCount(
+				1,
+			);
 
 			await page.locator(COMPONENT_LOCATOR).click();
 			await page

--- a/tests/e2e/tests/image.spec.ts
+++ b/tests/e2e/tests/image.spec.ts
@@ -5,21 +5,22 @@ test.describe("image", () => {
 	const COMPONENT_LOCATOR = `div.CoreImage.component`;
 	let url: string;
 
-	test.beforeAll(async ({request}) => {
+	test.beforeAll(async ({ request }) => {
 		const response = await request.post(`/preset/section`);
 		expect(response.ok()).toBeTruthy();
-		({url} = await response.json());
+		({ url } = await response.json());
 	});
 
-	test.afterAll(async ({request}) => {
+	test.afterAll(async ({ request }) => {
 		await request.delete(url);
 	});
 
 	test.beforeEach(async ({ page }) => {
-		await page.goto(url, {waitUntil: "domcontentloaded"});
+		await page.goto(url, { waitUntil: "domcontentloaded" });
 	});
 
 	test("configure", async ({ page }) => {
+		await page.locator(`[data-automation-action="sidebar-add"]`).click();
 		await page
 			.locator(`.BuilderSidebarToolkit [data-component-type="${TYPE}"]`)
 			.dragTo(page.locator(".CoreSection .ChildlessPlaceholder"));

--- a/tests/e2e/tests/reuse.spec.ts
+++ b/tests/e2e/tests/reuse.spec.ts
@@ -6,55 +6,69 @@ test.describe("Reuse component", () => {
 
 	const fillSettingsField = async (page: Page, key: string, value: string) => {
 		await page
-			.locator(`.BuilderFieldsText[data-automation-key="${key}"] input, .BuilderFieldsText[data-automation-key="${key}"] textarea`)
+			.locator(
+				`.BuilderFieldsText[data-automation-key="${key}"] input, .BuilderFieldsText[data-automation-key="${key}"] textarea`,
+			)
 			.fill(value);
-	}
+	};
 
-	const dragNewComponent = async (page: Page, type: string, where = ".CoreSection") => {
+	const dragNewComponent = async (
+		page: Page,
+		type: string,
+		where = ".CoreSection",
+	) => {
 		await page
 			.locator(`.BuilderSidebarToolkit [data-component-type="${type}"]`)
 			.dragTo(page.locator(where));
-	}
+	};
 
 	const getSelectedComponentId = async (page: Page): Promise<string> => {
-		return await page.locator('.BuilderSettings .BuilderCopyText').innerText();
-	}
+		return await page.locator(".BuilderSettings .BuilderCopyText").innerText();
+	};
 
 	const setReuseTarget = async (page: Page, id: string) => {
 		await page.locator(COMPONENT_LOCATOR).click();
 		await fillSettingsField(page, "proxyId", id);
 	};
 
-	const createReuseable = async (page: Page, where = '.CoreSection'): Promise<string> => {
+	const createReuseable = async (
+		page: Page,
+		where = ".CoreSection",
+	): Promise<string> => {
 		await dragNewComponent(page, TYPE, where);
 		await page.locator(COMPONENT_LOCATOR).click();
 		return await getSelectedComponentId(page);
 	};
 
-	const createText = async (page: Page, where = ".CoreSection"): Promise<string> => {
+	const createText = async (
+		page: Page,
+		where = ".CoreSection",
+	): Promise<string> => {
 		await dragNewComponent(page, "text", where);
-		await page.locator('.CoreText.component').click();
+		await page.locator(".CoreText.component").click();
 		await fillSettingsField(page, "text", "Hello, World!");
 		return await getSelectedComponentId(page);
 	};
 
 	const createSidebar = async (page: Page) => {
 		dragNewComponent(page, "sidebar", ".CorePage");
-		await page.locator('.CoreSidebar.component').click();
+		await page.locator(".CoreSidebar.component").click();
 		return await getSelectedComponentId(page);
 	};
 
 	const collapseSettingsBar = async (page: Page) => {
-		const collapseSettingsLocator = page.locator('[data-automation-action="collapse-settings"]');
+		const collapseSettingsLocator = page.locator(
+			'[data-automation-action="collapse-settings"]',
+		);
 
-		if (await collapseSettingsLocator.count() > 0) {
+		if ((await collapseSettingsLocator.count()) > 0) {
 			await collapseSettingsLocator.click();
 		}
-	}
+	};
 
 	const expandSettingsBar = async (page: Page) => {
 		await page.locator('[data-automation-action="expand-settings"]').click();
-	}
+	};
 
 	const removeComponent = async (page: Page, selector: string) => {
 		await page.locator(".CorePage").click();
@@ -68,13 +82,18 @@ test.describe("Reuse component", () => {
 		await expect(page.locator(selector)).toHaveCount(0);
 	};
 
-	const moveFromTo = async (page: Page, selector: string, from: string, to: string) => {
+	const moveFromTo = async (
+		page: Page,
+		selector: string,
+		from: string,
+		to: string,
+	) => {
 		await expect(page.locator(from + " " + selector)).toHaveCount(1);
 		await expect(page.locator(to + " " + selector)).toHaveCount(0);
 		await page.locator(selector).dragTo(page.locator(to));
 		await expect(page.locator(from + " " + selector)).toHaveCount(0);
 		await expect(page.locator(to + " " + selector)).toHaveCount(1);
-	}
+	};
 
 	test.describe("basic", () => {
 		let url: string;
@@ -89,11 +108,12 @@ test.describe("Reuse component", () => {
 		});
 
 		test.beforeEach(async ({ page }) => {
-			await page.goto(url, {waitUntil: "domcontentloaded"});
+			await page.goto(url, { waitUntil: "domcontentloaded" });
+			await page.locator(`[data-automation-action="sidebar-add"]`).click();
 		});
 
 		test.afterEach(async ({ page }) => {
-			await removeComponent(page, '.CoreReuse');
+			await removeComponent(page, ".CoreReuse");
 		});
 
 		test("empty info", async ({ page }) => {
@@ -105,14 +125,18 @@ test.describe("Reuse component", () => {
 			const id = await createText(page);
 			await createReuseable(page);
 			await setReuseTarget(page, id);
-			await expect(page.locator('.CoreText.component')).toHaveCount(2);
-			await expect(page.locator('.CoreReuse.CoreText.component')).toHaveCount(1);
+			await expect(page.locator(".CoreText.component")).toHaveCount(2);
+			await expect(page.locator(".CoreReuse.CoreText.component")).toHaveCount(
+				1,
+			);
 		});
 
 		test("self-referencing", async ({ page }) => {
 			const id = await createReuseable(page);
 			await setReuseTarget(page, id);
-			await expect(page.locator('.CoreReuse.component')).toHaveClass(/invalid-value/);
+			await expect(page.locator(".CoreReuse.component")).toHaveClass(
+				/invalid-value/,
+			);
 		});
 
 		test("reuse in incorect context", async ({ page }) => {
@@ -121,7 +145,9 @@ test.describe("Reuse component", () => {
 			await createReuseable(page);
 			await expandSettingsBar(page);
 			await setReuseTarget(page, id);
-			await expect(page.locator(COMPONENT_LOCATOR)).toHaveClass(/invalid-context/);
+			await expect(page.locator(COMPONENT_LOCATOR)).toHaveClass(
+				/invalid-context/,
+			);
 			collapseSettingsBar(page);
 		});
 	});
@@ -140,16 +166,17 @@ test.describe("Reuse component", () => {
 		});
 
 		test.beforeEach(async ({ page }) => {
-			await page.goto(url, {waitUntil: "domcontentloaded"});
+			await page.goto(url, { waitUntil: "domcontentloaded" });
+			await page.locator(`[data-automation-action="sidebar-add"]`).click();
 		});
 
 		test.afterEach(async ({ page }) => {
 			await page.goto(url + "#page2");
 			await removeComponent(page, ".CoreReuse");
 			await page.goto(url + "#page1");
-			const c = await page.locator('.CoreSidebar').count();
+			const c = await page.locator(".CoreSidebar").count();
 			if (c > 0) {
-				await removeComponent(page, '.CoreSidebar');
+				await removeComponent(page, ".CoreSidebar");
 			}
 		});
 
@@ -159,7 +186,9 @@ test.describe("Reuse component", () => {
 			await page.goto(url + "#page2");
 			await createReuseable(page, ".CorePage");
 			await setReuseTarget(page, id);
-			await expect(page.locator('.sidebarContainer .CoreReuse.CoreSidebar')).toHaveCount(1);
+			await expect(
+				page.locator(".sidebarContainer .CoreReuse.CoreSidebar"),
+			).toHaveCount(1);
 		});
 
 		test("dynamic slot change", async ({ page }) => {
@@ -168,11 +197,13 @@ test.describe("Reuse component", () => {
 			await page.goto(url + "#page2");
 			await createReuseable(page, ".CorePage");
 			await setReuseTarget(page, sidebarId);
-			await expect(page.locator('.sidebarContainer .CoreReuse.CoreSidebar')).toHaveCount(1);
+			await expect(
+				page.locator(".sidebarContainer .CoreReuse.CoreSidebar"),
+			).toHaveCount(1);
 			const textId = await createText(page, ".CorePage");
 			await setReuseTarget(page, textId);
-			expect(page.locator('.sidebarContainer .CoreText')).toHaveCount(0);
-			expect(page.locator('.main .CoreReuse.CoreText')).toHaveCount(1);
+			expect(page.locator(".sidebarContainer .CoreText")).toHaveCount(0);
+			expect(page.locator(".main .CoreReuse.CoreText")).toHaveCount(1);
 		});
 
 		test("target component deleted", async ({ page }) => {
@@ -182,15 +213,16 @@ test.describe("Reuse component", () => {
 			await createReuseable(page, ".CorePage");
 			await setReuseTarget(page, sidebarId);
 			await page.goto(url + "#page1");
-			await removeComponent(page, '.CoreSidebar');
+			await removeComponent(page, ".CoreSidebar");
 			await page.goto(url + "#page2");
-			await expect(page.locator('.CoreReuse.component')).toHaveClass(/invalid-value/);
+			await expect(page.locator(".CoreReuse.component")).toHaveClass(
+				/invalid-value/,
+			);
 		});
 	});
 
-
-	test.describe('dragging', () => {
-		const COMPONENT_LOCATOR = 'div.CoreReuse.component';
+	test.describe("dragging", () => {
+		const COMPONENT_LOCATOR = "div.CoreReuse.component";
 		const COLUMN1 = ".CoreColumns .CoreColumn:nth-child(1 of .CoreColumn)";
 		const COLUMN2 = ".CoreColumns .CoreColumn:nth-child(2 of .CoreColumn)";
 		let url: string;
@@ -206,7 +238,8 @@ test.describe("Reuse component", () => {
 		});
 
 		test.beforeEach(async ({ page }) => {
-			await page.goto(url, {waitUntil: "domcontentloaded"});
+			await page.goto(url, { waitUntil: "domcontentloaded" });
+			await page.locator(`[data-automation-action="sidebar-add"]`).click();
 		});
 
 		test("create, drag and drop and remove", async ({ page }) => {
@@ -217,13 +250,13 @@ test.describe("Reuse component", () => {
 		});
 
 		test("drag and drop after initialization", async ({ page }) => {
-			const id = await createText(page, '.CorePage');
+			const id = await createText(page, ".CorePage");
 			await createReuseable(page, COLUMN1);
 			await setReuseTarget(page, id);
 			await collapseSettingsBar(page);
 			await moveFromTo(page, COMPONENT_LOCATOR, COLUMN1, COLUMN2);
 			await removeComponent(page, COMPONENT_LOCATOR);
-			await removeComponent(page, '.CoreText');
+			await removeComponent(page, ".CoreText");
 		});
 	});
 });

--- a/tests/e2e/tests/sidebar.spec.ts
+++ b/tests/e2e/tests/sidebar.spec.ts
@@ -22,23 +22,19 @@ test.describe("sidebar", () => {
 		test("should filter", async ({ page }) => {
 			await page.locator(`[data-automation-action="sidebar-add"]`).click();
 			// click on icon to begin search
-			await page.locator(`.BuilderSidebarToolkit input`).click();
+			const panel = page.locator(`.BuilderSidebarToolkit`);
 
 			// search a button
-			await page.locator(`.BuilderSidebarToolkit input`).fill("button");
+			await panel.locator(`input`).fill("button");
 
 			// should have only one result
-			expect(await page.locator(`.BuilderSidebarToolkit .tool`).count()).toBe(
-				1,
-			);
+			expect(await panel.locator(`.tool`).count()).toBe(1);
 
 			// search a button
-			await page.locator(`.BuilderSidebarToolkit input`).fill("");
+			await panel.locator(`input`).fill("");
 
 			// should reset the search
-			expect(
-				await page.locator(`.BuilderSidebarToolkit .tool`).count(),
-			).not.toBe(1);
+			expect(await panel.locator(`.tool`).count()).not.toBe(1);
 		});
 	});
 });

--- a/tests/e2e/tests/sidebar.spec.ts
+++ b/tests/e2e/tests/sidebar.spec.ts
@@ -14,33 +14,26 @@ test.describe("sidebar", () => {
 	});
 
 	test.beforeEach(async ({ page }) => {
-		await page.goto(url, {waitUntil: "domcontentloaded"});
+		await page.goto(url, { waitUntil: "domcontentloaded" });
 		test.setTimeout(5000);
 	});
 
 	test.describe("Toolkit", () => {
 		test("should filter", async ({ page }) => {
+			await page.locator(`[data-automation-action="sidebar-add"]`).click();
 			// click on icon to begin search
-			await page
-				.locator(
-					`.BuilderSidebarToolkit input`,
-				)
-				.click();
+			await page.locator(`.BuilderSidebarToolkit input`).click();
 
 			// search a button
-			await page
-				.locator(`.BuilderSidebarToolkit input`)
-				.fill("button");
+			await page.locator(`.BuilderSidebarToolkit input`).fill("button");
 
 			// should have only one result
-			expect(
-				await page.locator(`.BuilderSidebarToolkit .tool`).count(),
-			).toBe(1);
+			expect(await page.locator(`.BuilderSidebarToolkit .tool`).count()).toBe(
+				1,
+			);
 
 			// search a button
-			await page
-				.locator(`.BuilderSidebarToolkit input`)
-				.fill("");
+			await page.locator(`.BuilderSidebarToolkit input`).fill("");
 
 			// should reset the search
 			expect(

--- a/tests/e2e/tests/stateAutocompletion.spec.ts
+++ b/tests/e2e/tests/stateAutocompletion.spec.ts
@@ -1,126 +1,209 @@
-
 import { test, expect } from "@playwright/test";
 
 const setTextField = async (page, text) => {
-	await page.locator('div.CoreText.component').click();
+	await page.locator("div.CoreText.component").click();
 	await page
 		.locator('.BuilderFieldsText[data-automation-key="text"] textarea')
 		.fill(text);
-}
+};
 
 test.describe("state autocompletion", () => {
 	let url: string;
-	test.beforeAll(async ({request}) => {
+	test.beforeAll(async ({ request }) => {
 		const response = await request.post(`/preset/state`);
 		expect(response.ok()).toBeTruthy();
-		({url} = await response.json());
+		({ url } = await response.json());
 	});
 
-	test.afterAll(async ({request}) => {
+	test.afterAll(async ({ request }) => {
 		await request.delete(url);
 	});
 
 	test.beforeEach(async ({ page }) => {
-		await page.goto(url, {waitUntil: "domcontentloaded"});
+		await page.goto(url, { waitUntil: "domcontentloaded" });
 	});
 
 	test.describe("text", () => {
 		test("completion", async ({ page }) => {
 			await setTextField(page, "@{types.");
-			page.locator('.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.prop:text-matches("string")').click();
-			await expect(page
-				.locator('.BuilderFieldsText[data-automation-key="text"] textarea'))
-				.toHaveValue("@{types.string}");
+			page
+				.locator(
+					'.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.prop:text-matches("string")',
+				)
+				.click();
+			await expect(
+				page.locator('.BuilderFieldsText[data-automation-key="text"] textarea'),
+			).toHaveValue("@{types.string}");
 		});
 		test("counter", async ({ page }) => {
 			await setTextField(page, "@{counter");
-			await expect(page.locator('.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.prop')).toContainText(["counter"]);
-			await expect(page.locator('.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.type')).toContainText(["number"]);
+			await expect(
+				page.locator(
+					'.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.prop',
+				),
+			).toContainText(["counter"]);
+			await expect(
+				page.locator(
+					'.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.type',
+				),
+			).toContainText(["number"]);
 		});
 
 		test("types", async ({ page }) => {
 			await setTextField(page, "@{types.");
-			await expect(page.locator('.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.prop')).toHaveText(["none", "string", "integer", "float"]);
-			await expect(page.locator('.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.type')).toHaveText(["null", "string", "number", "number"]);
+			await expect(
+				page.locator(
+					'.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.prop',
+				),
+			).toHaveText(["none", "string", "integer", "float"]);
+			await expect(
+				page.locator(
+					'.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.type',
+				),
+			).toHaveText(["null", "string", "number", "number"]);
 		});
 
 		test("deeply nested", async ({ page }) => {
 			await setTextField(page, "@{nested.c.");
-			await expect(page.locator('.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.prop')).toContainText(["d", "e"]);
-			await expect(page.locator('.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.type')).toContainText(["number", "number"]);
+			await expect(
+				page.locator(
+					'.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.prop',
+				),
+			).toContainText(["d", "e"]);
+			await expect(
+				page.locator(
+					'.BuilderFieldsText[data-automation-key="text"] .fieldStateAutocomplete span.type',
+				),
+			).toContainText(["number", "number"]);
 		});
 	});
 
 	test.describe("text with dropdown", () => {
 		test("options should show on focus", async ({ page }) => {
-			await page.locator('div.CoreText.component').click();
+			await page.locator("div.CoreText.component").click();
 			await page
 				.locator('.BuilderFieldsText[data-automation-key="useMarkdown"] input')
 				.focus();
-			await expect(page.locator('.BuilderFieldsText[data-automation-key="useMarkdown"] datalist option[value="yes"]')).toHaveCount(1);
-			await expect(page.locator('.BuilderFieldsText[data-automation-key="useMarkdown"] datalist option[value="no"]')).toHaveCount(1);
-		})
+			await expect(
+				page.locator(
+					'.BuilderFieldsText[data-automation-key="useMarkdown"] datalist option[value="yes"]',
+				),
+			).toHaveCount(1);
+			await expect(
+				page.locator(
+					'.BuilderFieldsText[data-automation-key="useMarkdown"] datalist option[value="no"]',
+				),
+			).toHaveCount(1);
+		});
 	});
 
 	test.describe("Key-Value", () => {
 		test("Static List - completion", async ({ page }) => {
+			await page.locator(`[data-automation-action="sidebar-add"]`).click();
 			const FIELD = `.BuilderFieldsKeyValue[data-automation-key="options"]`;
 			await page
 				.locator(`.BuilderSidebarToolkit [data-component-type="radioinput"]`)
 				.dragTo(page.locator(".CorePage"));
 
-			await page.locator('div.CoreRadioInput.component > label').click();
+			await page.locator("div.CoreRadioInput.component > label").click();
 			await page
 				.locator(`${FIELD} button[data-automation-key="openAssistedMode"]`)
 				.click();
 
 			// key
 
-			const assistedKeyField = page.locator(`.BuilderFieldsKeyValueModal__assistedEntries .WdsFieldWrapper`).first()
-			const assistedKeyFieldInput = assistedKeyField.locator('.WdsTextInput')
+			const assistedKeyField = page
+				.locator(
+					`.BuilderFieldsKeyValueModal__assistedEntries .WdsFieldWrapper`,
+				)
+				.first();
+			const assistedKeyFieldInput = assistedKeyField.locator(".WdsTextInput");
 
 			await assistedKeyFieldInput.fill("@{types.");
 
-			await expect(assistedKeyField.locator(`.fieldStateAutocomplete span.prop`)).toHaveText(["none", "string", "integer", "float"]);
-			await expect(assistedKeyField.locator(`.fieldStateAutocomplete span.type`)).toHaveText(["null", "string", "number", "number"]);
-			await assistedKeyField.locator(`.fieldStateAutocomplete span.prop:text-matches("string")`).click();
+			await expect(
+				assistedKeyField.locator(`.fieldStateAutocomplete span.prop`),
+			).toHaveText(["none", "string", "integer", "float"]);
+			await expect(
+				assistedKeyField.locator(`.fieldStateAutocomplete span.type`),
+			).toHaveText(["null", "string", "number", "number"]);
+			await assistedKeyField
+				.locator(`.fieldStateAutocomplete span.prop:text-matches("string")`)
+				.click();
 			await expect(assistedKeyFieldInput).toHaveValue("@{types.string}");
 
 			// value
 
-			const assistedValueField = page.locator(`.BuilderFieldsKeyValueModal__assistedEntries .WdsFieldWrapper`).nth(1)
-			const assistedKeyValueInput = assistedValueField.locator('.WdsTextInput')
+			const assistedValueField = page
+				.locator(
+					`.BuilderFieldsKeyValueModal__assistedEntries .WdsFieldWrapper`,
+				)
+				.nth(1);
+			const assistedKeyValueInput = assistedValueField.locator(".WdsTextInput");
 
 			await assistedKeyValueInput.fill("@{types.");
-			await expect(assistedValueField.locator(`.fieldStateAutocomplete span.prop`)).toHaveText(["none", "string", "integer", "float"]);
-			await expect(assistedValueField.locator(`.fieldStateAutocomplete span.type`)).toHaveText(["null", "string", "number", "number"]);
-			await assistedValueField.locator(`.fieldStateAutocomplete span.prop:text-matches("string")`).click();
+			await expect(
+				assistedValueField.locator(`.fieldStateAutocomplete span.prop`),
+			).toHaveText(["none", "string", "integer", "float"]);
+			await expect(
+				assistedValueField.locator(`.fieldStateAutocomplete span.type`),
+			).toHaveText(["null", "string", "number", "number"]);
+			await assistedValueField
+				.locator(`.fieldStateAutocomplete span.prop:text-matches("string")`)
+				.click();
 			await expect(assistedKeyValueInput).toHaveValue("@{types.string}");
 		});
 	});
 
 	function testFieldType(type, key, componentSelector) {
 		test(`${type} field - state completion`, async ({ page }) => {
-			const FIELD = `.${type}[data-automation-key="${key}"]`; 
+			await page.locator(`[data-automation-action="sidebar-layers"]`).click();
+			const FIELD = `.${type}[data-automation-key="${key}"]`;
 			await page.locator(componentSelector).click();
-			await page
-				.locator(`${FIELD} button.WdsTab:text-matches("CSS")`)
-				.click();
+			await page.locator(`${FIELD} button.WdsTab:text-matches("CSS")`).click();
 			await page
 				.locator(`${FIELD} .BuilderTemplateInput input`)
 				.fill("@{types.");
-			await expect(page.locator(`${FIELD} .fieldStateAutocomplete span.prop`)).toHaveText(["none", "string", "integer", "float"]);
-			await expect(page.locator(`${FIELD} .fieldStateAutocomplete span.type`)).toHaveText(["null", "string", "number", "number"]);
-			page.locator(`${FIELD} .fieldStateAutocomplete span.prop:text-matches("string")`).click();
-			await expect(page
-				.locator(`${FIELD} .BuilderTemplateInput input`))
-				.toHaveValue("@{types.string}");
+			await expect(
+				page.locator(`${FIELD} .fieldStateAutocomplete span.prop`),
+			).toHaveText(["none", "string", "integer", "float"]);
+			await expect(
+				page.locator(`${FIELD} .fieldStateAutocomplete span.type`),
+			).toHaveText(["null", "string", "number", "number"]);
+			page
+				.locator(
+					`${FIELD} .fieldStateAutocomplete span.prop:text-matches("string")`,
+				)
+				.click();
+			await expect(
+				page.locator(`${FIELD} .BuilderTemplateInput input`),
+			).toHaveValue("@{types.string}");
 		});
 	}
 
-	testFieldType("BuilderFieldsColor", "primaryTextColor", 'div.CoreText.component');
-	testFieldType("BuilderFieldsShadow", "buttonShadow", '.BuilderSidebarComponentTree [data-automation-key="root"]');
-	testFieldType("BuilderFieldsAlign", "contentHAlign", '.BuilderSidebarComponentTree [data-automation-key="root"]');
-	testFieldType("BuilderFieldsPadding", "contentPadding", '.BuilderSidebarComponentTree [data-automation-key="root"]');
-	testFieldType("BuilderFieldsWidth", "contentWidth", '.BuilderSidebarComponentTree [data-automation-key="root"]');
+	testFieldType(
+		"BuilderFieldsColor",
+		"primaryTextColor",
+		"div.CoreText.component",
+	);
+	testFieldType(
+		"BuilderFieldsShadow",
+		"buttonShadow",
+		'.BuilderSidebarComponentTree [data-automation-key="root"]',
+	);
+	testFieldType(
+		"BuilderFieldsAlign",
+		"contentHAlign",
+		'.BuilderSidebarComponentTree [data-automation-key="root"]',
+	);
+	testFieldType(
+		"BuilderFieldsPadding",
+		"contentPadding",
+		'.BuilderSidebarComponentTree [data-automation-key="root"]',
+	);
+	testFieldType(
+		"BuilderFieldsWidth",
+		"contentWidth",
+		'.BuilderSidebarComponentTree [data-automation-key="root"]',
+	);
 });

--- a/tests/e2e/tests/undoRedo.spec.ts
+++ b/tests/e2e/tests/undoRedo.spec.ts
@@ -1,15 +1,19 @@
 import { test, expect, type Page } from "@playwright/test";
 
-test.describe('undo and redo', () => {
-	const TYPE = 'button';
-	const COMPONENT_LOCATOR = 'button.CoreButton.component';
+test.describe("undo and redo", () => {
+	const TYPE = "button";
+	const COMPONENT_LOCATOR = "button.CoreButton.component";
 	const COLUMN1 = ".CoreColumns .CoreColumn:nth-child(1 of .CoreColumn)";
 	const COLUMN2 = ".CoreColumns .CoreColumn:nth-child(2 of .CoreColumn)";
 	let url: string;
 
 	const collapseSettingsBar = async (page: Page) => {
-		await page.locator('.BuilderSettings button[data-automation-action="collapse-settings"]').click();
-	}
+		await page
+			.locator(
+				'.BuilderSettings button[data-automation-action="collapse-settings"]',
+			)
+			.click();
+	};
 
 	test.beforeAll(async ({ request }) => {
 		const response = await request.post(`/preset/2columns`);
@@ -22,43 +26,46 @@ test.describe('undo and redo', () => {
 	});
 
 	test.beforeEach(async ({ page }) => {
-		await page.goto(url, {waitUntil: "domcontentloaded"});
+		await page.goto(url, { waitUntil: "domcontentloaded" });
 	});
 
-	test("create, drag and drop, property change and remove", async ({ page }) => {
+	test("create, drag and drop, property change and remove", async ({
+		page,
+	}) => {
+		await page.locator(`[data-automation-action="sidebar-add"]`).click();
 		await page
 			.locator(`.BuilderSidebarToolkit [data-component-type="${TYPE}"]`)
 			.dragTo(page.locator(COLUMN1));
-		await page.locator('.BuilderHeader [data-automation-key="undo"]').click();
-		await expect(page.locator(COMPONENT_LOCATOR)).toHaveCount(0)
-		await page.locator('.BuilderHeader [data-automation-key="redo"]').click();
-		await expect(page.locator(COMPONENT_LOCATOR)).toHaveCount(1)
+		await page.locator('[data-automation-key="undo"]').click();
+		await expect(page.locator(COMPONENT_LOCATOR)).toHaveCount(0);
+		await page.locator('[data-automation-key="redo"]').click();
+		await expect(page.locator(COMPONENT_LOCATOR)).toHaveCount(1);
 
 		await page.locator(COMPONENT_LOCATOR).dragTo(page.locator(COLUMN2));
-		await page.locator('.BuilderHeader [data-automation-key="undo"]').click();
-		await expect(
-			page.locator(COLUMN1 + " " + COMPONENT_LOCATOR),
-		).toHaveCount(1);
-		await expect(
-			page.locator(COLUMN2 + " " + COMPONENT_LOCATOR),
-		).toHaveCount(0);
-		await page.locator('.BuilderHeader [data-automation-key="redo"]').click();
-		await expect(
-			page.locator(COLUMN1 + " " + COMPONENT_LOCATOR),
-		).toHaveCount(0);
-		await expect(
-			page.locator(COLUMN2 + " " + COMPONENT_LOCATOR),
-		).toHaveCount(1);
+		await page.locator('[data-automation-key="undo"]').click();
+		await expect(page.locator(COLUMN1 + " " + COMPONENT_LOCATOR)).toHaveCount(
+			1,
+		);
+		await expect(page.locator(COLUMN2 + " " + COMPONENT_LOCATOR)).toHaveCount(
+			0,
+		);
+		await page.locator('[data-automation-key="redo"]').click();
+		await expect(page.locator(COLUMN1 + " " + COMPONENT_LOCATOR)).toHaveCount(
+			0,
+		);
+		await expect(page.locator(COLUMN2 + " " + COMPONENT_LOCATOR)).toHaveCount(
+			1,
+		);
 
 		await page.locator(COMPONENT_LOCATOR).click();
 		await page
 			.locator('.BuilderFieldsText[data-automation-key="text"] input')
-			.fill('cool text');
+			.fill("cool text");
 		await collapseSettingsBar(page);
-		await page.locator('.BuilderHeader [data-automation-key="undo"]').click();
-		await expect(page.locator(COMPONENT_LOCATOR)).toHaveText('Button Text')
-		await page.locator('.BuilderHeader [data-automation-key="redo"]').click();
-		await expect(page.locator(COMPONENT_LOCATOR)).toHaveText('cool text')
+		await page.locator('[data-automation-key="undo"]').click();
+		await expect(page.locator(COMPONENT_LOCATOR)).toHaveText("Button Text");
+		await page.locator('[data-automation-key="redo"]').click();
+		await expect(page.locator(COMPONENT_LOCATOR)).toHaveText("cool text");
 
 		await page.locator(COMPONENT_LOCATOR).click();
 		await page
@@ -66,9 +73,9 @@ test.describe('undo and redo', () => {
 				'.BuilderSettingsActions .actionButton[data-automation-action="delete"]',
 			)
 			.click();
-		await page.locator('.BuilderHeader [data-automation-key="undo"]').click();
-		await expect(page.locator(COMPONENT_LOCATOR)).toHaveCount(1)
-		await page.locator('.BuilderHeader [data-automation-key="redo"]').click();
-		await expect(page.locator(COMPONENT_LOCATOR)).toHaveCount(0)
+		await page.locator('[data-automation-key="undo"]').click();
+		await expect(page.locator(COMPONENT_LOCATOR)).toHaveCount(1);
+		await page.locator('[data-automation-key="redo"]').click();
+		await expect(page.locator(COMPONENT_LOCATOR)).toHaveCount(0);
 	});
 });


### PR DESCRIPTION
Implement a new layout with

- the header in black with a centered menu switcher
- a left sidebar containing the panel of Components Tree and Components List

![localhost_5173_](https://github.com/user-attachments/assets/b731f5dc-069b-4fbc-8ec2-5605256a39d9)


I also updated the library `@fontsource-variable/material-symbols-outlined` to get newer icons
