### PR TITLE
feat: Vault secrets cannot be revealed from UI

### DIFF
--- a/src/ui/src/builder/BuilderVault.vue
+++ b/src/ui/src/builder/BuilderVault.vue
@@ -115,6 +115,7 @@ onMounted(async () => {
 							placeholder="Type a value..."
 							:model-value="entry.value"
 							:readonly="readonly"
+							:revealable="false"
 							@update:model-value="
 								updateAssistedEntryValue(id, $event)
 							"

--- a/src/ui/src/wds/WdsPasswordInput.vue
+++ b/src/ui/src/wds/WdsPasswordInput.vue
@@ -3,11 +3,11 @@
 		v-model="model"
 		class="WdsPasswordInput"
 		:type="type"
-		:right-icon="rightIcon"
+		:right-icon="revealable ? rightIcon : undefined"
 		:autofocus="autofocus"
 		:invalid="invalid"
 		:variant="variant"
-		@right-icon-click="isShown = !isShown"
+		@right-icon-click="revealable ? (isShown = !isShown) : undefined"
 	/>
 </template>
 
@@ -19,6 +19,7 @@ const model = defineModel({ type: String });
 
 defineProps({
 	invalid: { type: Boolean, required: false },
+	revealable: { type: Boolean, default: true, required: false },
 	variant: { type: String as PropType<"ghost">, default: undefined },
 	rightText: { type: String, required: false, default: "" },
 	autofocus: { type: Boolean },


### PR DESCRIPTION
This PR adds the option of non-revealable WDS password inputs. This prevents the user from easily disclosing passwords in the UI. It does not however make it impossible for advanced users to get stored secrets (as secrets are fetched by the frontend and also available in the backend, if the right permissions are in place). Therefore, this PR should be considered strictly for aesthetic/usability purposes and not a security one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to disable the "show password" option in password input fields.

- **Bug Fixes**
  - Password fields in the key-value pairs editor now prevent revealing their contents for enhanced privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->