### PR TITLE
feat: add version beta label - WF-505

### DIFF
--- a/src/ui/src/builder/sidebar/BuilderSidebar.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebar.vue
@@ -101,6 +101,7 @@
 </template>
 
 <script setup lang="ts">
+/* global FRAMEWORK_VERSION */
 import BuilderAsyncLoader from "../BuilderAsyncLoader.vue";
 import BuilderSidebarButton from "./BuilderSidebarButton.vue";
 import BuilderSidebarVersion from "./BuilderSidebarVersion.vue";

--- a/src/ui/src/builder/sidebar/BuilderSidebar.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebar.vue
@@ -50,8 +50,8 @@
 			</div>
 			<div class="BuilderSidebar__toolbar__bottom">
 				<BuilderSidebarVersion
-					v-if="framework_version"
-					:version="framework_version"
+					v-if="frameworkVersion"
+					:version="frameworkVersion"
 				/>
 				<hr />
 				<BuilderSidebarButton
@@ -101,7 +101,7 @@
 </template>
 
 <script setup lang="ts">
-/* global FRAMEWORK_VERSION */
+/* global WRITER_FRAMEWORK_VERSION */
 import BuilderAsyncLoader from "../BuilderAsyncLoader.vue";
 import BuilderSidebarButton from "./BuilderSidebarButton.vue";
 import BuilderSidebarVersion from "./BuilderSidebarVersion.vue";
@@ -148,7 +148,7 @@ const undoRedoSnapshot = computed(() => getUndoRedoSnapshot());
 const { undo, redo, getUndoRedoSnapshot } = useComponentActions(wf, wfbm);
 
 const isPreview = computed(() => wfbm.mode.value === "preview");
-const framework_version = FRAMEWORK_VERSION;
+const frameworkVersion = WRITER_FRAMEWORK_VERSION;
 
 const activePaneLocalStorage = useLocalStorageJSON<Pane>("activePane", isPane);
 

--- a/src/ui/src/builder/sidebar/BuilderSidebar.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebar.vue
@@ -49,6 +49,10 @@
 				/>
 			</div>
 			<div class="BuilderSidebar__toolbar__bottom">
+				<BuilderSidebarVersion
+					v-if="framework_version"
+					:version="framework_version"
+				/>
 				<hr />
 				<BuilderSidebarButton
 					target="_blank"
@@ -99,6 +103,7 @@
 <script setup lang="ts">
 import BuilderAsyncLoader from "../BuilderAsyncLoader.vue";
 import BuilderSidebarButton from "./BuilderSidebarButton.vue";
