### PR TITLE
chore: unify chat management blocks - WF-545

### DIFF
--- a/src/writer/blocks/__init__.py
+++ b/src/writer/blocks/__init__.py
@@ -15,6 +15,7 @@ from writer.blocks.writeraddchatmessage import WriterAddChatMessage
 from writer.blocks.writeraddtokg import WriterAddToKG
 from writer.blocks.writeraskkg import WriterAskGraphQuestion
 from writer.blocks.writerchat import WriterChat
+from writer.blocks.writerchatmanager import WriterChatManager
 from writer.blocks.writerclassification import WriterClassification
 from writer.blocks.writercompletion import WriterCompletion
 from writer.blocks.writerfileapi import WriterUploadFile
@@ -28,6 +29,7 @@ from writer.blocks.writervision import WriterVision
 SetState.register("blueprints_setstate")
 WriterClassification.register("blueprints_writerclassification")
 WriterCompletion.register("blueprints_writercompletion")
+WriterChatManager.register("blueprints_writerchatmanager")
 HTTPRequest.register("blueprints_httprequest")
 RunBlueprint.register("blueprints_runblueprint")
 WriterNoCodeApp.register("blueprints_writernocodeapp")

--- a/src/writer/blocks/writeraddchatmessage.py
+++ b/src/writer/blocks/writeraddchatmessage.py
@@ -14,6 +14,7 @@ class WriterAddChatMessage(BlueprintBlock):
                 "name": "Add chat message",
                 "description": "Adds a message to the conversation history. Use for displaying user or AI messages.",
                 "category": "Writer",
