### PR TITLE
feat(ui): Persist current page for Blueprints and UI - WF-543

### DIFF
--- a/src/ui/src/builder/BuilderSwitcher.spec.ts
+++ b/src/ui/src/builder/BuilderSwitcher.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vitest, vi, Mock } from "vitest";
+import { beforeEach, describe, expect, it, vitest, vi } from "vitest";
 import { buildMockComponent, buildMockCore } from "@/tests/mocks";
 import { flushPromises, shallowMount } from "@vue/test-utils";
 import BuilderSwitcher from "./BuilderSwitcher.vue";
@@ -57,6 +57,42 @@ describe("BuilderSwitcher", () => {
 			},
 		});
 	}
+
+	it("should restore the previous page", async () => {
+		mockCore.core.addComponent(
+			buildMockComponent({
+				id: "A",
+			}),
+		);
+		mockCore.core.addComponent(
+			buildMockComponent({
+				id: "B",
+			}),
+		);
+
+		wfbm.mode.value = "ui";
+		mockCore.core.setActivePageId("A");
+
+		const wrapper = mountBuilderSwitcher();
+
+		// navigates to blueprint and change active page
+		await wrapper
+			.get('[data-automation-action="set-mode-blueprints"]')
+			.trigger("click");
+		mockCore.core.setActivePageId("B");
+
+		// navigate back to UI
+		await wrapper
+			.get('[data-automation-action="set-mode-ui"]')
+			.trigger("click");
+		expect(mockCore.core.activePageId.value).toBe("A");
+
+		// navigate back to Blueprints
+		await wrapper
+			.get('[data-automation-action="set-mode-blueprints"]')
+			.trigger("click");
+		expect(mockCore.core.activePageId.value).toBe("B");
+	});
 
 	describe("non-cloud app", () => {
 		beforeEach(() => {

--- a/src/ui/src/builder/BuilderSwitcher.vue
+++ b/src/ui/src/builder/BuilderSwitcher.vue
@@ -54,17 +54,32 @@ import injectionKeys from "@/injectionKeys";
 import { useWriterTracking } from "@/composables/useWriterTracking";
 import { BUILDER_MANAGER_MODE_ICONS } from "@/constants/icons";
 import type { BuilderManagerMode } from "./builderManager";
+import { Component } from "@/writerTypes";
 
 const wf = inject(injectionKeys.core);
-const ssbm = inject(injectionKeys.builderManager);
+const wfbm = inject(injectionKeys.builderManager);
 
 let selectedId: Ref<string> = ref(null);
 
 const tracking = useWriterTracking(wf);
 
-const selectOption = (optionId: BuilderManagerMode) => {
-	const preMode = ssbm.getMode();
+const previousActivePage: Record<"ui" | "blueprints", Component["id"]> = {
+	ui: undefined,
+	blueprints: undefined,
+};
+
+function canHaveActivePage(mode: BuilderManagerMode) {
+	return mode === "blueprints" || mode === "ui";
+}
+
+function selectOption(optionId: BuilderManagerMode) {
+	const preMode = wfbm.mode.value;
 	if (preMode == optionId) return;
+
+	if (canHaveActivePage(preMode) && wf.activePageId.value) {
+		previousActivePage[preMode] = wf.activePageId.value;
+	}
+
 	selectedId.value = optionId;
 	switch (optionId) {
 		case "ui":
@@ -80,17 +95,28 @@ const selectOption = (optionId: BuilderManagerMode) => {
 			tracking.track("nav_vault_opened");
 			break;
 	}
-	ssbm.mode.value = optionId;
+
+	wfbm.mode.value = optionId;
+
+	// restore the previous active page
+	if (
+		canHaveActivePage(optionId) &&
+		previousActivePage[optionId] &&
+		wf.getComponentById(previousActivePage[optionId])
+	) {
+		wf.setActivePageId(previousActivePage[optionId]);
+	}
+
 	if (
 		optionId == "preview" ||
 		preMode == "blueprints" ||
 		optionId == "blueprints"
 	) {
-		ssbm.setSelection(null);
+		wfbm.setSelection(null);
 	}
-};
+}
 
-const activeId = computed(() => ssbm.getMode());
+const activeId = computed(() => wfbm.getMode());
 </script>
 
 <style scoped>

--- a/src/ui/src/builder/BuilderTree.vue
+++ b/src/ui/src/builder/BuilderTree.vue
@@ -99,6 +99,7 @@ const props = defineProps({
 		default: undefined,
 	},
 	disableCollapse: { type: Boolean, required: false },
+	startCollapsed: { type: Boolean, required: false },
 });
 
 const emit = defineEmits({
@@ -113,7 +114,7 @@ const emit = defineEmits({
 
 defineExpose({ expand, toggleCollapse });
 
-const collapsed = ref(false);
+const collapsed = ref(props.startCollapsed);
 const isMainHovered = ref(false);
 
 const notMatched = computed(() => !props.matched);

--- a/src/ui/src/builder/BuilderTree.vue
+++ b/src/ui/src/builder/BuilderTree.vue
@@ -67,7 +67,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineAsyncComponent, PropType, ref } from "vue";
+import {
+	computed,
+	defineAsyncComponent,
+	PropType,
+	ref,
+	toRef,
+	watch,
+} from "vue";
 import WdsButton from "@/wds/WdsButton.vue";
 import type { Option } from "@/components/shared/SharedMoreDropdown.vue";
 import BaseTransitionSlideFade from "@/components/core/base/BaseTransitionSlideFade.vue";
@@ -99,7 +106,6 @@ const props = defineProps({
 		default: undefined,
 	},
 	disableCollapse: { type: Boolean, required: false },
-	startCollapsed: { type: Boolean, required: false },
 });
 
 const emit = defineEmits({
@@ -114,7 +120,12 @@ const emit = defineEmits({
 
 defineExpose({ expand, toggleCollapse });
 
-const collapsed = ref(props.startCollapsed);
+const collapsed = defineModel("collapsed", {
+	type: Boolean,
+	required: false,
+	default: false,
+});
+
 const isMainHovered = ref(false);
 
 const notMatched = computed(() => !props.matched);

--- a/src/ui/src/builder/BuilderTree.vue
+++ b/src/ui/src/builder/BuilderTree.vue
@@ -17,7 +17,7 @@
 			@drop="$emit('drop', $event)"
 		>
 			<WdsButton
-				v-if="hasChildren"
+				v-if="hasChildren && !disableCollapse"
 				class="BuilderTree__main__collapser"
 				variant="neutral"
 				size="icon"
@@ -98,6 +98,7 @@ const props = defineProps({
 		required: false,
 		default: undefined,
 	},
+	disableCollapse: { type: Boolean, required: false },
 });
 
 const emit = defineEmits({

--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
@@ -1,5 +1,6 @@
 <template>
 	<BuilderTree
+		v-if="component"
 		ref="treeBranch"
 		class="BuilderSidebarComponentTreeBranch"
 		:component-id="componentId"

--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
@@ -15,6 +15,7 @@
 		"
 		:disable-collapse="COMPONENT_TYPES_ROOT.has(component.type)"
 		:no-nested-space="COMPONENT_TYPES_ROOT.has(component.type)"
+		:start-collapsed="isOutsideActivePage"
 		@select="select"
 		@dragover="handleDragOver"
 		@dragstart="handleDragStart"
@@ -188,6 +189,18 @@ function handleDrop(ev: DragEvent) {
 
 	removeInsertionCandidacy(ev);
 }
+
+const isOutsideActivePage = computed(
+	() =>
+		COMPONENT_TYPES_PAGE.has(component.value.type) &&
+		props.componentId !== wf.activePageId.value,
+);
+
+watch(wf.activePageId, () => {
+	if (isOutsideActivePage.value) {
+		treeBranch.value?.toggleCollapse(true);
+	}
+});
 
 watch(
 	wfbm.firstSelectedItem,

--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
@@ -16,7 +16,7 @@
 		"
 		:disable-collapse="COMPONENT_TYPES_ROOT.has(component.type)"
 		:no-nested-space="COMPONENT_TYPES_ROOT.has(component.type)"
-		:start-collapsed="isOutsideActivePage"
+		:collapsed="isOutsideActivePage"
 		@select="select"
 		@dragover="handleDragOver"
 		@dragstart="handleDragStart"
@@ -191,14 +191,25 @@ function handleDrop(ev: DragEvent) {
 	removeInsertionCandidacy(ev);
 }
 
-const isOutsideActivePage = computed(
-	() =>
-		COMPONENT_TYPES_PAGE.has(component.value.type) &&
-		props.componentId !== wf.activePageId.value,
-);
+const isOutsideActivePage = computed(() => {
+	if (!wf.activePageId.value) return false;
+
+	// activate page can be relative to UI or Blueprint
+	const isActivePageMatchingMode = wf
+		.getComponents(wfbm.activeRootId.value)
+		.some((c) => c.id === wf.activePageId.value);
+
+	const isPage = COMPONENT_TYPES_PAGE.has(component.value.type);
+
+	return (
+		isPage &&
+		isActivePageMatchingMode &&
+		props.componentId !== wf.activePageId.value
+	);
+});
 
 watch(wf.activePageId, () => {
-	if (isOutsideActivePage.value) {
+	if (wf.activePageId.value && isOutsideActivePage.value) {
 		treeBranch.value?.toggleCollapse(true);
 	}
 });

--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
@@ -13,6 +13,7 @@
 		:variant="
 			COMPONENT_TYPES_TOP_LEVEL.has(component.type) ? 'root' : undefined
 		"
+		:disable-collapse="COMPONENT_TYPES_ROOT.has(component.type)"
 		:no-nested-space="COMPONENT_TYPES_ROOT.has(component.type)"
 		@select="select"
 		@dragover="handleDragOver"
@@ -75,6 +76,7 @@ import { useComponentsTreeSearchForComponent } from "./composables/useComponents
 import { useComponentDescription } from "../useComponentDescription";
 import { useWriterTracking } from "@/composables/useWriterTracking";
 import {
+	COMPONENT_TYPES_PAGE,
 	COMPONENT_TYPES_ROOT,
 	COMPONENT_TYPES_TOP_LEVEL,
 } from "@/constants/component";
@@ -88,7 +90,6 @@ const treeBranch = ref<ComponentPublicInstance<typeof BuilderTree>>();
 
 const wf = inject(injectionKeys.core);
 const wfbm = inject(injectionKeys.builderManager);
-const collapsed = ref(false);
 const selected = computed(() => wfbm.isComponentIdSelected(props.componentId));
 
 const tracking = useWriterTracking(wf);
@@ -141,7 +142,6 @@ async function select(ev: MouseEvent | KeyboardEvent) {
 function expand() {
 	if (!treeBranch.value) return;
 	treeBranch.value.expand();
-	collapsed.value = false;
 	emit("expandBranch");
 }
 

--- a/src/ui/src/components/blueprints/BlueprintsRoot.vue
+++ b/src/ui/src/components/blueprints/BlueprintsRoot.vue
@@ -1,5 +1,5 @@
 <template>
-	<div ref="rootEl" class="BlueprintsRoot" data-writer-container>
+	<div class="BlueprintsRoot" data-writer-container>
 		<template v-for="vnode in getChildrenVNodes()" :key="vnode.key">
 			<component
 				:is="vnode"
@@ -24,13 +24,13 @@ export default {
 	},
 };
 </script>
+
 <script setup lang="ts">
-import { computed, inject, useTemplateRef } from "vue";
+import { computed, inject, onMounted } from "vue";
 import injectionKeys from "@/injectionKeys";
 
 const wf = inject(injectionKeys.core);
 const getChildrenVNodes = inject(injectionKeys.getChildrenVNodes);
-const rootEl = useTemplateRef("rootEl");
 
 const displayedBlueprintId = computed(() => {
 	const activePageId = wf.activePageId.value;
@@ -46,6 +46,15 @@ const displayedBlueprintId = computed(() => {
 	if (pageComponents.length == 0) return null;
 
 	return pageComponents[0].id;
+});
+
+onMounted(() => {
+	if (
+		displayedBlueprintId.value &&
+		wf.activePageId.value !== displayedBlueprintId.value
+	) {
+		wf.setActivePageId(displayedBlueprintId.value);
+	}
 });
 </script>
 

--- a/src/ui/src/components/core/root/CoreRoot.vue
+++ b/src/ui/src/components/core/root/CoreRoot.vue
@@ -28,6 +28,7 @@ import {
 	contentWidth,
 } from "@/renderer/sharedStyleFields";
 import { useEvaluator } from "@/renderer/useEvaluator";
+import { useAbortController } from "@/composables/useAbortController";
 
 const ssHashChangeStub = `
 def handle_hashchange(state, payload):
@@ -121,6 +122,7 @@ import {
 	nextTick,
 	onBeforeMount,
 	useTemplateRef,
+	onMounted,
 } from "vue";
 import injectionKeys from "@/injectionKeys";
 import { changePageInHash, serializeParsedHash } from "@/core/navigation";
@@ -146,6 +148,15 @@ const displayedPageId = computed(() => {
 	const visiblePages = pageComponents.filter((c) => isComponentVisible(c.id));
 	if (visiblePages.length == 0) return null;
 	return visiblePages[0].id;
+});
+
+onMounted(() => {
+	if (
+		displayedPageId.value &&
+		wf.activePageId.value !== displayedPageId.value
+	) {
+		wf.setActivePageId(displayedPageId.value);
+	}
 });
 
 function handleHashChange() {
@@ -175,9 +186,11 @@ watch(displayedPageId, (newPageId) => {
 	changePageInHash(pageKey);
 });
 
+const abort = useAbortController();
+
 onBeforeMount(() => {
-	window.addEventListener("hashchange", () => {
-		handleHashChange();
+	window.addEventListener("hashchange", () => handleHashChange(), {
+		signal: abort.signal,
 	});
 	handleHashChange();
 });

--- a/src/ui/src/constants/component.ts
+++ b/src/ui/src/constants/component.ts
@@ -1,7 +1,7 @@
 export const COMPONENT_TYPES_ROOT = new Set(["root", "blueprints_root"]);
+export const COMPONENT_TYPES_PAGE = new Set(["page", "blueprints_blueprint"]);
 
 export const COMPONENT_TYPES_TOP_LEVEL = new Set([
 	...COMPONENT_TYPES_ROOT,
-	"page",
-	"blueprints_blueprint",
+	...COMPONENT_TYPES_PAGE,
 ]);

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -67,10 +67,7 @@ export function generateCore() {
 	let mailSubscriptions: { mailType: string; fn: Function }[] = [];
 	const collaborationPingSubscriptions: { fn: Function }[] = [];
 
-	const activePageId = useLocalStorageJSON<Component["id"]>(
-		"generateCore__activePageId",
-		(v) => typeof v === "string",
-	);
+	const activePageId = ref<Component["id"] | undefined>();
 
 	const writerOrgId = computed(
 		() => Number(writerApplication.value?.organizationId) || undefined,


### PR DESCRIPTION


https://github.com/user-attachments/assets/1796a844-613d-4542-a65f-2ee712f8f4aa


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added options to disable collapsing and set initial collapsed state for tree components.
  - Sidebar tree branches now automatically collapse or prevent collapse based on component type and active page context.

- **Refactor**
  - Improved handling of active page memory when switching between modes in the builder.
  - Grouped related component types into a new constant for better maintainability.
  - Updated initialization of active page tracking for simpler state management.
  - Synchronized active page state with displayed page on component mount for consistent UI.

- **Tests**
  - Added tests to verify restoration of previous active page when switching modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->