### PR TITLE
feat(ui): change default `target` for `CoreLink` - WF-389

### DIFF
--- a/src/ui/src/components/core/content/CoreLink.vue
+++ b/src/ui/src/components/core/content/CoreLink.vue
@@ -45,7 +45,7 @@ export default {
 					_top: "Top",
 				},
 				desc: "Specifies where to open the linked document.",
-				default: "_self",
+				default: "_blank",
 			},
 			rel: {
 				name: "Rel",


### PR DESCRIPTION
Use `target="_blank"` so link open a new tab by default