### PR TITLE
fix: error on non-alpha categories

### DIFF
--- a/src/writer/blocks/writerclassification.py
+++ b/src/writer/blocks/writerclassification.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from writer.abstract import register_abstract_template
 from writer.blocks.base_block import WriterBlock
@@ -27,7 +28,7 @@ class WriterClassification(WriterBlock):
                             "name": "Categories",
                             "type": "Key-Value",
                             "default": "{}",
-                            "desc": "The keys should be the categories you want to classify the text in, for example 'valid' and 'invalid', and the values the criteria for each category.",
+                            "desc": "The keys should be the categories you want to classify the text in, for example 'valid' and 'invalid', and the values the criteria for each category. Category names should contain only letters of the English alphabet, digits and underscores.",
                         },
                         "additionalContext": {
                             "name": "Additional context",
@@ -55,6 +56,11 @@ class WriterClassification(WriterBlock):
             text = self._get_field("text", required=True)
             additional_context = self._get_field("additionalContext")
             categories = self._get_field("categories", as_json=True, required=True)
+
+            invalid_categories = [category for category in categories if not re.fullmatch(r"\w+", category, flags=re.ASCII)]
+            if invalid_categories:
+                self.outcome = "error"
+                raise ValueError(f"Category names should contain only letters of the English alphabet, digits and underscores. Invalid categories: {', '.join(invalid_categories)}")
 
             config = {}
 

--- a/tests/backend/blocks/test_writerclassification.py
+++ b/tests/backend/blocks/test_writerclassification.py
@@ -29,6 +29,22 @@ def test_classify(monkeypatch, session, runner, fake_client):
     assert block.outcome == "category_dog"
 
 
+def test_classify_invalid_category(monkeypatch, session, runner, fake_client):
+    monkeypatch.setattr("writer.ai.complete", fake_complete)
+    categories = json.dumps(
+        {
+            "apple": "is an apple",
+            "banana": "is a banana",
+            "other!": "is another fruit"
+        }
+    )
+    component = session.add_fake_component({"text": "fruits", "categories": categories})
+    block = WriterClassification(component, runner, {})
+
+    with pytest.raises(ValueError):
+        block.run()
+
+
 def test_classify_missing_categories(monkeypatch, session, runner, fake_client):
     monkeypatch.setattr("writer.ai.complete", fake_complete)
     component = session.add_fake_component({"text": "canine", "categories": json.dumps({})})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for category names to ensure they contain only English letters, digits, and underscores. Invalid category names will now trigger an error.
- **Tests**
	- Added a new test to confirm that invalid category names are correctly detected and result in an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->