### PR TITLE
fix: enable support of new lines in chatbot messages

### DIFF
--- a/src/ui/src/components/core/content/CoreChatBot/CoreChatbotMessage.vue
+++ b/src/ui/src/components/core/content/CoreChatBot/CoreChatbotMessage.vue
@@ -124,6 +124,7 @@ const contentBgColor = computed(() => {
 .CoreChatbotMessage__content__text {
 	line-height: 2;
 	padding: 12px 16px 12px 16px;
+	white-space: pre-wrap;
 }
 
 .CoreChatbotMessage__content__actions {


### PR DESCRIPTION
A simple CSS fix to enable support for new lines in Chatbot component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved chatbot message display to preserve whitespace and line breaks for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->