### PR TITLE
fix: drag into editor snaps node

### DIFF
--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -657,8 +657,8 @@ function moveNode(ev: MouseEvent) {
 	const { nodeId, offset } = activeNodeMove.value;
 	const { x, y } = getAdjustedCoordinates(ev);
 
-	const newX = Math.floor(x - offset.x);
-	const newY = Math.floor(y - offset.y);
+	const newX = Math.max(Math.floor(x - offset.x), 0);
+	const newY = Math.max(Math.floor(y - offset.y), 0);
 
 	const component = wf.getComponentById(nodeId);
 
@@ -757,21 +757,21 @@ async function handleMouseup(ev: MouseEvent) {
 	if (activeNodeMove.value) {
 		saveNodeMove();
 	}
-	if (activeConnection.value === null) {
+	const connectionValue = activeConnection.value;
+	clearActiveOperations();
+	if (connectionValue === null) {
 		return;
 	}
 	const hoveredId = getHoveredNodeId(ev);
 	if (!hoveredId) {
-		activeConnection.value = null;
 		return;
 	}
-	const { fromNodeId, fromOutId } = activeConnection.value;
+	const { fromNodeId, fromOutId } = connectionValue;
 	if (fromNodeId == hoveredId) {
-		activeConnection.value = null;
 		return;
 	}
 
-	addOut(activeConnection.value.fromNodeId, {
+	addOut(connectionValue.fromNodeId, {
 		toNodeId: hoveredId,
 		outId: fromOutId,
 	});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved node movement to prevent nodes from being positioned outside the visible area.
	- Enhanced reliability of clearing active operations when moving or connecting nodes, ensuring smoother interaction during drag-and-drop actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->