### PR TITLE
fix(ui): avoid rendering vault vars - WF-428

### DIFF
--- a/src/ui/src/renderer/useEvaluator.ts
+++ b/src/ui/src/renderer/useEvaluator.ts
@@ -79,6 +79,10 @@ export function useEvaluator(wf: Core, secretsManager?: SecretsManager) {
 		};
 		const accessors = parseExpression(expr, instancePath);
 
+		const isSecrets = accessors[0] === "vault";
+
+		if (isSecrets) return `@{${expr}}`;
+
 		for (let i = 0; i < accessors.length; i++) {
 			contextRef = contextRef?.[accessors[i]];
 			stateRef = stateRef?.[accessors[i]];

--- a/src/ui/src/renderer/useEvaluator.ts
+++ b/src/ui/src/renderer/useEvaluator.ts
@@ -81,7 +81,7 @@ export function useEvaluator(wf: Core, secretsManager?: SecretsManager) {
 
 		const isSecrets = accessors[0] === "vault";
 
-		if (isSecrets) return `@{${expr}}`;
+		if (isSecrets) return `********`;
 
 		for (let i = 0; i < accessors.length; i++) {
 			contextRef = contextRef?.[accessors[i]];


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9aa53a89-09fb-402d-8320-02657a21b6cf)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Expressions starting with "vault" now display as masked with asterisks for enhanced security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->