### PR TITLE
Rename exerpt variable to excerpt

### DIFF
--- a/src/ui/src/builder/sidebar/BuilderSidebarNote.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarNote.vue
@@ -41,8 +41,8 @@ const displayUserLoader = computed(
 
 const contentExcerpt = computed(() => {
 	if (content.value.length < 100) return content.value;
-	const exerpt = content.value.slice(0, 100);
-	return `${exerpt}...`;
+	const excerpt = content.value.slice(0, 100);
+	return `${excerpt}...`;
 });
 
 const contentParagraphs = computed(() => content.value.split("\n"));

--- a/src/writer/wf_project.py
+++ b/src/writer/wf_project.py
@@ -393,11 +393,11 @@ def build_source_files(app_path: str) -> SourceFilesDirectory:
                     content = load_persisted_script(relative_path)
                     extension = os.path.splitext(relative_path)[1]
                     # limit only the first 100 characters to limit bandwidth usage, the rest will be lazy loaded
-                    exerpt = content if extension == '.py' else content[0:100]
+                    excerpt = content if extension == '.py' else content[0:100]
                     current_level["children"][part] = {
                         "type": "file",
-                        "content": exerpt,
-                        "complete": exerpt == content,
+                        "content": excerpt,
+                        "complete": excerpt == content,
                     }
                 except UnicodeDecodeError:
                     # TODO: get mimetype


### PR DESCRIPTION
## Summary
- rename `exerpt` variable to `excerpt`
- run prettier on sidebar note component

## Testing
- `npm run cli:test` *(fails: ModuleNotFoundError: No module named 'writer')*
- `PYTHONPATH=./src pytest -q` *(fails: ModuleNotFoundError: No module named 'pyarrow')*
- `npm test` *(fails: vitest: not found)*