### PR TITLE
fix: BasicAuth docstring

### DIFF
--- a/src/writer/auth.py
+++ b/src/writer/auth.py
@@ -82,7 +82,7 @@ class BasicAuth(Auth):
     >>>     login=os.getenv('LOGIN'),
     >>>     password=os.getenv('PASSWORD'),
     >>>     delay_after_failure=5,
-    >>>     block_webserver_after_failure=False
+    >>>     block_user_after_failure=False
     >>> )
     """
     login: str


### PR DESCRIPTION
## Summary
- fix docstring of `BasicAuth` to use `block_user_after_failure`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*