### PR TITLE
fix(ui): use correct icons for JSON viewer - WF-458

### DIFF
--- a/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewerCollapsible.vue
+++ b/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewerCollapsible.vue
@@ -2,7 +2,7 @@
 	<SharedCollapsible
 		:open="open"
 		:disabled="disabled"
-		:icons="{ open: 'keyboard_arrow_right', close: 'keyboard_arrow_down' }"
+		:icons="{ close: 'keyboard_arrow_right', open: 'keyboard_arrow_down' }"
 		@toggle="$emit('toggle', $event)"
 	>
 		<template #title>

--- a/src/ui/src/components/shared/SharedJsonViewer/__snapshots__/SharedJsonViewer.spec.ts.snap
+++ b/src/ui/src/components/shared/SharedJsonViewer/__snapshots__/SharedJsonViewer.spec.ts.snap
@@ -20,7 +20,7 @@ exports[`SharedJsonViewer > should render a nested object 1`] = `
         class="SharedCollapsible__summary__icon material-symbols-outlined"
         data-v-55c4d015=""
       >
-        keyboard_arrow_down
+        keyboard_arrow_right
       </span>
       
       <div
@@ -71,7 +71,7 @@ exports[`SharedJsonViewer > should render a nested object 1`] = `
                 class="SharedCollapsible__summary__icon material-symbols-outlined"
                 data-v-55c4d015=""
               >
-                keyboard_arrow_down
+                keyboard_arrow_right
               </span>
               
               <div
@@ -128,7 +128,7 @@ exports[`SharedJsonViewer > should render a nested object 1`] = `
                 class="SharedCollapsible__summary__icon material-symbols-outlined"
                 data-v-55c4d015=""
               >
-                keyboard_arrow_down
+                keyboard_arrow_right
               </span>
               
               <div
@@ -199,7 +199,7 @@ exports[`SharedJsonViewer > should render an array 1`] = `
         class="SharedCollapsible__summary__icon material-symbols-outlined"
         data-v-55c4d015=""
       >
-        keyboard_arrow_down
+        keyboard_arrow_right
       </span>
       
       <div


### PR DESCRIPTION
The icons for showing an expanded/collapsed version of nested state elements in state explorer are backwards. The `>` shows when it’s expanded instead of when it’s collapsed, and `V` shows when it’s collapsed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the display of icons for expanding and collapsing sections in the JSON viewer to better match their expected states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->