### PR TITLE
chore: Enable jobs API by default

### DIFF
--- a/src/writer/command_line.py
+++ b/src/writer/command_line.py
@@ -21,9 +21,13 @@ def main():
 @main.command()
 @click.option('--host', default="127.0.0.1", help="Host to run the app on")
 @click.option('--port', default=None, help="Port to run the app on")
-@click.option("--enable-jobs-api", help="Set this flag to enable the Jobs API, allowing you to execute jobs without user interaction.", is_flag=True)
+@click.option(
+    "--disable-jobs-api",
+    help="Disable the Jobs API, preventing job execution without user interaction.",
+    is_flag=True,
+)
 @click.argument('path')
-def run(path: str, host: str, port: Optional[int], enable_jobs_api: bool):
+def run(path: str, host: str, port: Optional[int], disable_jobs_api: bool):
     """Run the app from PATH folder in run mode."""
 
     abs_path = os.path.abspath(path)
@@ -36,7 +40,13 @@ def run(path: str, host: str, port: Optional[int], enable_jobs_api: bool):
         raise click.ClickException(f"There's no Writer Framework project at this location : {abs_path}")
 
     writer.serve.serve(
-        abs_path, mode="run", port=port, host=host, enable_server_setup=True, enable_jobs_api=enable_jobs_api)
+        abs_path,
+        mode="run",
+        port=port,
+        host=host,
+        enable_server_setup=True,
+        enable_jobs_api=not disable_jobs_api,
+    )
 
 @main.command()
 @click.option('--host', default="127.0.0.1", help="Host to run the app on")
@@ -47,7 +57,11 @@ def run(path: str, host: str, port: Optional[int], enable_jobs_api: bool):
 @click.option('--buffer-sync-interval', default=10, type=int, help="Interval in seconds for synchronizing the file buffer.")
 @click.option('--buffer-path', default=None, type=str, help="Path to the file buffer directory. If not provided, a temporary directory will be used.")
 @click.option("--no-interactive", help="Set this flag to run the app without asking anything to the user.", is_flag=True)
-@click.option("--enable-jobs-api", help="Set this flag to enable the Jobs API, allowing you to execute jobs without user interaction.", is_flag=True)
+@click.option(
+    "--disable-jobs-api",
+    help="Disable the Jobs API, preventing job execution without user interaction.",
+    is_flag=True,
+)
 @click.option('--verbose', '-v', is_flag=True, help="Enable verbose output.")
 @click.argument('path')
 def edit(
@@ -60,7 +74,7 @@ def edit(
     buffer_sync_interval: int,
     buffer_path: Optional[str],
     no_interactive: bool,
-    enable_jobs_api: bool,
+    disable_jobs_api: bool,
     verbose: bool = False
 ):
     """Run the app from PATH folder in edit mode."""
@@ -101,8 +115,8 @@ def edit(
     try:
         writer.serve.serve(
             abs_path, mode="edit", port=port, host=host,
-            enable_remote_edit=enable_remote_edit, enable_server_setup=enable_server_setup, 
-            enable_jobs_api=enable_jobs_api)
+            enable_remote_edit=enable_remote_edit, enable_server_setup=enable_server_setup,
+            enable_jobs_api=not disable_jobs_api)
     finally:
         if buffer:
             print("Stopping file buffering...")

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -190,7 +190,7 @@ def get_asgi_app(
     enable_server_setup: bool = True,
     on_load: Optional[Callable] = None,
     on_shutdown: Optional[Callable] = None,
-    enable_jobs_api: bool = False,
+    enable_jobs_api: bool = True,
 ) -> WriterFastAPI:
     """
     Builds an ASGI server that can be injected into another ASGI application
@@ -976,7 +976,7 @@ def serve(
     host,
     enable_remote_edit=False,
     enable_server_setup=False,
-    enable_jobs_api=False,
+    enable_jobs_api=True,
 ):
     """Initialises the web server."""
 


### PR DESCRIPTION
## Summary
- add `--disable-jobs-api` option to `run` and `edit`
- keep Jobs API enabled by default

## Testing
- `python -m py_compile src/writer/command_line.py src/writer/serve.py`
- `pip install -e .` *(fails: Could not find poetry-core)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'writer')*

------
https://chatgpt.com/codex/tasks/task_b_684a71025a4c832cab1f130c2c6e8680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Jobs API feature is now enabled by default in both the run and edit commands. Users can disable it using a new command-line option.
- **Chores**
  - Updated command-line options to use a `--disable-jobs-api` flag instead of `--enable-jobs-api`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->