### PR TITLE
feat(ui): introduce the App name renamer field - WF-355 WF-442

### DIFF
--- a/src/ui/src/builder/BuilderHeader.vue
+++ b/src/ui/src/builder/BuilderHeader.vue
@@ -11,6 +11,13 @@
 			</a>
 			<img v-else src="../assets/logo.svg" alt="Writer Framework logo" />
 			<hr />
+			<input
+				v-if="wf.isWriterCloudApp.value"
+				v-model="applicationName"
+				type="text"
+				:disabled="!!lastDeployedAt"
+				class="BuilderHeader__logo__appTitle"
+			/>
 		</div>
 		<BuilderSwitcher class="BuilderHeader__switcher" />
 		<div class="BuilderHeader__toolbar">
@@ -87,6 +94,7 @@ const {
 	hasBeenPublished,
 	lastDeployedAt,
 	writerDeployUrl,
+	name: applicationName,
 } = useWriterAppDeployment(wf);
 
 const dateFormater = new Intl.DateTimeFormat(undefined, {
@@ -196,6 +204,25 @@ function showStateExplorer() {
 	text-decoration: none;
 	display: inline-flex;
 	align-items: center;
+}
+.BuilderHeader__logo__appTitle {
+	background-color: transparent;
+	width: 100%;
+	border: none;
+	font-weight: 500;
+	font-size: 16px;
+	border-radius: 4px;
+	padding: 4px;
+	height: 32px;
+	text-overflow: ellipsis;
+}
+.BuilderHeader__logo__appTitle:focus {
+	outline: none;
+}
+.BuilderHeader__logo__appTitle:not([disabled]):hover,
+.BuilderHeader__logo__appTitle:not([disabled]):focus {
+	outline: none;
+	background-color: var(--wdsColorGray5);
 }
 
 .BuilderHeader__toolbar {

--- a/src/ui/src/composables/useDebouncer.spec.ts
+++ b/src/ui/src/composables/useDebouncer.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, vi, expect, beforeAll, afterAll } from "vitest";
+import { useDebouncer } from "./useDebouncer";
+
+describe(useDebouncer.name, () => {
+	beforeAll(() => {
+		vi.useFakeTimers();
+	});
+
+	afterAll(() => {
+		vi.useRealTimers();
+	});
+
+	it("should call the callback one time", () => {
+		const callback = vi.fn();
+
+		const callbackDebounced = useDebouncer(callback, 1_000);
+
+		callbackDebounced();
+		callbackDebounced();
+		vi.advanceTimersByTime(1_000);
+		expect(callback).toHaveBeenCalledTimes(1);
+
+		callbackDebounced();
+		vi.advanceTimersByTime(500);
+		expect(callback).toHaveBeenCalledTimes(1);
+
+		callbackDebounced();
+		vi.advanceTimersByTime(1_000);
+		expect(callback).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/ui/src/composables/useDebouncer.ts
+++ b/src/ui/src/composables/useDebouncer.ts
@@ -1,0 +1,7 @@
+export function useDebouncer(callback: () => void | Promise<void>, ms: number) {
+	let id: ReturnType<typeof setTimeout>;
+	return () => {
+		if (id) clearTimeout(id);
+		id = setTimeout(callback, ms);
+	};
+}

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -65,13 +65,13 @@ export function generateCore() {
 	let mailSubscriptions: { mailType: string; fn: Function }[] = [];
 	const activePageId: Ref<Component["id"]> = ref(null);
 
-	const isWriterCloudApp = computed(
-		() => writerApplication.value !== undefined,
-	);
 	const writerOrgId = computed(
 		() => Number(writerApplication.value?.organizationId) || undefined,
 	);
 	const writerAppId = computed(() => writerApplication.value?.id);
+	const isWriterCloudApp = computed(() =>
+		Boolean(writerAppId.value || writerOrgId.value),
+	);
 
 	/**
 	 * Initialise the core.

--- a/src/ui/src/writerApi.ts
+++ b/src/ui/src/writerApi.ts
@@ -76,6 +76,38 @@ export class WriterApi {
 		return data;
 	}
 
+	async updateApplicationMetadata(
+		orgId: number,
+		appId: string,
+		body: Partial<
+			Omit<
+				WriterApiApplicationMetadata,
+				| "id"
+				| "applicationId"
+				| "createdBy"
+				| "createdBy"
+				| "updatedAt"
+				| "updatedBy"
+			>
+		>,
+	): Promise<WriterApiApplicationMetadata> {
+		const url = new URL(
+			`/api/template/organization/${orgId}/application/${appId}/metadata`,
+			this.#baseUrl,
+		);
+
+		const res = await fetch(url, {
+			method: "PUT",
+			body: JSON.stringify(body),
+			signal: this.#signal,
+			credentials: "include",
+		});
+		if (!res.ok) throw Error(await res.text());
+
+		const data = await res.json();
+		return data;
+	}
+
 	async fetchUserProfile(): Promise<WriterApiUserProfile> {
 		const url = new URL(`/api/user/v2/profile`, this.#baseUrl);
 		const res = await fetch(url, {
@@ -169,6 +201,18 @@ type WriterApiBlamable = {
 	createdAt: string;
 	updatedAt: string;
 };
+
+type WriterApiApplicationMetadata = {
+	id: string;
+	applicationId: string;
+	name: string;
+	description: string | null;
+	shortDescription: string | null;
+	guideUrl: string | null;
+	tutorialUrl: string | null;
+	icon: string | null;
+	idAlias: string | null;
+} & WriterApiBlamable;
 
 export type WriterApiOrganizationUsers = {
 	result: {


### PR DESCRIPTION
Add an input field in the navbar to update the Agent name through the endpoint

```http
PUT /api/template/organization/{orgId}/application/{appId}/metadata
```

The logic in `useWriterAppDeployment` will handle synchronization with the special block `root` and update the field `appName`.

https://github.com/user-attachments/assets/8186027e-95dc-4ee0-a744-de3695adce03

