### PR TITLE
feat(ui): persist current page for Blueprints and UI - WF-543

### DIFF
--- a/src/ui/src/builder/builderManager.ts
+++ b/src/ui/src/builder/builderManager.ts
@@ -84,9 +84,17 @@ type State = {
 	logEntries: LogEntry[];
 };
 
+function isBuilderManagerMode(v: unknown): v is BuilderManagerMode {
+	return (
+		typeof v === "string" &&
+		["ui", "blueprints", "preview", "vault"].includes(v)
+	);
+}
+
 export function generateBuilderManager() {
-	const modeCache = useLocalStorageJSON<State["mode"]>(
+	const modeCache = useLocalStorageJSON<BuilderManagerMode>(
 		"generateBuilderManager__mode",
+		isBuilderManagerMode,
 	);
 	const initState: State = {
 		mode: modeCache.value ?? "ui",

--- a/src/ui/src/builder/builderManager.ts
+++ b/src/ui/src/builder/builderManager.ts
@@ -74,6 +74,13 @@ export const enum SelectionStatus {
 
 export type BuilderManagerMode = "ui" | "blueprints" | "preview" | "vault";
 
+const BUILDER_MANAGER_MODES = new Set<BuilderManagerMode>([
+	"ui",
+	"blueprints",
+	"preview",
+	"vault",
+]);
+
 type State = {
 	mode: BuilderManagerMode;
 	selection: Selection;
@@ -87,7 +94,7 @@ type State = {
 function isBuilderManagerMode(v: unknown): v is BuilderManagerMode {
 	return (
 		typeof v === "string" &&
-		["ui", "blueprints", "preview", "vault"].includes(v)
+		BUILDER_MANAGER_MODES.has(v as BuilderManagerMode)
 	);
 }
 

--- a/src/ui/src/builder/settings/BuilderSettingsProperties.spec.ts
+++ b/src/ui/src/builder/settings/BuilderSettingsProperties.spec.ts
@@ -12,6 +12,7 @@ import { generateBuilderManager } from "../builderManager";
 import { flattenInstancePath } from "@/renderer/instancePath";
 import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
 import templateMap from "@/core/templateMap";
+import { useSecretsManager } from "@/core/useSecretsManager";
 
 describe("BuilderSettingsProperties", () => {
 	it.each(Object.keys(templateMap))(
@@ -34,6 +35,8 @@ describe("BuilderSettingsProperties", () => {
 						...mockProvides,
 						[injectionKeys.builderManager as symbol]: ssbm,
 						[injectionKeys.core as symbol]: core,
+						[injectionKeys.secretsManager as symbol]:
+							useSecretsManager(core),
 					},
 				},
 			});

--- a/src/ui/src/composables/useLocalStorageJSON.ts
+++ b/src/ui/src/composables/useLocalStorageJSON.ts
@@ -10,7 +10,16 @@ export function useLocalStorageJSON<T>(
 ) {
 	const actualValue = shallowRef<T | undefined>(get());
 
+	function hasLocalStorage() {
+		return (
+			typeof window !== "undefined" &&
+			typeof window.localStorage !== "undefined"
+		);
+	}
+
 	function get() {
+		if (!hasLocalStorage()) return undefined;
+
 		const value = localStorage.getItem(key);
 		if (!value) return undefined;
 
@@ -33,6 +42,7 @@ export function useLocalStorageJSON<T>(
 		},
 		set(value) {
 			actualValue.value = value;
+			if (!hasLocalStorage()) return;
 			value === undefined
 				? localStorage.removeItem(key)
 				: localStorage.setItem(key, JSON.stringify(value));

--- a/src/ui/src/composables/useLocalStorageJSON.ts
+++ b/src/ui/src/composables/useLocalStorageJSON.ts
@@ -2,7 +2,7 @@ import { computed, shallowRef } from "vue";
 
 /**
  * Get/Set the JSON object in localStorage
- * @param validator validate that the data has a given shape, remote the localStorage value if returns `false`
+ * @param validator Validate that the data has a given shape; remove the localStorage value if the validator returns `false`.
  */
 export function useLocalStorageJSON<T>(
 	key: string,

--- a/src/ui/src/composables/useLocalStorageJSON.ts
+++ b/src/ui/src/composables/useLocalStorageJSON.ts
@@ -1,4 +1,4 @@
-import { computed } from "vue";
+import { computed, shallowRef } from "vue";
 
 /**
  * Get/Set the JSON object in localStorage
@@ -8,24 +8,31 @@ export function useLocalStorageJSON<T>(
 	key: string,
 	validator?: (value: T) => boolean,
 ) {
-	return computed<T | undefined>({
-		get() {
-			const value = localStorage.getItem(key);
-			if (!value) return undefined;
+	const actualValue = shallowRef<T | undefined>(get());
 
-			try {
-				const data = JSON.parse(value);
-				if (validator?.(data) === false) {
-					localStorage.removeItem(key);
-					return undefined;
-				}
-				return data;
-			} catch {
+	function get() {
+		const value = localStorage.getItem(key);
+		if (!value) return undefined;
+
+		try {
+			const data = JSON.parse(value);
+			if (validator?.(data) === false) {
 				localStorage.removeItem(key);
 				return undefined;
 			}
+			return data;
+		} catch {
+			localStorage.removeItem(key);
+			return undefined;
+		}
+	}
+
+	return computed<T | undefined>({
+		get() {
+			return actualValue.value;
 		},
 		set(value) {
+			actualValue.value = value;
 			value === undefined
 				? localStorage.removeItem(key)
 				: localStorage.setItem(key, JSON.stringify(value));

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -856,7 +856,7 @@ export function generateCore() {
 		getComponents,
 		getComponentsNested,
 		setActivePageId,
-		activePageId: computed(() => activePageId.value),
+		activePageId: readonly(activePageId),
 		setActivePageFromKey,
 		getComponentDefinition,
 		getSupportedComponentTypes,

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -29,6 +29,7 @@ import {
 	isSourceFilesFile,
 	moveFileToSourceFiles,
 } from "./sourceFiles";
+import { useLocalStorageJSON } from "@/composables/useLocalStorageJSON";
 
 const RECONNECT_DELAY_MS = 1000;
 const KEEP_ALIVE_DELAY_MS = 60000;
@@ -66,7 +67,10 @@ export function generateCore() {
 	let mailSubscriptions: { mailType: string; fn: Function }[] = [];
 	const collaborationPingSubscriptions: { fn: Function }[] = [];
 
-	const activePageId: Ref<Component["id"]> = ref(null);
+	const activePageId = useLocalStorageJSON<Component["id"]>(
+		"generateCore__activePageId",
+		(v) => typeof v === "string",
+	);
 
 	const writerOrgId = computed(
 		() => Number(writerApplication.value?.organizationId) || undefined,
@@ -852,7 +856,7 @@ export function generateCore() {
 		getComponents,
 		getComponentsNested,
 		setActivePageId,
-		activePageId: readonly(activePageId),
+		activePageId: computed(() => activePageId.value),
 		setActivePageFromKey,
 		getComponentDefinition,
 		getSupportedComponentTypes,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The active page selection is now saved between sessions, allowing you to pick up where you left off after reloading or returning to the app.
  - Added validation to ensure saved modes and settings are correctly recognized and applied from local storage.

- **Bug Fixes**
  - Improved reliability when restoring saved modes and settings from local storage.

- **Tests**
  - Enhanced test setup to better support components that rely on secrets management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->