### PR TITLE
chore: API cleanup

### DIFF
--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -15,7 +15,7 @@ import writer.blocks
 import writer.blocks.base_block
 import writer.core
 import writer.core_ui
-from writer.ss_types import BlueprintExecutionLog, WriterConfigurationError
+from writer.ss_types import BlueprintExecutionError, BlueprintExecutionLog, WriterConfigurationError
 
 
 class BlueprintRunner:
@@ -453,6 +453,7 @@ class BlueprintRunner:
                             ready.append(to_tool)
             if is_cancelled:
                 update_log("Execution failed.", entry_type="error")
+                raise BlueprintExecutionError("Blueprint execution was cancelled due to an error.")
             else:
                 update_log("Execution completed.")
 

--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -402,6 +402,7 @@ class BlueprintRunner:
 
         with self._get_executor() as executor:
             futures: set[Future] = set()
+            first_exception: Optional[BaseException] = None
             while ready or futures:
                 while ready:
                     tool = ready.popleft()
@@ -414,7 +415,6 @@ class BlueprintRunner:
 
                 update_log("Executing...")
                 done, _ = wait(futures, return_when=FIRST_COMPLETED)
-                first_exception: Optional[BaseException] = None
                 for future in done:
                     futures.remove(future)
                     try:
@@ -455,9 +455,12 @@ class BlueprintRunner:
                             ready.append(to_tool)
             if is_cancelled:
                 update_log("Execution failed.", entry_type="error")
-                raise BlueprintExecutionError(
-                    f"Blueprint execution was cancelled due to an error - {first_exception.__class__.__name__}: {first_exception}"
-                    ) from first_exception
+                if first_exception is not None:
+                    raise BlueprintExecutionError(
+                        f"Blueprint execution was cancelled due to an error - {first_exception.__class__.__name__}: {first_exception}"
+                        ) from first_exception
+                else:
+                    raise BlueprintExecutionError("Blueprint execution was cancelled.")
             else:
                 update_log("Execution completed.")
 

--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -456,7 +456,7 @@ class BlueprintRunner:
             if is_cancelled:
                 update_log("Execution failed.", entry_type="error")
                 raise BlueprintExecutionError(
-                    f"Blueprint execution was cancelled due to an error: {first_exception}"
+                    f"Blueprint execution was cancelled due to an error - {first_exception.__class__.__name__}: {first_exception}"
                     ) from first_exception
             else:
                 update_log("Execution completed.")

--- a/src/writer/command_line.py
+++ b/src/writer/command_line.py
@@ -21,13 +21,8 @@ def main():
 @main.command()
 @click.option('--host', default="127.0.0.1", help="Host to run the app on")
 @click.option('--port', default=None, help="Port to run the app on")
-@click.option(
-    "--disable-jobs-api",
-    help="Disable the Jobs API, preventing job execution without user interaction.",
-    is_flag=True,
-)
 @click.argument('path')
-def run(path: str, host: str, port: Optional[int], disable_jobs_api: bool):
+def run(path: str, host: str, port: Optional[int]):
     """Run the app from PATH folder in run mode."""
 
     abs_path = os.path.abspath(path)
@@ -44,8 +39,7 @@ def run(path: str, host: str, port: Optional[int], disable_jobs_api: bool):
         mode="run",
         port=port,
         host=host,
-        enable_server_setup=True,
-        enable_jobs_api=not disable_jobs_api,
+        enable_server_setup=True
     )
 
 @main.command()
@@ -57,11 +51,6 @@ def run(path: str, host: str, port: Optional[int], disable_jobs_api: bool):
 @click.option('--buffer-sync-interval', default=10, type=int, help="Interval in seconds for synchronizing the file buffer.")
 @click.option('--buffer-path', default=None, type=str, help="Path to the file buffer directory. If not provided, a temporary directory will be used.")
 @click.option("--no-interactive", help="Set this flag to run the app without asking anything to the user.", is_flag=True)
