### PR TITLE
fix: WF-441 convert `created_at` datetime into isoformat str

### DIFF
--- a/src/writer/blocks/writerfileapi.py
+++ b/src/writer/blocks/writerfileapi.py
@@ -73,7 +73,7 @@ class WriterUploadFile(WriterBlock):
                     "id": file.id,
                     "name": file.name,
                     "status": file.status,
-                    "created_at": file.created_at,
+                    "created_at": file.created_at.isoformat(),
                     "graph_ids": file.graph_ids
                 })
             if len(outputs) == 0:

--- a/tests/backend/blocks/test_writerfileapi.py
+++ b/tests/backend/blocks/test_writerfileapi.py
@@ -1,3 +1,4 @@
+from datetime import datetime as dt
 import pytest
 from writer.blocks.writerfileapi import WriterUploadFile
 from writer.ss_types import WriterConfigurationError
@@ -11,7 +12,7 @@ class MockFile:
         self.id = "file-123"
         self.name = "myfile.pdf"
         self.status = "processed"
-        self.created_at = "2024-01-01T00:00:00Z"
+        self.created_at = dt.strptime("2024-01-01T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
         self.graph_ids = ["g1", "g2"]
 
 

--- a/tests/backend/blocks/test_writerfileapi.py
+++ b/tests/backend/blocks/test_writerfileapi.py
@@ -1,4 +1,5 @@
 from datetime import datetime as dt
+
 import pytest
 from writer.blocks.writerfileapi import WriterUploadFile
 from writer.ss_types import WriterConfigurationError


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - File upload timestamps are now displayed in ISO 8601 format for improved consistency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->