### PR TITLE
chore: increase timeout for `HTTPRequest` block

### DIFF
--- a/src/writer/blocks/httprequest.py
+++ b/src/writer/blocks/httprequest.py
@@ -114,7 +114,8 @@ class HTTPRequest(BlueprintBlock):
                     method,
                     url,
                     headers=headers,
-                    content=raw_body
+                    content=raw_body,
+                    timeout=180
                     )
 
                 content_type = res.headers.get("Content-Type", "")


### PR DESCRIPTION
Default timeout is 20 seconds – which is too short for some synchronous AI operations. This sets the timeout to 180 seconds.