### PR TITLE
fix: Handle empty IP in Basic Auth

### DIFF
--- a/src/writer/auth.py
+++ b/src/writer/auth.py
@@ -405,6 +405,11 @@ def _client_ip(request: Request) -> str:
         ip = x_forwarded_for.split(",")[0].strip()
     else:
         # Otherwise, use the direct connection IP
-        ip = request.headers.get("X-Real-IP", request.client.host)  # type: ignore
+        x_real_ip = request.headers.get("X-Real-IP")
+        if x_real_ip is not None:
+            ip = x_real_ip
+        else:
+            client = request.client
+            ip = client.host if client is not None else ""
 
     return ip


### PR DESCRIPTION
## Summary
- handle cases where `request.client` is missing in `auth._client_ip`

## Testing
- `ruff check src/writer/auth.py`
- ❌ `pytest` *(fails: ModuleNotFoundError: No module named 'pyarrow')*