+                "deprecated": True,
                 "fields": {
                     "conversationStateElement": {
                         "name": "Conversation state element",

--- a/src/writer/blocks/writerchat.py
+++ b/src/writer/blocks/writerchat.py
@@ -15,6 +15,7 @@ class WriterChat(WriterBlock):
                     "name": "Generate chat reply",
                     "description": "Generates an AI chat response using the full conversation history. Requires prior messages.",
                     "category": "Writer",
+                    "deprecated": True,
                     "fields": {
                         "conversationStateElement": {
                             "name": "Conversation state element",

--- a/src/writer/blocks/writerchatmanager.py
+++ b/src/writer/blocks/writerchatmanager.py
@@ -1,0 +1,221 @@
+from writer.abstract import register_abstract_template
+from writer.blocks.base_block import WriterBlock
+from writer.ss_types import AbstractTemplate, WriterConfigurationError
+
+DEFAULT_MODEL = "palmyra-x-004"
+
+
+class WriterChatManager(WriterBlock):
+    @classmethod
+    def register(cls, type: str):
+        super(WriterChatManager, cls).register(type)
+        register_abstract_template(
+            type,
+            AbstractTemplate(
+                baseType="blueprints_node",
+                writer={
+                    "name": "Chat manager",
+                    "description": "Initializes conversations, adds messages, and can generate replies.",
+                    "category": "Writer",
+                    "fields": {
+                        "conversationStateElement": {
+                            "name": "Conversation state element",
+                            "desc": "Where the conversation will be stored",
+                            "type": "Text",
+                        },
+                        "systemPrompt": {
+                            "name": "System prompt",
+                            "type": "Text",
+                            "control": "Textarea",
+                            "default": "",
+                            "desc": "A system prompt to set the context for the conversation. Can be left empty if conversation is already initialized in state.",
+                        },
+                        "message": {
+                            "name": "Message",
+                            "type": "Object",
+                            "init": '{ "role": "assistant", "content": "Hello" }',
+                            "desc": "The message to add to the conversation. Can be left empty if only generating a reply from AI.",
+                            "validator": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {"type": "string"},
+                                    "content": {"type": "string"},
+                                },
+                                "additionalProperties": False,
+                            },
+                        },
+                        "initModelId": {
+                            "name": "Initial model",
+                            "type": "Model Id",
+                            "default": DEFAULT_MODEL,
+                        },
+                        "initTemperature": {
+                            "name": "Initial temperature",
+                            "type": "Number",
+                            "default": "0.7",
+                            "validator": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1,
+                            },
+                        },
+                        "initMaxTokens": {
+                            "name": "Initial max tokens",
+                            "type": "Number",
+                            "default": "1024",
+                            "validator": {
+                                "type": "number",
+                                "minimum": 1,
+                                "maximum": 8192,
+                            },
+                        },
+                        "generateReply": {
+                            "name": "Generate reply",
+                            "type": "Text",
+                            "default": "no",
+                            "desc": "If set to 'yes', the block will generate a reply based on the conversation. If set to 'no', it will only add the message to the conversation.",
+                            "options": {"yes": "Yes", "no": "No"},
+                        },
+                        "useStreaming": {
+                            "name": "Use streaming",
+                            "type": "Text",
+                            "default": "yes",
+                            "desc": "If set to 'yes', the block will stream the reply as it is generated. If set to 'no', it will wait for the entire reply to be generated before returning.",
+                            "options": {"yes": "Yes", "no": "No"},
+                        },
+                        "tools": {
+                            "name": "Tools",
+                            "type": "Tools",
+                            "default": "{}",
+                            "init": "",
+                            "category": "Tools",
+                        },
+                    },
+                    "outs": {
+                        "tools": {
+                            "name": "Tools",
+                            "field": "tools",
+                            "description": "Run associated tools.",
+                            "style": "dynamic",
+                        },
+                        "success": {
+                            "name": "Success",
+                            "description": "If the function doesn't raise an Exception.",
+                            "style": "success",
+                        },
+                        "error": {
+                            "name": "Error",
+                            "description": "If the function raises an Exception.",
+                            "style": "error",
+                        },
+                    },
+                },
+            ),
+        )
+
+    def _make_callable(self, tool_name: str):
+        def callable(**args):
+            expanded_execution_environment = self.execution_environment | args
+            return_value = self.runner.run_branch(
+                self.component.id,
+                f"tools_{tool_name}",
+                expanded_execution_environment,
+                f"Blueprint branch execution (chat tool {tool_name})",
+            )
+
+            if return_value is None:
+                self.outcome = "error"
+                raise ValueError(
+                    f'No value has been returned for the outcome branch "{tool_name}". Use the block "Return value" to specify one.'
+                )
+
+            return return_value
+
+        return callable
+
+    def run(self):
+        try:
+            import writer.ai
+
+            conversation_state_element = self._get_field(
+                "conversationStateElement", required=True
+            )
+            message = self._get_field("message", as_json=True)
+            system_prompt = self._get_field(
+                "systemPrompt", False, default_field_value=None
+            )
+            init_model_id = self._get_field(
+                "initModelId", False, default_field_value=DEFAULT_MODEL
+            )
+            init_temperature = float(self._get_field("initTemperature", False, "0.7"))
+            init_max_tokens = int(self._get_field("initMaxTokens", False, "1024"))
+            use_streaming = self._get_field("useStreaming", False, "yes") == "yes"
+            generate_reply = self._get_field("generateReply", False, "no") == "yes"
+            tools_raw = self._get_field("tools", True)
+            tools = []
+
+            for tool_name, tool_raw in tools_raw.items():
+                tool_type = tool_raw.get("type")
+                tool = None
+                if tool_type == "function":
+                    tool = writer.ai.FunctionTool(
+                        type="function",
+                        name=tool_name,
+                        description=tool_raw.get("description"),
+                        callable=self._make_callable(tool_name),
+                        parameters=tool_raw.get("parameters"),
+                    )
+                elif tool_type == "graph":
+                    tool = writer.ai.GraphTool(
+                        type="graph",
+                        graph_ids=tool_raw.get("graph_ids"),
+                        subqueries=False,
+                        description=tool_name,
+                    )
+                else:
+                    continue
+                tools.append(tool)
+
+            conversation = self.evaluator.evaluate_expression(
+                conversation_state_element, self.instance_path, self.execution_environment
+            )
+
+            if conversation is None:
+                config = {
+                    "temperature": init_temperature,
+                    "model": init_model_id,
+                    "max_tokens": init_max_tokens,
+                }
+                conversation = writer.ai.Conversation(prompt_or_history=system_prompt, config=config)
+                self._set_state(conversation_state_element, conversation)
+            elif not isinstance(conversation, writer.ai.Conversation):
+                raise WriterConfigurationError(
+                    "The state element specified doesn't contain a Conversation."
+                )
+
+            if message not in (None, {}, ""):
+                writer.ai.Conversation.validate_message(message)
+                conversation += message
+
+            result_text = None
+            if generate_reply:
+                msg = ""
+                if not use_streaming:
+                    reply = conversation.complete(tools=tools)
+                    msg = reply.get("content") or ""
+                    conversation += reply
+                    self._set_state(conversation_state_element, conversation)
+                else:
+                    for chunk in conversation.stream_complete(tools=tools):
+                        if chunk.get("content") is None:
+                            chunk["content"] = ""
+                        msg += chunk.get("content")
+                        conversation += chunk
+                        self._set_state(conversation_state_element, conversation)
+                result_text = msg
+            self._set_state(conversation_state_element, conversation)
+            self.result = result_text
+            self.outcome = "success"
+        except BaseException as e:
+            self.outcome = "error"
+            raise e

--- a/src/writer/blocks/writerchatmanager.py
+++ b/src/writer/blocks/writerchatmanager.py
@@ -147,8 +147,11 @@ class WriterChatManager(WriterBlock):
             init_model_id = self._get_field(
                 "initModelId", False, default_field_value=DEFAULT_MODEL
             )
-            init_temperature = float(self._get_field("initTemperature", False, "0.7"))
-            init_max_tokens = int(self._get_field("initMaxTokens", False, "1024"))
+            try:
+                init_temperature = float(self._get_field("initTemperature", False, "0.7"))
+                init_max_tokens = int(self._get_field("initMaxTokens", False, "1024"))
+            except ValueError as e:
+                raise WriterConfigurationError(f"Invalid numeric value in configuration: {e}")
             use_streaming = self._get_field("useStreaming", False, "yes") == "yes"
             generate_reply = self._get_field("generateReply", False, "no") == "yes"
             tools_raw = self._get_field("tools", True)

--- a/src/writer/blocks/writerinitchat.py
+++ b/src/writer/blocks/writerinitchat.py
@@ -16,6 +16,7 @@ class WriterInitChat(WriterBlock):
                 "name": "Start chat conversation",
                 "description": "Starts a new chat conversation. Use to initialize context for AI interactions.",
                 "category": "Writer",
+                "deprecated": True,
                 "fields": {
                     "conversationStateElement": {
                         "name": "Conversation state element",

--- a/tests/backend/blocks/test_writerchatmanager.py
+++ b/tests/backend/blocks/test_writerchatmanager.py
@@ -1,0 +1,116 @@
+import json
+
+import pytest
+import writer.ai
+from writer.blocks.writerchatmanager import WriterChatManager
+
+
+class MockConversation(writer.ai.Conversation):
+    def __init__(self):
+        super().__init__()
+
+    def _check_tools(self, tools):
+        if tools is None or tools == []:
+            return
+        if len(tools) != 2:
+            raise RuntimeError("Invalid number of tools.")
+        function_tool = tools[0]
+        assert function_tool.get("type") == "function"
+        assert function_tool.get("name") == "bat_locator"
+        assert function_tool.get("description") == "Locates bats."
+        assert function_tool.get("parameters").get("color") == {
+            "type": "string",
+            "description": "The color of the bat you're looking for.",
+        }
+        graph_tool = tools[1]
+        assert graph_tool.get("type") == "graph"
+        assert graph_tool.get("graph_ids") == [111, 112, 113]
+
+    def complete(self, tools=None):
+        self._check_tools(tools)
+        return {"role": "assistant", "content": "Next to the grill."}
+
+    def stream_complete(self, tools=None):
+        self._check_tools(tools)
+        yield {"role": "assistant", "content": "On "}
+        yield {"role": "assistant", "content": "the ", "chunk": True}
+        yield {"role": "assistant", "content": "car's ", "chunk": True}
+        yield {"role": "assistant", "content": "roof.", "chunk": True}
+
+
+@pytest.fixture
+def conversation():
+    return MockConversation()
+
+
+def test_init_and_add_message(session, runner, fake_client):
+    component = session.add_fake_component(
+        {
+            "conversationStateElement": "convo",
+            "message": '{"role": "user", "content": "hi"}',
+            "generateReply": "no",
+        }
+    )
+    block = WriterChatManager(component, runner, {})
+    block.run()
+    assert isinstance(session.session_state["convo"], writer.ai.Conversation)
+    assert session.session_state["convo"].messages[0]["content"] == "hi"
+
+
+def test_add_message_existing(session, runner, fake_client):
+    session.session_state["convo"] = writer.ai.Conversation()
+    component = session.add_fake_component(
+        {
+            "conversationStateElement": "convo",
+            "message": '{"role": "user", "content": "hi"}',
+            "generateReply": "no",
+        }
+    )
+    block = WriterChatManager(component, runner, {})
+    block.run()
+    assert len(session.session_state["convo"].messages) == 1
+
+
+def test_generate_complete(session, runner, conversation, fake_client):
+    conversation.add("user", "Hi, where's the bat?")
+    session.session_state["convo"] = conversation
+    component = session.add_fake_component(
+        {
+            "conversationStateElement": "convo",
+            "generateReply": "yes",
+            "useStreaming": "no",
+        }
+    )
+    block = WriterChatManager(component, runner, {})
+    block.run()
+    assert conversation.messages[1].get("content") == "Next to the grill."
+
+
+def test_generate_stream(session, runner, conversation, fake_client):
+    conversation.add("user", "Hi, where's the bat?")
+    session.session_state["convo"] = conversation
+    component = session.add_fake_component(
+        {
+            "conversationStateElement": "convo",
+            "generateReply": "yes",
+            "useStreaming": "yes",
+            "tools": json.dumps(
+                {
+                    "bat_locator": {
+                        "type": "function",
+                        "description": "Locates bats.",
+                        "parameters": {
+                            "color": {
+                                "type": "string",
+                                "description": "The color of the bat you're looking for.",
+                            }
+                        },
+                    },
+                    "known_bat_spots": {"type": "graph", "graph_ids": [111, 112, 113]},
+                }
+            ),
+        }
+    )
+    block = WriterChatManager(component, runner, {})
+    block.run()
+    assert conversation.messages[1].get("content") == "On the car's roof."

--- a/tests/backend/blocks/test_writerchatmanager.py
+++ b/tests/backend/blocks/test_writerchatmanager.py
@@ -54,7 +54,7 @@ def test_init_and_add_message(session, runner, fake_client):
     block = WriterChatManager(component, runner, {})
     block.run()
     assert isinstance(session.session_state["convo"], writer.ai.Conversation)
-    assert session.session_state["convo"].messages[0]["content"] == "hi"
+    assert session.session_state["convo"].messages[1]["content"] == "hi"
 
 
 def test_add_message_existing(session, runner, fake_client):


### PR DESCRIPTION
Creates a new block - Chat manager - that replaces three existing blocks related to chat management: "Generate chat reply", "Add chat message" & "Init chat". 

Fields:
- Conversation state element - used for referencing the conversation stored in state, creates a new one if no such conversation was present in the state;
- System prompt - initial set of instructions for the model
- Message - a JSON representation of a new message to add into conversation; can be left empty if no new message needs to be added
- Model ID, temperature, max tokens - LLM configuration
- Generate reply (yes/no) - if yes, triggers the LLM to add a new AI-generated message into the conversation
- Use streaming (yes/no) - if yes, updates the state element with incoming chunks; if no, awaits for the whole response before update
- Tools - a configuration of tools exposed to the model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new chat manager block that manages conversations, adds messages, and can generate AI replies with advanced configuration options.

- **Bug Fixes**
  - None.

- **Tests**
  - Added comprehensive tests for the new chat manager block, covering conversation state, message handling, reply generation, and tool integration.

- **Chores**
  - Marked several older chat-related blocks as deprecated in the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->