### PR TITLE
chore: Add alert on autogen error

### DIFF
--- a/src/ui/src/components/blueprints/BlueprintsAutogen.vue
+++ b/src/ui/src/components/blueprints/BlueprintsAutogen.vue
@@ -116,10 +116,9 @@ async function handleAutogen() {
 		);
 
 		if (!response.ok) {
-			const reason = await response
-				.text()
-				.catch(() => response.statusText);
-			window.alert(`Autogen failed: ${reason}`);
+			window.alert(
+				`Autogen failed. Please try again with a different prompt.`,
+			);
 			return;
 		}
 

--- a/src/ui/src/components/blueprints/BlueprintsAutogen.vue
+++ b/src/ui/src/components/blueprints/BlueprintsAutogen.vue
@@ -99,36 +99,41 @@ function alterIds(components: Component[]) {
 }
 
 async function handleAutogen() {
-        const description = prompt.value;
-        isBusy.value = true;
-        tracking.track("blueprints_auto_gen_started", { prompt: prompt.value });
+	const description = prompt.value;
+	isBusy.value = true;
+	tracking.track("blueprints_auto_gen_started", { prompt: prompt.value });
 
-        try {
-                const response = await fetch(convertAbsolutePathtoFullURL("/api/autogen"), {
-                        method: "POST",
-                        headers: {
-                                "Content-Type": "application/json",
-                        },
-                        body: JSON.stringify({ description }),
-                });
+	try {
+		const response = await fetch(
+			convertAbsolutePathtoFullURL("/api/autogen"),
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ description }),
+			},
+		);
 
-                if (!response.ok) {
-                        const reason = await response.text().catch(() => response.statusText);
-                        window.alert(`Autogen failed: ${reason}`);
-                        return;
-                }
+		if (!response.ok) {
+			const reason = await response
+				.text()
+				.catch(() => response.statusText);
+			window.alert(`Autogen failed: ${reason}`);
+			return;
+		}
 
-                const data = await response.json(); // Assuming the response is JSON
+		const data = await response.json(); // Assuming the response is JSON
 
-                const components: Component[] = alterIds(data.blueprint?.components);
-                emits("blockGeneration", { components });
+		const components: Component[] = alterIds(data.blueprint?.components);
+		emits("blockGeneration", { components });
 
-                tracking.track("blueprints_auto_gen_completed");
-        } catch (error) {
-                window.alert(`Autogen failed: ${error}`);
-        } finally {
-                isBusy.value = false;
-        }
+		tracking.track("blueprints_auto_gen_completed");
+	} catch (error) {
+		window.alert(`Autogen failed: ${error}`);
+	} finally {
+		isBusy.value = false;
+	}
 }
 </script>
 


### PR DESCRIPTION
## Summary
- improve UX for BlueprintsAutogen by alerting the user when autogen fails

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run cli:lint` *(fails: mypy internal error)*
- `npm run test` *(fails: vitest not found)*
- `npm run cli:test` *(fails: ModuleNotFoundError: No module named 'writer')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for the autogen feature, ensuring users receive clear alerts if an error occurs during the process.
  - The busy indicator now reliably resets after completion or failure, preventing it from getting stuck.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->