### PR TITLE
fix: add spaces to keys

### DIFF
--- a/src/writer/blocks/writerclassification.py
+++ b/src/writer/blocks/writerclassification.py
@@ -28,7 +28,7 @@ class WriterClassification(WriterBlock):
                             "name": "Categories",
                             "type": "Key-Value",
                             "default": "{}",
-                            "desc": "The keys should be the categories you want to classify the text in, for example 'valid' and 'invalid', and the values the criteria for each category. Category names should contain only letters of the English alphabet, digits and underscores.",
+                            "desc": "The keys should be the categories you want to classify the text in, for example 'valid' and 'invalid', and the values the criteria for each category. Category names should contain only letters of the English alphabet, digits, underscores and spaces.",
                         },
                         "additionalContext": {
                             "name": "Additional context",
@@ -57,10 +57,10 @@ class WriterClassification(WriterBlock):
             additional_context = self._get_field("additionalContext")
             categories = self._get_field("categories", as_json=True, required=True)
 
-            invalid_categories = [category for category in categories if not re.fullmatch(r"\w+", category, flags=re.ASCII)]
+            invalid_categories = [category for category in categories if not re.fullmatch(r"[\w ]+", category, flags=re.ASCII)]
             if invalid_categories:
                 self.outcome = "error"
-                raise ValueError(f"Category names should contain only letters of the English alphabet, digits and underscores. Invalid categories: {', '.join(invalid_categories)}")
+                raise ValueError(f"Category names should contain only letters of the English alphabet, digits, underscores and spaces. Invalid categories: {', '.join(invalid_categories)}")
 
             config = {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Category names in the classification block now support spaces in addition to letters, digits, and underscores.
- **Documentation**
  - Updated descriptions and error messages to clarify that spaces are allowed in category names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->