+import BuilderSidebarVersion from "./BuilderSidebarVersion.vue";
 import {
 	computed,
 	defineAsyncComponent,
@@ -142,6 +147,7 @@ const undoRedoSnapshot = computed(() => getUndoRedoSnapshot());
 const { undo, redo, getUndoRedoSnapshot } = useComponentActions(wf, wfbm);
 
 const isPreview = computed(() => wfbm.mode.value === "preview");
+const framework_version = FRAMEWORK_VERSION;
 
 const activePaneLocalStorage = useLocalStorageJSON<Pane>("activePane", isPane);
 

--- a/src/ui/src/builder/sidebar/BuilderSidebarVersion.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarVersion.vue
@@ -25,7 +25,6 @@ defineProps({
 	background: var(--wdsColorGray6);
 	white-space: nowrap;
 	font-size: 13px;
-	font-family: Poppins, sans-serif;
 	transform: rotate(-90deg);
 	border-radius: 4px;
 	padding: 1px 8px;

--- a/src/ui/src/builder/sidebar/BuilderSidebarVersion.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarVersion.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+defineProps({
+	version: { type: String, required: true },
+});
+</script>
+
+<template>
+	<span class="BuilderSidebarVersion">
+		<span class="BuilderSidebarVersion__capsule">
+			BETA {{ version }}
+		</span>
+	</span>
+</template>
+
+<style lang="css" scoped>
+.BuilderSidebarVersion{
+	background-color: transparent;
+	color: var(--wdsColorWhite);
+	margin: 0 auto;
+	height: 64px;
+	width: 32px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+.BuilderSidebarVersion__capsule {
+	background: var(--wdsColorGray6);
+	white-space: nowrap;
+	font-size: 13px;
+	font: Poppins, sans-serif;
+	transform: rotate(-90deg);
+	border-radius: 4px;
+	padding: 1px 8px;
+	gap: 8px;
+
+}
+</style>

--- a/src/ui/src/builder/sidebar/BuilderSidebarVersion.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarVersion.vue
@@ -6,14 +6,12 @@ defineProps({
 
 <template>
 	<span class="BuilderSidebarVersion">
-		<span class="BuilderSidebarVersion__capsule">
-			BETA {{ version }}
-		</span>
+		<span class="BuilderSidebarVersion__capsule"> BETA {{ version }} </span>
 	</span>
 </template>
 
 <style lang="css" scoped>
-.BuilderSidebarVersion{
+.BuilderSidebarVersion {
 	background-color: transparent;
 	color: var(--wdsColorWhite);
 	margin: 0 auto;
@@ -32,6 +30,5 @@ defineProps({
 	border-radius: 4px;
 	padding: 1px 8px;
 	gap: 8px;
-
 }
 </style>

--- a/src/ui/src/builder/sidebar/BuilderSidebarVersion.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarVersion.vue
@@ -25,7 +25,7 @@ defineProps({
 	background: var(--wdsColorGray6);
 	white-space: nowrap;
 	font-size: 13px;
-	font: Poppins, sans-serif;
+	font-family: Poppins, sans-serif;
 	transform: rotate(-90deg);
 	border-radius: 4px;
 	padding: 1px 8px;

--- a/src/ui/vite-env.d.ts
+++ b/src/ui/vite-env.d.ts
@@ -1,2 +1,2 @@
 declare const WRITER_LIVE_CCT: string;
-declare const FRAMEWORK_VERSION: string;
+declare const WRITER_FRAMEWORK_VERSION: string;

--- a/src/ui/vite-env.d.ts
+++ b/src/ui/vite-env.d.ts
@@ -1,1 +1,2 @@
 declare const WRITER_LIVE_CCT: string;
+declare const FRAMEWORK_VERSION: string;

--- a/src/ui/vite.config.custom.ts
+++ b/src/ui/vite.config.custom.ts
@@ -10,6 +10,7 @@ export default defineConfig({
 	includeWriterComponentPath: false,
 	define: {
 		WRITER_LIVE_CCT: JSON.stringify("yes"),
+		FRAMEWORK_VERSION: JSON.stringify(process.env.FRAMEWORK_VERSION || ""),
 	},
 	publicDir: false,
 	build: {

--- a/src/ui/vite.config.custom.ts
+++ b/src/ui/vite.config.custom.ts
@@ -10,7 +10,7 @@ export default defineConfig({
 	includeWriterComponentPath: false,
 	define: {
 		WRITER_LIVE_CCT: JSON.stringify("yes"),
-		FRAMEWORK_VERSION: JSON.stringify(process.env.FRAMEWORK_VERSION || ""),
+		WRITER_FRAMEWORK_VERSION: JSON.stringify(process.env.WRITER_FRAMEWORK_VERSION || ""),
 	},
 	publicDir: false,
 	build: {

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
 	includeWriterComponentPath: false,
 	define: {
 		WRITER_LIVE_CCT: JSON.stringify("no"),
+		FRAMEWORK_VERSION: JSON.stringify(process.env.FRAMEWORK_VERSION || ""),
 	},
 	css: {
 		postcss: {

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 	includeWriterComponentPath: false,
 	define: {
 		WRITER_LIVE_CCT: JSON.stringify("no"),
-		FRAMEWORK_VERSION: JSON.stringify(process.env.FRAMEWORK_VERSION || ""),
+		WRITER_FRAMEWORK_VERSION: JSON.stringify(process.env.WRITER_FRAMEWORK_VERSION || ""),
 	},
 	css: {
 		postcss: {


### PR DESCRIPTION
<img width="470" alt="Screenshot 2025-06-10 at 15 49 59" src="https://github.com/user-attachments/assets/37bf5686-5f8d-49dc-98e1-888542cfdbfa" />

`FRAMEWORK_VERSION` environment variable needs to be present during frontend build, otherwise this won't show.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a version label displaying the current framework version in the sidebar toolbar when available.
  - Introduced a visually distinct "BETA" badge with the version number for improved visibility.

- **Chores**
  - Exposed the framework version as a global constant for use in the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->