-@click.option(
-    "--disable-jobs-api",
-    help="Disable the Jobs API, preventing job execution without user interaction.",
-    is_flag=True,
-)
 @click.option('--verbose', '-v', is_flag=True, help="Enable verbose output.")
 @click.argument('path')
 def edit(
@@ -74,7 +63,6 @@ def edit(
     buffer_sync_interval: int,
     buffer_path: Optional[str],
     no_interactive: bool,
-    disable_jobs_api: bool,
     verbose: bool = False
 ):
     """Run the app from PATH folder in edit mode."""
@@ -116,7 +104,7 @@ def edit(
         writer.serve.serve(
             abs_path, mode="edit", port=port, host=host,
             enable_remote_edit=enable_remote_edit, enable_server_setup=enable_server_setup,
-            enable_jobs_api=not disable_jobs_api)
+            )
     finally:
         if buffer:
             print("Stopping file buffering...")

--- a/src/writer/core.py
+++ b/src/writer/core.py
@@ -47,6 +47,7 @@ import writer.evaluator
 from writer import core_ui
 from writer.core_ui import Component
 from writer.ss_types import (
+    BlueprintExecutionError,
     BlueprintExecutionLog,
     InstancePath,
     Readable,
@@ -1818,17 +1819,21 @@ class EventHandler:
             calling_arguments = self._get_calling_arguments(ev, instance_path=None)
             return self._call_handler_callable(handler_callable, calling_arguments)
         except BaseException as e:
-            self.session_state.add_notification(
-                "error",
-                "Runtime Error",
-                f"An error occurred when processing event '{ ev.type }'.",
-            )
-            self.session_state.add_log_entry(
-                "error",
-                "Runtime Exception",
-                f"A runtime exception was raised when processing event '{ ev.type }'.",
-                traceback.format_exc(),
-            )
+            if not isinstance(e, BlueprintExecutionError):
+                # Only create a notification and log entry
+                # for non-blueprint errors, as blueprint errors
+                # have their own logging mechanism
+                self.session_state.add_notification(
+                    "error",
+                    "Runtime Error",
+                    f"An error occurred when processing event '{ ev.type }'.",
+                )
+                self.session_state.add_log_entry(
+                    "error",
+                    "Runtime Exception",
+                    f"A runtime exception was raised when processing event '{ ev.type }'.",
+                    traceback.format_exc(),
+                )
             raise e
 
     def _handle_component_event(self, ev: WriterEvent):

--- a/src/writer/ss_types.py
+++ b/src/writer/ss_types.py
@@ -297,5 +297,16 @@ class BlueprintExecutionLog(BaseModel):
     summary: List[Dict]
 
 
+class BlueprintExecutionError(Exception):
+    """Exception raised when a blueprint execution fails."""
+    def __init__(
+            self,
+            message: Optional[str] = "An error occurred "
+                                     "during blueprint execution."
+    ):
+        super().__init__(message)
+        self.message = message
+
+
 class WriterConfigurationError(ValueError):
     pass

--- a/tests/backend/test_serve.py
+++ b/tests/backend/test_serve.py
@@ -239,12 +239,12 @@ class TestServe:
             assert feature_flags == ["blueprints", "flag_one", "flag_two", "api_trigger"]
 
     def test_create_blueprint_job_api(self, monkeypatch):
-        asgi_app = writer.serve.get_asgi_app(test_app_dir, "run", enable_jobs_api=True)
+        asgi_app = writer.serve.get_asgi_app(test_app_dir, "run")
         monkeypatch.setenv("WRITER_SECRET_KEY", "abc")
         blueprint_key = "blueprint2"
 
         with fastapi.testclient.TestClient(asgi_app) as client:
-            with client.stream("POST", f"/private/api/job/blueprint/{blueprint_key}",
+            with client.stream("POST", f"/private/api/blueprint/{blueprint_key}",
                                 json={"proposedSessionId": None},
                                 headers={"Content-Type": "application/json"}) as response:
 
@@ -268,12 +268,12 @@ class TestServe:
                     assert final_payload.get("artifact") == "987127"
 
     def test_create_blueprint_job_api_error_handling(self, monkeypatch):
-        asgi_app = writer.serve.get_asgi_app(test_app_dir, "run", enable_jobs_api=True)
+        asgi_app = writer.serve.get_asgi_app(test_app_dir, "run")
         monkeypatch.setenv("WRITER_SECRET_KEY", "abc")
 
         with fastapi.testclient.TestClient(asgi_app) as client:
             with client.stream(
-                "POST", "/private/api/job/blueprint/nonexistent",
+                "POST", "/private/api/blueprint/nonexistent",
                 json={"proposedSessionId": None},
                 headers={"Content-Type": "application/json"}
             ) as response:
@@ -288,25 +288,14 @@ class TestServe:
                 assert "msg" in final_payload
                 assert "not found" in final_payload["msg"].lower()
 
-    def test_create_blueprint_job_api_disabled(self, monkeypatch):
-        asgi_app = writer.serve.get_asgi_app(test_app_dir, "run", enable_jobs_api=False)
-        monkeypatch.setenv("WRITER_SECRET_KEY", "abc")
-        blueprint_key = "blueprint2"
-
-        with fastapi.testclient.TestClient(asgi_app) as client:
-            res = client.post(f"/private/api/job/blueprint/{blueprint_key}",
-                            json={"proposedSessionId": None},
-                            headers={"Content-Type": "application/json"})
-            assert res.status_code == 404
-
     def test_create_blueprint_job_api_streaming_events(self, monkeypatch):
-        asgi_app = writer.serve.get_asgi_app(test_app_dir, "run", enable_jobs_api=True)
+        asgi_app = writer.serve.get_asgi_app(test_app_dir, "run")
         monkeypatch.setenv("WRITER_SECRET_KEY", "abc")
         blueprint_key = "blueprint2"
 
         with fastapi.testclient.TestClient(asgi_app) as client:
             with client.stream(
-                "POST", f"/private/api/job/blueprint/{blueprint_key}",
+                "POST", f"/private/api/blueprint/{blueprint_key}",
                 json={"proposedSessionId": None},
                 headers={"Content-Type": "application/json"}
             ) as response:


### PR DESCRIPTION
- Fixed keep-alive events during streaming
- Implemented frontend-friendly way to signal blueprint execution errors to API
- Removed API CLI flag
- Removed `JobVault` & `RedisJobVault`
- "Job" naming cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved error reporting for blueprint execution failures with clearer error messages.

- **Bug Fixes**
  - Enhanced handling of blueprint execution errors to prevent duplicate notifications and logs.

- **Refactor**
  - Removed the Jobs API disabling option and related command-line flag.
  - Simplified event streaming and blueprint job execution logic.
  - Changed the blueprint job API endpoint path for consistency.
  - Removed persistent job vault support and related infrastructure.

- **Tests**
  - Updated tests to match new API endpoint paths and removed tests for the deprecated Jobs API disabling feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->