### PR TITLE
fix(ui): avoid computing errors for fields using template - WF-496

### DIFF
--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -29,7 +29,6 @@ import {
 	isSourceFilesFile,
 	moveFileToSourceFiles,
 } from "./sourceFiles";
-import { useLocalStorageJSON } from "@/composables/useLocalStorageJSON";
 
 const RECONNECT_DELAY_MS = 1000;
 const KEEP_ALIVE_DELAY_MS = 60000;

--- a/src/ui/src/renderer/useEvaluator.ts
+++ b/src/ui/src/renderer/useEvaluator.ts
@@ -7,8 +7,10 @@ import {
 	SecretsManager,
 } from "@/writerTypes";
 
+export const TEMPLATE_REGEX = /[\\]?@{([^}]*)}/;
+
 export function useEvaluator(wf: Core, secretsManager?: SecretsManager) {
-	const templateRegex = /[\\]?@{([^}]*)}/g;
+	const templateRegex = new RegExp(TEMPLATE_REGEX.source, "g");
 
 	/**
 	 * Returns the expression as an array of static accessors.
@@ -19,8 +21,8 @@ export function useEvaluator(wf: Core, secretsManager?: SecretsManager) {
 		expr: string,
 		instancePath?: InstancePath,
 	): string[] {
-		let accessors = [],
-			s = "";
+		const accessors = [];
+		let s = "";
 		let level = 0;
 
 		let i = 0;

--- a/src/ui/src/renderer/useFieldsErrors.spec.ts
+++ b/src/ui/src/renderer/useFieldsErrors.spec.ts
@@ -1,20 +1,23 @@
 import { describe, vi, it, expect, beforeAll } from "vitest";
 import { useFieldsErrors } from "./useFieldsErrors";
 import { computed, ref } from "vue";
-import { generateCore } from "@/core";
 import {
-	Core,
 	FieldType,
 	InstancePath,
 	WriterComponentDefinition,
 } from "@/writerTypes";
 import { validatorCustomSchemas } from "@/constants/validators";
+import { buildMockComponent, buildMockCore } from "@/tests/mocks";
 
 const getEvaluatedFields = vi.fn();
 
-vi.mock("./useEvaluator", () => ({
-	useEvaluator: () => ({ getEvaluatedFields }),
-}));
+vi.mock("./useEvaluator", async () => {
+	const actual = await vi.importActual("./useEvaluator");
+	return {
+		...actual,
+		useEvaluator: () => ({ getEvaluatedFields }),
+	};
+});
 
 describe(useFieldsErrors.name, () => {
 	const instancePath = computed<InstancePath>(() => [
@@ -23,21 +26,34 @@ describe(useFieldsErrors.name, () => {
 			instanceNumber: 0,
 		},
 	]);
-	let core: Core;
+	let mockCore: ReturnType<typeof buildMockCore>;
 
 	const dummyComponent: WriterComponentDefinition = {
 		name: "dummmy component",
 		description: "",
 	};
 
+	function mockComponentFieldValue<T>(value: T) {
+		const valueRef = ref(value);
+		getEvaluatedFields.mockReturnValue({ value: valueRef });
+		mockCore.core.getComponentById("1").content = {
+			value: String(value),
+		};
+		return valueRef;
+	}
+
 	beforeAll(() => {
-		core = generateCore();
-		// @ts-expect-error return a dummy mock
-		vi.spyOn(core, "getComponentById").mockReturnValue({});
+		mockCore = buildMockCore();
+
+		mockCore.core.addComponent(
+			buildMockComponent({
+				id: "1",
+			}),
+		);
 	});
 
 	it("should validate a field as number", () => {
-		vi.spyOn(core, "getComponentDefinition").mockReturnValue({
+		vi.spyOn(mockCore.core, "getComponentDefinition").mockReturnValue({
 			...dummyComponent,
 			fields: {
 				value: {
@@ -51,10 +67,9 @@ describe(useFieldsErrors.name, () => {
 			},
 		});
 
-		const value = ref(1);
-		getEvaluatedFields.mockReturnValue({ value });
+		const value = mockComponentFieldValue(1);
 
-		const errors = useFieldsErrors(core, instancePath);
+		const errors = useFieldsErrors(mockCore.core, instancePath);
 		expect(errors.value).toStrictEqual({ value: "must be >= 10" });
 
 		value.value = 10;
@@ -63,7 +78,7 @@ describe(useFieldsErrors.name, () => {
 	});
 
 	it("should validate a field as string", () => {
-		vi.spyOn(core, "getComponentDefinition").mockReturnValue({
+		vi.spyOn(mockCore.core, "getComponentDefinition").mockReturnValue({
 			...dummyComponent,
 			fields: {
 				value: {
@@ -77,10 +92,36 @@ describe(useFieldsErrors.name, () => {
 			},
 		});
 
-		const value = ref("test");
-		getEvaluatedFields.mockReturnValue({ value });
+		const value = mockComponentFieldValue("test");
 
-		const errors = useFieldsErrors(core, instancePath);
+		const errors = useFieldsErrors(mockCore.core, instancePath);
+		expect(errors.value).toStrictEqual({
+			value: validatorCustomSchemas.uri.errorMessage,
+		});
+
+		value.value = "https://writer.com";
+
+		expect(errors.value).toStrictEqual({ value: undefined });
+	});
+
+	it("should not validate a field containing a template expression", () => {
+		vi.spyOn(mockCore.core, "getComponentDefinition").mockReturnValue({
+			...dummyComponent,
+			fields: {
+				value: {
+					name: "value",
+					type: FieldType.Text,
+					validator: {
+						type: "string",
+						format: "uri",
+					},
+				},
+			},
+		});
+
+		const value = mockComponentFieldValue("test");
+
+		const errors = useFieldsErrors(mockCore.core, instancePath);
 		expect(errors.value).toStrictEqual({
 			value: validatorCustomSchemas.uri.errorMessage,
 		});
@@ -91,7 +132,7 @@ describe(useFieldsErrors.name, () => {
 	});
 
 	it("should validate a field as options", () => {
-		vi.spyOn(core, "getComponentDefinition").mockReturnValue({
+		vi.spyOn(mockCore.core, "getComponentDefinition").mockReturnValue({
 			...dummyComponent,
 			fields: {
 				value: {
@@ -106,10 +147,9 @@ describe(useFieldsErrors.name, () => {
 			},
 		});
 
-		const value = ref("test");
-		getEvaluatedFields.mockReturnValue({ value });
+		const value = mockComponentFieldValue("test");
 
-		const errors = useFieldsErrors(core, instancePath);
+		const errors = useFieldsErrors(mockCore.core, instancePath);
 		expect(errors.value).toStrictEqual({
 			value: "must be equal to one of the allowed values: a, b, c",
 		});

--- a/src/ui/src/renderer/useFieldsErrors.ts
+++ b/src/ui/src/renderer/useFieldsErrors.ts
@@ -5,7 +5,7 @@ import type {
 	WriterComponentDefinitionField,
 } from "@/writerTypes";
 import { computed, ComputedRef } from "vue";
-import { useEvaluator } from "./useEvaluator";
+import { TEMPLATE_REGEX, useEvaluator } from "./useEvaluator";
 import {
 	buildJsonSchemaForEnum,
 	getJsonSchemaValidator,
@@ -21,14 +21,19 @@ export function useFieldsErrors(
 ) {
 	const { getEvaluatedFields } = useEvaluator(wf, secretsManager);
 
+	function includesTemplate(template: string) {
+		return Boolean(TEMPLATE_REGEX.exec(template));
+	}
+
 	const componentId = computed(() => instancePath.value.at(-1)?.componentId);
 
-	const componentFields = computed(() => {
-		if (componentId.value === undefined) return {};
-		const component = wf.getComponentById(componentId.value);
-		if (!component) return {};
+	const component = computed(() => {
+		if (componentId.value === undefined) return undefined;
+		return wf.getComponentById(componentId.value);
+	});
 
-		return wf.getComponentDefinition(component.type).fields ?? {};
+	const componentFields = computed(() => {
+		return wf.getComponentDefinition(component.value.type).fields ?? {};
 	});
 
 	const evaluatedFields = computed(() =>
@@ -38,7 +43,12 @@ export function useFieldsErrors(
 	return computed(() => {
 		return Object.entries(componentFields.value).reduce(
 			(acc, [key, definition]) => {
+				// skip validation if the value contains a template var
+				const plainValue = component.value.content?.[key] ?? "";
+				if (includesTemplate(plainValue)) return acc;
+
 				const value = evaluatedFields.value[key].value;
+
 				acc[key] = computeFieldErrors(
 					wf,
 					componentId.value,


### PR DESCRIPTION
https://github.com/user-attachments/assets/29a6e742-ee6b-48b4-8f27-48ffbd502ca8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Validation is now skipped for fields containing template expressions, preventing incorrect error messages for dynamic values.

- **Tests**
	- Test suite for field validation was refactored and expanded, including new scenarios for fields with template expressions and more detailed validation cases.

- **Refactor**
	- Improved internal logic for identifying and skipping fields with template variables during validation.
	- Enhanced consistency and maintainability in test code.
	- Moved template expression regex to a shared constant for better reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->