### PR TITLE
fix: process context ref lists

### DIFF
--- a/src/writer/evaluator.py
+++ b/src/writer/evaluator.py
@@ -227,6 +227,9 @@ class Evaluator:
             elif isinstance(context_ref, dict) and accessor in context_ref:
                 context_ref = context_ref.get(accessor)
                 result = context_ref
+            elif isinstance(context_ref, list) and context_ref[int(accessor)] is not None:
+                context_ref = context_ref[int(accessor)]
+                result = context_ref
 
         if isinstance(result, writer.core.StateProxy):
             return result.to_dict()


### PR DESCRIPTION
Fixes an issue where context references using list accessors (e.g., `result.0.id`) were not correctly processed. Instead of accessing the specified list element, the system defaulted to treating the reference via a top-level accessor, ignoring the intended list indexing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved expression evaluation to support list indexing within context data, allowing for more flexible data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->