### PR TITLE
feat: Invite collaborators popup

### DIFF
--- a/src/ui/src/builder/BuilderHeader.vue
+++ b/src/ui/src/builder/BuilderHeader.vue
@@ -32,6 +32,15 @@
 				<i class="material-symbols-outlined">code</i>
 			</WdsButton>
 			<WdsButton
+				variant="secondary"
+				size="smallIcon"
+				data-writer-tooltip="Invite collaborators"
+				data-writer-tooltip-placement="bottom"
+				@click="showInviteCollaborators"
+			>
+				<i class="material-symbols-outlined">share</i>
+			</WdsButton>
+			<WdsButton
 				v-if="canDeploy"
 				size="small"
 				:loading="isDeploying"
@@ -67,6 +76,25 @@
 			>
 				<BuilderStateExplorer />
 			</WdsModal>
+			<WdsModal
+				v-if="isInviteCollaboratorsShown"
+				title="Share edit link with collaborators"
+				description="All AI Studio builders in your org can edit this agent. Copy the link below to point them directly to editing this agent."
+				display-close-button
+				:actions="[
+					{
+						desc: 'Close',
+						fn: () => (isInviteCollaboratorsShown = false),
+					},
+					{
+						desc: 'Copy edit link',
+						fn: () => copyInviteCollaboratorsURL(),
+						icon: 'content_copy',
+					},
+				]"
+				@close="isInviteCollaboratorsShown = false"
+			>
+			</WdsModal>
 		</div>
 	</div>
 </template>
@@ -86,6 +114,7 @@ import BuilderHeaderConnected from "./BuilderHeaderConnected.vue";
 const wf = inject(injectionKeys.core);
 
 const isStateExplorerShown = ref(false);
+const isInviteCollaboratorsShown = ref(false);
 
 const tracking = useWriterTracking(wf);
 
@@ -178,6 +207,17 @@ const stateDotState = computed<WdsStateDotState>(() => {
 function showStateExplorer() {
 	tracking.track("nav_state_explorer_opened");
 	isStateExplorerShown.value = true;
+}
+
+function showInviteCollaborators() {
+	isInviteCollaboratorsShown.value = true;
+}
+
+function copyInviteCollaboratorsURL() {
+	const url = location.href;
+	navigator.clipboard.writeText(url).catch((err) => {
+		console.error("Failed to copy url to clipboard: ", err);
+	});
 }
 </script>
 

--- a/src/ui/src/builder/BuilderHeader.vue
+++ b/src/ui/src/builder/BuilderHeader.vue
@@ -108,6 +108,7 @@ import BuilderStateExplorer from "./BuilderStateExplorer.vue";
 import WdsStateDot, { WdsStateDotState } from "@/wds/WdsStateDot.vue";
 import { useWriterAppDeployment } from "./useWriterAppDeployment";
 import WdsButton from "@/wds/WdsButton.vue";
+import { useToasts } from "./useToast";
 import { useWriterTracking } from "@/composables/useWriterTracking";
 import BuilderHeaderConnected from "./BuilderHeaderConnected.vue";
 
@@ -117,6 +118,7 @@ const isStateExplorerShown = ref(false);
 const isInviteCollaboratorsShown = ref(false);
 
 const tracking = useWriterTracking(wf);
+const toasts = useToasts();
 
 const {
 	canDeploy,
@@ -213,11 +215,28 @@ function showInviteCollaborators() {
 	isInviteCollaboratorsShown.value = true;
 }
 
-function copyInviteCollaboratorsURL() {
+async function copyInviteCollaboratorsURL() {
 	const url = location.href;
-	navigator.clipboard.writeText(url).catch((err) => {
-		console.error("Failed to copy url to clipboard: ", err);
-	});
+	try {
+		if (navigator.clipboard?.writeText) {
+			await navigator.clipboard.writeText(url);
+		} else {
+			const tmp = document.createElement("textarea");
+			tmp.value = url;
+			tmp.style.position = "fixed";
+			tmp.style.opacity = "0";
+			document.body.appendChild(tmp);
+			tmp.select();
+			document.execCommand("copy");
+			document.body.removeChild(tmp);
+		}
+		toasts.pushToast({
+			type: "success",
+			message: "Edit link copied to clipboard.",
+		});
+	} catch {
+		toasts.pushToast({ type: "error", message: "Could not copy link." });
+	}
 }
 </script>
 

--- a/src/ui/src/wds/WdsModal.vue
+++ b/src/ui/src/wds/WdsModal.vue
@@ -51,6 +51,11 @@
 							:disabled="action.disabled"
 							@click="action.fn"
 						>
+							<i
+								v-if="action.icon"
+								class="material-symbols-outlined"
+								>{{ action.icon }}</i
+							>
 							{{ action.desc }}
 						</WdsButton>
 					</div>
@@ -67,8 +72,8 @@ import { PropType, toRefs } from "vue";
 export type ModalAction = {
 	desc: string;
 	fn: (..._args: unknown[]) => unknown;
-
 	disabled?: boolean;
+	icon?: string;
 };
 
 const props = defineProps({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an "Invite collaborators" button to the builder header, enabling users to share an edit link with others via a modal dialog.
  - The invite modal allows copying the edit link to the clipboard and provides clear collaboration details.

- **Enhancements**
  - Modal action buttons now support icons for improved visual clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->