### PR TITLE
fix(ui): avoid moving blueprint node on renaming alias

### DIFF
--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -983,7 +983,13 @@ function handleKeydown(event: KeyboardEvent) {
 	if (!wfbm.selection.value.length) return;
 
 	const target = event.target as HTMLElement;
-	if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return;
+	if (
+		target.tagName === "INPUT" ||
+		target.tagName === "TEXTAREA" ||
+		target.getAttribute("contenteditable") === "true"
+	) {
+		return;
+	}
 
 	function getDirection(): Point | undefined {
 		switch (event.key) {

--- a/src/ui/src/components/shared/SharedCollaborationCanvas.vue
+++ b/src/ui/src/components/shared/SharedCollaborationCanvas.vue
@@ -32,7 +32,7 @@ const props = defineProps<{
 	zoomLevel: number;
 }>();
 
-const emit = defineEmits({
+defineEmits({
 	toggle: (open: boolean) => typeof open === "boolean",
 });
 


### PR DESCRIPTION
skip moving blueprint node when the user moves the cursor when focusing a `<div contenteditable="true">`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard handling to prevent shortcuts or arrow key actions from triggering when focus is on editable elements, including contenteditable fields, input boxes, and textareas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->