### PR TITLE
fix: use vault for blueprint handlers

### DIFF
--- a/src/writer/core.py
+++ b/src/writer/core.py
@@ -1206,23 +1206,27 @@ class EventHandlerRegistry:
     # === BLUEPRINT HANLDERS ===
 
     @staticmethod
-    def run_blueprint_by_id(payload: dict, context: dict, session: dict, blueprint_runner: 'BlueprintRunner'):
+    def run_blueprint_by_id(payload: dict, context: dict, session: dict, blueprint_runner: 'BlueprintRunner', vault: Dict):
         blueprint_id = payload.pop("blueprint_id", None)
         if not blueprint_id:
             raise ValueError("Missing blueprint_id in payload")
-        execution_environment = {"payload": payload, "context": context, "session": session}
+        execution_environment = EventHandler._get_blueprint_execution_environment(
+            payload, context, session, vault
+        )
         return blueprint_runner.run_blueprint(component_id=blueprint_id, execution_environment=execution_environment, title="Blueprint execution triggered on demand")
 
     @staticmethod
-    def run_blueprint_by_key(payload: dict, context: dict, session: dict, blueprint_runner: 'BlueprintRunner'):
+    def run_blueprint_by_key(payload: dict, context: dict, session: dict, blueprint_runner: 'BlueprintRunner', vault: Dict):
         blueprint_key = payload.pop("blueprint_key", None)
         if not blueprint_key:
             raise ValueError("Missing blueprint_key in payload")
-        execution_environment = {"payload": payload, "context": context, "session": session}
+        execution_environment = EventHandler._get_blueprint_execution_environment(
+            payload, context, session, vault
+        )
         return blueprint_runner.run_blueprint_by_key(blueprint_key=blueprint_key, execution_environment=execution_environment)
 
     @staticmethod
-    def run_blueprint_via_api(payload: dict, context: dict, session: dict, blueprint_runner: 'BlueprintRunner'):
+    def run_blueprint_via_api(payload: dict, context: dict, session: dict, blueprint_runner: 'BlueprintRunner', vault: Dict):
         """
         This handler is used to run a blueprint via the API.
         It is used by the frontend to run a blueprint when the user clicks on a button.
@@ -1230,49 +1234,31 @@ class EventHandlerRegistry:
         blueprint_key = payload.pop("blueprint_key", None)
         if not blueprint_key:
             raise ValueError("Missing blueprint_key in payload")
-        execution_environment = {"payload": payload, "context": context, "session": session}
+        execution_environment = EventHandler._get_blueprint_execution_environment(
+            payload, context, session, vault
+        )
         return blueprint_runner.run_blueprint_via_api(blueprint_key=blueprint_key, execution_environment=execution_environment)
 
     @staticmethod
-    def run_blueprint_branch(payload: dict, context: dict, session: dict, blueprint_runner: 'BlueprintRunner'):
+    def run_blueprint_branch(payload: dict, context: dict, session: dict, blueprint_runner: 'BlueprintRunner', vault: Dict):
         branch_id = payload.pop("branch_id", None)
         if not branch_id:
             raise ValueError("Missing branch_id in payload")
-        execution_environment = {"payload": payload, "context": context, "session": session}
+        execution_environment = EventHandler._get_blueprint_execution_environment(
+            payload, context, session, vault
+        )
         return blueprint_runner.run_branch(start_node_id=branch_id, branch_out_id=None, execution_environment=execution_environment, title="Branch execution triggered by demand")
 
     def __init__(self):
-        self.handler_map: Dict[str, "EventHandlerRegistry.HandlerEntry"] = \
-            {
-                "run_blueprint_by_key": {
-                   "callable": self.run_blueprint_by_key,
-                   "meta": {
-                        "name": "run_blueprint_by_key",
-                        "args": ["payload", "context", "session", "blueprint_runner"]
-                   }
-                },
-                "run_blueprint_by_id": {
-                    "callable": self.run_blueprint_by_id,
-                    "meta": {
-                        "name": "run_blueprint_by_id",
-                        "args": ["payload", "context", "session", "blueprint_runner"]
-                    }
-                },
-                "run_blueprint_via_api": {
-                    "callable": self.run_blueprint_via_api,
-                    "meta": {
-                        "name": "run_blueprint_via_api",
-                        "args": ["payload", "context", "session", "blueprint_runner"]
-                    }
-                },
-                "run_blueprint_branch": {
-                    "callable": self.run_blueprint_branch,
-                    "meta": {
-                        "name": "run_blueprint_branch",
-                        "args": ["payload", "context", "session", "blueprint_runner"]
-                    }
-                }
-            }
+        self.handler_map: Dict[str, "EventHandlerRegistry.HandlerEntry"] = {}
+        for handler in [
+            self.run_blueprint_by_id,
+            self.run_blueprint_by_key,
+            self.run_blueprint_via_api,
+            self.run_blueprint_branch,
+        ]:
+            # Register built-in blueprint handlers
+            self.register_handler(handler)
 
     def __iter__(self):
         return iter(self.handler_map.keys())
@@ -1709,7 +1695,8 @@ class EventHandler:
             return
         self.evaluator.set_state(binding["stateRef"], instance_path, payload)
 
-    def _get_blueprint_execution_environment(self, payload, context, session, vault):
+    @staticmethod
+    def _get_blueprint_execution_environment(payload, context, session, vault):
         return {
             "payload": payload,
             "context": context,

--- a/src/writer/core.py
+++ b/src/writer/core.py
@@ -1250,15 +1250,36 @@ class EventHandlerRegistry:
         return blueprint_runner.run_branch(start_node_id=branch_id, branch_out_id=None, execution_environment=execution_environment, title="Branch execution triggered by demand")
 
     def __init__(self):
-        self.handler_map: Dict[str, "EventHandlerRegistry.HandlerEntry"] = {}
-        for handler in [
-            self.run_blueprint_by_id,
-            self.run_blueprint_by_key,
-            self.run_blueprint_via_api,
-            self.run_blueprint_branch,
-        ]:
-            # Register built-in blueprint handlers
-            self.register_handler(handler)
+        self.handler_map: Dict[str, "EventHandlerRegistry.HandlerEntry"] = {
+                "run_blueprint_by_key": {
+                   "callable": self.run_blueprint_by_key,
+                   "meta": {
+                        "name": "run_blueprint_by_key",
+                        "args": ["payload", "context", "session", "blueprint_runner", "vault"]
+                   }
+                },
+                "run_blueprint_by_id": {
+                    "callable": self.run_blueprint_by_id,
+                    "meta": {
+                        "name": "run_blueprint_by_id",
+                        "args": ["payload", "context", "session", "blueprint_runner", "vault"]
+                    }
+                },
+                "run_blueprint_via_api": {
+                    "callable": self.run_blueprint_via_api,
+                    "meta": {
+                        "name": "run_blueprint_via_api",
+                        "args": ["payload", "context", "session", "blueprint_runner", "vault"]
+                    }
+                },
+                "run_blueprint_branch": {
+                    "callable": self.run_blueprint_branch,
+                    "meta": {
+                        "name": "run_blueprint_branch",
+                        "args": ["payload", "context", "session", "blueprint_runner", "vault"]
+                    }
+                }
+            }
 
     def __iter__(self):
         return iter(self.handler_map.keys())


### PR DESCRIPTION
Refactor to enable blueprint handlers to use vault; use `register_handler` function instead of manual map population.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved consistency in how execution environments are created for blueprint-related operations.
	- Enhanced flexibility in handler registration for blueprint events.
- **Chores**
	- Updated internal methods to accept an additional parameter for improved extensibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->