### PR TITLE
fix(ui): setup `type="button"` for `WdsButtonLink`

### DIFF
--- a/src/ui/src/wds/WdsButton.vue
+++ b/src/ui/src/wds/WdsButton.vue
@@ -2,7 +2,7 @@
 	<button
 		class="WdsButton colorTransformer"
 		:class="className"
-		role="button"
+		type="button"
 		:style="style"
 		:disabled="disabled || loading"
 	>

--- a/src/ui/src/wds/WdsButtonLink.vue
+++ b/src/ui/src/wds/WdsButtonLink.vue
@@ -3,7 +3,7 @@
 		class="WdsButtonLink"
 		:disabled="disbaled"
 		:class="className"
-		role="button"
+		type="button"
 	>
 		<i v-if="leftIcon" class="material-symbols-outlined">{{ leftIcon }}</i>
 		<span class="WdsButtonLink__text">{{ text }}</span>

--- a/src/ui/src/wds/WdsDropdownMenu.vue
+++ b/src/ui/src/wds/WdsDropdownMenu.vue
@@ -13,7 +13,7 @@
 				</div>
 				<button
 					class="WdsDropdownMenu__header__multiSelect__clear"
-					role="button"
+					type="button"
 					@click="$emit('select', [])"
 				>
 					Clear all

--- a/src/ui/src/wds/WdsTag.vue
+++ b/src/ui/src/wds/WdsTag.vue
@@ -27,7 +27,7 @@ defineEmits({
 		<span class="WdsTag__text">{{ text }}</span>
 		<button
 			v-if="closable"
-			role="button"
+			type="button"
 			class="WdsTag__close"
 			@click.stop="$emit('close')"
 		>


### PR DESCRIPTION
Without `type="button"`, the button is considerate as a Submit button, which sends the parent form and produces a page reloading