### PR TITLE
fix(ui): allow binding mode for Key/Value editor - WF-470

### DIFF
--- a/src/ui/src/builder/settings/BuilderFieldsKeyValueModal.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsKeyValueModal.vue
@@ -105,7 +105,7 @@ const BuilderEmbeddedCodeEditor = defineAsyncComponent({
 
 const props = defineProps({
 	data: {
-		type: Object as PropType<JSONValue>,
+		type: [Object, String] as PropType<JSONValue>,
 		required: true,
 	},
 	initialMode: {
@@ -121,6 +121,7 @@ const {
 	freehandValue,
 	isValid,
 	currentValue,
+	isInBindingMode,
 	addAssistedEntry,
 	updateAssistedEntryValue,
 	updateAssistedEntryKey,
@@ -145,10 +146,13 @@ const actions = computed<ModalAction[]>(() => [
 ]);
 
 const tabs = computed<WdsTabOptions<Mode>[]>(() => {
-	let listDisabled =
-		mode.value === "freehand" && !isValid.value
-			? "The JSON is not valid"
-			: undefined;
+	let listDisabled = undefined;
+
+	if (isInBindingMode.value) {
+		listDisabled = "The value is binded to the state";
+	} else if (mode.value === "freehand" && !isValid.value) {
+		listDisabled = "The JSON is not valid";
+	}
 
 	return [
 		{ label: "List", value: "assisted", disabled: listDisabled },


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/ffc71341-df28-4979-ab2e-6fb728362cd9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for binding expressions as input values in the key-value editor modal.
  - The editor now detects when a value is bound and updates the interface accordingly, including disabling the "List" tab with a relevant message.

- **Bug Fixes**
  - Improved validation and value handling to ensure correct behavior when using binding expressions.

- **User Experience**
  - Enhanced feedback and control flow when editing values that are bound to external state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->