### PR TITLE
fix(ui): bump library `vue-pdf` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3555,7 +3555,9 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
 			"integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"detect-libc": "^2.0.0",
 				"https-proxy-agent": "^5.0.0",
@@ -3575,7 +3577,9 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
 			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"semver": "^6.0.0"
 			},
@@ -3590,7 +3594,9 @@
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -3599,7 +3605,9 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
 			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"abbrev": "1"
 			},
@@ -3660,6 +3668,188 @@
 			},
 			"peerDependencies": {
 				"monaco-editor": ">= 0.21.0 < 1"
+			}
+		},
+		"node_modules/@napi-rs/canvas": {
+			"version": "0.1.70",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.70.tgz",
+			"integrity": "sha512-nD6NGa4JbNYSZYsTnLGrqe9Kn/lCkA4ybXt8sx5ojDqZjr2i0TWAHxx/vhgfjX+i3hCdKWufxYwi7CfXqtITSA==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@napi-rs/canvas-android-arm64": "0.1.70",
+				"@napi-rs/canvas-darwin-arm64": "0.1.70",
+				"@napi-rs/canvas-darwin-x64": "0.1.70",
+				"@napi-rs/canvas-linux-arm-gnueabihf": "0.1.70",
+				"@napi-rs/canvas-linux-arm64-gnu": "0.1.70",
+				"@napi-rs/canvas-linux-arm64-musl": "0.1.70",
+				"@napi-rs/canvas-linux-riscv64-gnu": "0.1.70",
+				"@napi-rs/canvas-linux-x64-gnu": "0.1.70",
+				"@napi-rs/canvas-linux-x64-musl": "0.1.70",
+				"@napi-rs/canvas-win32-x64-msvc": "0.1.70"
+			}
+		},
+		"node_modules/@napi-rs/canvas-android-arm64": {
+			"version": "0.1.70",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.70.tgz",
+			"integrity": "sha512-I/YOuQ0wbkVYxVaYtCgN42WKTYxNqFA0gTcTrHIGG1jfpDSyZWII/uHcjOo4nzd19io6Y4+/BqP8E5hJgf9OmQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-arm64": {
+			"version": "0.1.70",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.70.tgz",
+			"integrity": "sha512-4pPGyXetHIHkw2TOJHujt3mkCP8LdDu8+CT15ld9Id39c752RcI0amDHSuMLMQfAjvusA9B5kKxazwjMGjEJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-x64": {
+			"version": "0.1.70",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.70.tgz",
+			"integrity": "sha512-+2N6Os9LbkmDMHL+raknrUcLQhsXzc5CSXRbXws9C3pv/mjHRVszQ9dhFUUe9FjfPhCJznO6USVdwOtu7pOrzQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+			"version": "0.1.70",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.70.tgz",
+			"integrity": "sha512-QjscX9OaKq/990sVhSMj581xuqLgiaPVMjjYvWaCmAJRkNQ004QfoSMEm3FoTqM4DRoquP8jvuEXScVJsc1rqQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+			"version": "0.1.70",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.70.tgz",
+			"integrity": "sha512-LNakMOwwqwiHIwMpnMAbFRczQMQ7TkkMyATqFCOtUJNlE6LPP/QiUj/mlFrNbUn/hctqShJ60gWEb52ZTALbVw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-musl": {
+			"version": "0.1.70",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.70.tgz",
+			"integrity": "sha512-wBTOllEYNfJCHOdZj9v8gLzZ4oY3oyPX8MSRvaxPm/s7RfEXxCyZ8OhJ5xAyicsDdbE5YBZqdmaaeP5+xKxvtg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+			"version": "0.1.70",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.70.tgz",
+			"integrity": "sha512-GVUUPC8TuuFqHip0rxHkUqArQnlzmlXmTEBuXAWdgCv85zTCFH8nOHk/YCF5yo0Z2eOm8nOi90aWs0leJ4OE5Q==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-gnu": {
+			"version": "0.1.70",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.70.tgz",
+			"integrity": "sha512-/kvUa2lZRwGNyfznSn5t1ShWJnr/m5acSlhTV3eXECafObjl0VBuA1HJw0QrilLpb4Fe0VLywkpD1NsMoVDROQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-musl": {
+			"version": "0.1.70",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.70.tgz",
+			"integrity": "sha512-aqlv8MLpycoMKRmds7JWCfVwNf1fiZxaU7JwJs9/ExjTD8lX2KjsO7CTeAj5Cl4aEuzxUWbJPUUE2Qu9cZ1vfg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-win32-x64-msvc": {
+			"version": "0.1.70",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.70.tgz",
+			"integrity": "sha512-Q9QU3WIpwBTVHk4cPfBjGHGU4U0llQYRXgJtFtYqqGNEOKVN4OT6PQ+ve63xwIPODMpZ0HHyj/KLGc9CWc3EtQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
 			}
 		},
 		"node_modules/@ndelangen/get-tarball": {
@@ -5269,11 +5459,12 @@
 			}
 		},
 		"node_modules/@tato30/vue-pdf": {
-			"version": "1.9.6",
-			"resolved": "https://registry.npmjs.org/@tato30/vue-pdf/-/vue-pdf-1.9.6.tgz",
-			"integrity": "sha512-pYnxPBO7DEMXuBeRp0A/AbE0d3Z/TuyMtOJT5muxxTQyXmOB5PWLcTS/6RZivX0HhNWbS9g5U6nHI0hFBACKYQ==",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/@tato30/vue-pdf/-/vue-pdf-1.11.3.tgz",
+			"integrity": "sha512-YKEmy3NKAy+UsgYCu+GkKQ1VaIovjP/5lO5NmiKRjv9Jbl1LqJYGafZUt3QXp5Ijg0DN2gYDf8Jl949Lr9E7mA==",
+			"license": "MIT",
 			"dependencies": {
-				"pdfjs-dist": "3.11.174"
+				"pdfjs-dist": "4.9.124"
 			},
 			"peerDependencies": {
 				"vue": "^3.2.33"
@@ -6504,7 +6695,7 @@
 		},
 		"node_modules/abbrev": {
 			"version": "1.1.1",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/accepts": {
@@ -6548,7 +6739,9 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
 			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "4"
 			},
@@ -6674,13 +6867,17 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
 			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-			"optional": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/are-we-there-yet": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
 			"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^3.6.0"
@@ -7075,7 +7272,7 @@
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/base64-js": {
@@ -7370,8 +7567,10 @@
 			"version": "2.11.2",
 			"resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
 			"integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+			"dev": true,
 			"hasInstallScript": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@mapbox/node-pre-gyp": "^1.0.0",
 				"nan": "^2.17.0",
@@ -7553,7 +7752,7 @@
 		},
 		"node_modules/chownr": {
 			"version": "2.0.0",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
@@ -7728,7 +7927,9 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
 			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"color-support": "bin.js"
 			}
@@ -7855,7 +8056,7 @@
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/config-chain": {
@@ -7881,7 +8082,9 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-			"optional": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/constantinople": {
 			"version": "4.0.1",
@@ -8426,7 +8629,7 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
 			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -8451,7 +8654,9 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
 			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"mimic-response": "^2.0.0"
 			},
@@ -8644,7 +8849,9 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-			"optional": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/depd": {
 			"version": "2.0.0",
@@ -8681,7 +8888,9 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
 			"integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -10055,7 +10264,7 @@
 		},
 		"node_modules/fs-minipass": {
 			"version": "2.1.0",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
@@ -10066,7 +10275,7 @@
 		},
 		"node_modules/fs-minipass/node_modules/minipass": {
 			"version": "3.3.6",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^4.0.0"
@@ -10077,7 +10286,7 @@
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/fsevents": {
@@ -10119,7 +10328,9 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
 			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"aproba": "^1.0.3 || ^2.0.0",
 				"color-support": "^1.1.2",
@@ -10239,7 +10450,7 @@
 		},
 		"node_modules/glob": {
 			"version": "7.2.3",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
@@ -10274,7 +10485,7 @@
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
 			"version": "1.1.11",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -10283,7 +10494,7 @@
 		},
 		"node_modules/glob/node_modules/minimatch": {
 			"version": "3.1.2",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -10449,7 +10660,9 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-			"optional": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/hash-sum": {
 			"version": "2.0.0",
@@ -10589,7 +10802,9 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
 			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"agent-base": "6",
 				"debug": "4"
@@ -10701,7 +10916,7 @@
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"once": "^1.3.0",
@@ -13927,7 +14142,9 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
 			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -13968,7 +14185,7 @@
 		},
 		"node_modules/minipass": {
 			"version": "5.0.0",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=8"
@@ -13976,7 +14193,7 @@
 		},
 		"node_modules/minizlib": {
 			"version": "2.1.2",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"minipass": "^3.0.0",
@@ -13988,7 +14205,7 @@
 		},
 		"node_modules/minizlib/node_modules/minipass": {
 			"version": "3.3.6",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^4.0.0"
@@ -14036,7 +14253,9 @@
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
 			"integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
-			"optional": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.7",
@@ -14237,7 +14456,9 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
 			"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"are-we-there-yet": "^2.0.0",
 				"console-control-strings": "^1.1.0",
@@ -14407,7 +14628,7 @@
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -14485,7 +14706,7 @@
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
@@ -14757,7 +14978,7 @@
 		},
 		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -14813,15 +15034,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/path2d-polyfill": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path2d-polyfill/-/path2d-polyfill-2.0.1.tgz",
-			"integrity": "sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==",
-			"optional": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/pathe": {
 			"version": "1.1.2",
 			"dev": true,
@@ -14847,15 +15059,15 @@
 			}
 		},
 		"node_modules/pdfjs-dist": {
-			"version": "3.11.174",
-			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
-			"integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
+			"version": "4.9.124",
+			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.9.124.tgz",
+			"integrity": "sha512-yAoM7C+IYIG23dAZHE2KqtE5exEj067Ef6oblb+AHiqLwTJSQOMB+e8ftBA3pp1+6TyE4xeofoHcu9t7XaOE0g==",
+			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"optionalDependencies": {
-				"canvas": "^2.11.2",
-				"path2d-polyfill": "^2.0.1"
+				"@napi-rs/canvas": "^0.1.64"
 			}
 		},
 		"node_modules/peek-stream": {
@@ -15607,7 +15819,7 @@
 		},
 		"node_modules/readable-stream": {
 			"version": "3.6.2",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
@@ -15890,7 +16102,7 @@
 		},
 		"node_modules/rimraf": {
 			"version": "3.0.2",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"glob": "^7.1.3"
@@ -16087,7 +16299,9 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-			"optional": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/set-function-length": {
 			"version": "1.2.1",
@@ -16176,13 +16390,14 @@
 		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/simple-concat": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
 			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -16197,13 +16412,16 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/simple-get": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
 			"integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"decompress-response": "^4.2.0",
 				"once": "^1.3.1",
@@ -16395,7 +16613,7 @@
 		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
@@ -16589,7 +16807,7 @@
 		},
 		"node_modules/tar": {
 			"version": "6.2.1",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"chownr": "^2.0.0",
@@ -16636,7 +16854,7 @@
 		},
 		"node_modules/tar/node_modules/mkdirp": {
 			"version": "1.0.4",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"mkdirp": "bin/cmd.js"
@@ -17359,7 +17577,7 @@
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/utils-merge": {
@@ -18606,7 +18824,9 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
 			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
@@ -18728,7 +18948,7 @@
 		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/write-file-atomic": {
@@ -18807,7 +19027,7 @@
 		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/yargs": {
@@ -18854,7 +19074,7 @@
 				"@fontsource/poppins": "^5.0.14",
 				"@googlemaps/js-api-loader": "^1.16.6",
 				"@monaco-editor/loader": "^1.3.3",
-				"@tato30/vue-pdf": "^1.9.6",
+				"@tato30/vue-pdf": "^1.11.3",
 				"ajv": "^8.17.1",
 				"arquero": "^5.2.0",
 				"chroma-js": "^2.4.2",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -24,7 +24,7 @@
 		"@fontsource/poppins": "^5.0.14",
 		"@googlemaps/js-api-loader": "^1.16.6",
 		"@monaco-editor/loader": "^1.3.3",
-		"@tato30/vue-pdf": "^1.9.6",
+		"@tato30/vue-pdf": "^1.11.3",
 		"ajv": "^8.17.1",
 		"arquero": "^5.2.0",
 		"chroma-js": "^2.4.2",

--- a/src/ui/src/utils/base64.ts
+++ b/src/ui/src/utils/base64.ts
@@ -13,3 +13,17 @@ export function base64ToArrayBuffer(base64: string) {
 	}
 	return bytes.buffer;
 }
+
+export function dataURLToArrayBuffer(dataURL: string) {
+	const base64String = dataUrlToBase64(dataURL);
+	const binaryString = atob(base64String);
+
+	const buffer = new ArrayBuffer(binaryString.length);
+	const bytes = new Uint8Array(buffer);
+
+	for (let i = 0; i < binaryString.length; i++) {
+		bytes[i] = binaryString.charCodeAt(i);
+	}
+
+	return buffer;
+}


### PR DESCRIPTION
Bump `@tato30/vue-pdf` version to bump `pdf.js` version. It's needed to patch a vulnerability that executes JavaScript encoded in the PDF file.

This behavior is blocked on writer.com that block this behavior with CSP, and makes the PDF not loading.

fixes https://github.com/writer/writer-framework/security/dependabot/22

> If pdf.js is used to load a malicious PDF, and PDF.js is configured with `isEvalSupported` set to `true` (which is the default value), unrestricted attacker-controlled JavaScript will be executed in the context of the hosting domain.