### PR TITLE
fix(ui): forbid removing `blueprints_root` - WF-426

### DIFF
--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
@@ -74,6 +74,10 @@ import BuilderTree from "../BuilderTree.vue";
 import { useComponentsTreeSearchForComponent } from "./composables/useComponentsTreeSearch";
 import { useComponentDescription } from "../useComponentDescription";
 import { useWriterTracking } from "@/composables/useWriterTracking";
+import {
+	COMPONENT_TYPES_ROOT,
+	COMPONENT_TYPES_TOP_LEVEL,
+} from "@/constants/component";
 
 const props = defineProps({
 	componentId: { type: String, required: true },
@@ -102,13 +106,6 @@ const emit = defineEmits(["expandBranch"]);
 const q = computed(() => props.query?.toLocaleLowerCase() ?? "");
 
 const component = computed(() => wf.getComponentById(props.componentId));
-
-const COMPONENT_TYPES_ROOT = new Set(["root", "blueprints_root"]);
-const COMPONENT_TYPES_TOP_LEVEL = new Set([
-	...COMPONENT_TYPES_ROOT,
-	"page",
-	"blueprints_blueprint",
-]);
 
 const { hasMatchingChildren, matched } = useComponentsTreeSearchForComponent(
 	wf,

--- a/src/ui/src/builder/useComponentAction.spec.ts
+++ b/src/ui/src/builder/useComponentAction.spec.ts
@@ -16,6 +16,11 @@ describe(useComponentActions.name, () => {
 		const components: Component[] = [
 			{ id: "root", type: "root", position: 0 } as Component,
 			{
+				id: "blueprints_root",
+				type: "blueprints_root",
+				position: 0,
+			} as Component,
+			{
 				id: "page-id",
 				type: "page",
 				content: { key: "page" },
@@ -73,9 +78,32 @@ describe(useComponentActions.name, () => {
 				parentId: "page-id",
 				position: 1,
 			},
+			{
+				id: "blueprints_blueprint-id",
+				type: "blueprints_blueprint",
+				content: {},
+				handlers: {},
+				isCodeManaged: false,
+				parentId: "blueprints_root",
+				position: 1,
+			},
 		];
 
 		components.forEach((c) => core.addComponent(c));
+	});
+
+	describe("isDeleteAllowed", () => {
+		it("should handle UI components", () => {
+			const { isDeleteAllowed } = useComponentActions(core, ssbm);
+			expect(isDeleteAllowed("root")).toBeFalsy();
+			expect(isDeleteAllowed("page-id")).toBeTruthy();
+		});
+
+		it("should handle blueprint components", () => {
+			const { isDeleteAllowed } = useComponentActions(core, ssbm);
+			expect(isDeleteAllowed("blueprints_root")).toBeFalsy();
+			expect(isDeleteAllowed("blueprints_blueprint-id")).toBeTruthy();
+		});
 	});
 
 	describe("removeComponentSubtree", () => {

--- a/src/ui/src/builder/useComponentActions.ts
+++ b/src/ui/src/builder/useComponentActions.ts
@@ -2,6 +2,7 @@ import type { useWriterTracking } from "@/composables/useWriterTracking";
 import { getContainableTypes } from "../core/typeHierarchy";
 import { Core, BuilderManager, Component, ComponentMap } from "@/writerTypes";
 import { useComponentClipboard } from "./useComponentClipboard";
+import { COMPONENT_TYPES_ROOT } from "@/constants/component";
 
 export function useComponentActions(
 	wf: Core,
@@ -347,7 +348,7 @@ export function useComponentActions(
 	 * Whether a target component is the root
 	 */
 	function isRoot(targetId: Component["id"]): boolean {
-		return targetId == "root";
+		return COMPONENT_TYPES_ROOT.has(targetId);
 	}
 
 	/**

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -123,7 +123,6 @@ import { useLogger } from "@/composables/useLogger";
 import { mathCeilToMultiple } from "@/utils/math";
 import { WdsColor } from "@/wds/tokens";
 import { useWriterTracking } from "@/composables/useWriterTracking";
-import { instance } from "@apache-arrow/ts/visitor/set";
 
 const { log } = useLogger();
 

--- a/src/ui/src/constants/component.ts
+++ b/src/ui/src/constants/component.ts
@@ -1,0 +1,7 @@
+export const COMPONENT_TYPES_ROOT = new Set(["root", "blueprints_root"]);
+
+export const COMPONENT_TYPES_TOP_LEVEL = new Set([
+	...COMPONENT_TYPES_ROOT,
+	"page",
+	"blueprints_blueprint",
+]);

--- a/src/ui/src/core/typeHierarchy.ts
+++ b/src/ui/src/core/typeHierarchy.ts
@@ -3,6 +3,7 @@ import {
 	getComponentDefinition,
 	getSupportedComponentTypes,
 } from "./templateMap";
+import { COMPONENT_TYPES_ROOT } from "@/constants/component";
 
 function getDisallowedSet(
 	components: ComponentMap,
@@ -30,7 +31,7 @@ function getAllowedSet(
 ): Set<Component["type"]> {
 	const { type, parentId } = components[componentId];
 	const supportedTypes = getSupportedComponentTypes().filter(
-		(t) => t !== "root" && t !== "blueprints_root",
+		(t) => !COMPONENT_TYPES_ROOT.has(t),
 	);
 	const { allowedChildrenTypes, toolkit } = getComponentDefinition(type);
 	if (!allowedChildrenTypes) return new Set([]);

--- a/src/ui/src/renderer/ComponentProxy.vue
+++ b/src/ui/src/renderer/ComponentProxy.vue
@@ -14,6 +14,7 @@ import RenderError from "./RenderError.vue";
 import { flattenInstancePath } from "./instancePath";
 import { useEvaluator } from "./useEvaluator";
 import { useWriterTracking } from "@/composables/useWriterTracking";
+import { COMPONENT_TYPES_ROOT } from "@/constants/component";
 
 export default {
 	props: {
@@ -50,14 +51,13 @@ export default {
 			() =>
 				isBeingEdited.value &&
 				!component.value.isCodeManaged &&
-				component.value.type !== "root" &&
-				component.value.type !== "blueprints_root" &&
+				!COMPONENT_TYPES_ROOT.has(component.value.type) &&
 				componentDefinition.value?.toolkit !== "blueprints",
 		);
 
 		const isParentSuitable = (parentId, childType) => {
 			const allowedTypes = !parentId
-				? ["root", "blueprints_root"]
+				? [...COMPONENT_TYPES_ROOT]
 				: wf.getContainableTypes(parentId);
 			return allowedTypes.includes(childType);
 		};


### PR DESCRIPTION
`blueprints_root` was not considerated as a Root node and it was deletable by the user, which leaded to issues.

I also took the opportunity to reuse a constant listing the types of components conciderated as root.