### PR TITLE
chore: expand component definition to support feature flags array

### DIFF
--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -15,6 +15,7 @@ import {
 	getSupportedComponentTypes,
 	getComponentDefinition,
 	registerAbstractComponentTemplate,
+	setActiveFeatureFlags,
 } from "./templateMap";
 import * as typeHierarchy from "./typeHierarchy";
 import { auditAndFixComponents } from "./auditAndFix";
@@ -119,6 +120,7 @@ export function generateCore() {
 		sessionId = initData.sessionId;
 		sessionTimestamp.value = new Date().getTime();
 		featureFlags.value = initData.featureFlags;
+		setActiveFeatureFlags(featureFlags.value);
 		writerApplication.value = initData.writerApplication;
 		loadAbstractTemplates(initData.abstractTemplates);
 

--- a/src/ui/src/core/templateMap.ts
+++ b/src/ui/src/core/templateMap.ts
@@ -19,6 +19,17 @@ import CoreAnnotatedText from "../components/core/content/CoreAnnotatedText.vue"
 import CoreJsonViewer from "../components/core/content/CoreJsonViewer.vue";
 import CoreProgressBar from "../components/core/content/CoreProgressBar.vue";
 
+let activeFeatureFlags: string[] = [];
+
+export function setActiveFeatureFlags(flags: string[]) {
+	activeFeatureFlags = flags ?? [];
+}
+
+function checkFlags(required?: string[]): boolean {
+	if (!required || required.length === 0) return true;
+	return required.some((f) => activeFeatureFlags.includes(f));
+}
+
 // input
 import CoreCheckboxInput from "../components/core/input/CoreCheckboxInput.vue";
 import CoreColorInput from "../components/core/input/CoreColorInput.vue";
@@ -204,21 +215,32 @@ function getMergedAbstractTemplate(type: string) {
 }
 
 export function getTemplate(type: string) {
-	return (
+	const tmpl =
 		getMergedAbstractTemplate(type) ??
 		templateMap[type] ??
-		fallbackTemplate(type)
-	);
+		fallbackTemplate(type);
+
+	const required =
+		(tmpl as any)?.writer?.featureFlags;
+
+	if (!checkFlags(required)) {
+		return fallbackTemplate(type);
+	}
+	return tmpl;
 }
 
 export function getComponentDefinition(
-	type: string,
+        type: string,
 ): WriterComponentDefinition {
-	return getTemplate(type)?.writer;
+        return getTemplate(type)?.writer;
 }
 
 export function getSupportedComponentTypes() {
-	return [...Object.keys(templateMap), ...Object.keys(abstractTemplateMap)];
+        const allTypes = [...Object.keys(templateMap), ...Object.keys(abstractTemplateMap)];
+        return allTypes.filter((t) => {
+			const required = (templateMap[t] as any)?.writer?.featureFlags as string[] | undefined;
+			return checkFlags(required);
+        });
 }
 
 export function registerComponentTemplate(

--- a/src/ui/src/writerTypes.ts
+++ b/src/ui/src/writerTypes.ts
@@ -117,14 +117,15 @@ export type WriterComponentDefinition = {
 	previewField?: string; // Which field to use for previewing in the Component Tree
 	positionless?: boolean; // Whether this type of component is positionless (like Sidebar)
 	outs?: Record<
-		string,
-		{
-			name: string;
-			description: string;
-			style: string;
-			field?: keyof WriterComponentDefinition["fields"];
-		}
+			string,
+			{
+					name: string;
+					description: string;
+					style: string;
+					field?: keyof WriterComponentDefinition["fields"];
+			}
 	>;
+	featureFlags?: string[];
 };
 
 export type BuilderManager = ReturnType<typeof generateBuilderManager>;

--- a/src/writer/blocks/apitrigger.py
+++ b/src/writer/blocks/apitrigger.py
@@ -28,7 +28,11 @@ class APITrigger(BlueprintTrigger):
                             "style": "success",
                         },
                     },
+                    "featureFlags": [
+                        "api_trigger"
+                    ]
                 },
+                
             ),
         )
 

--- a/src/writer/blocks/writervision.py
+++ b/src/writer/blocks/writervision.py
@@ -67,6 +67,9 @@ class WriterVision(WriterBlock):
                             "style": "error",
                         },
                     },
+                    "featureFlags": [
+                        "vision_block"
+                    ]
                 },
             ),
         )

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -178,27 +178,6 @@ def get_asgi_app(
 
     # Init
 
-    def _apply_feature_flags_to_templates(
-        templates: Dict[str, Any], feature_flags: List[str]
-    ) -> Dict[str, Any]:
-        """
-        Applies feature flags to the templates by removing the ones that are not enabled.
-        """
-
-        # Restrict blocks by feature flags
-        restricted = {
-            "blueprints_apitrigger": "api_trigger",
-            "blueprints_writervision": "vision_block",
-        }
-
-        templates = {
-                k: v for k, v in templates.items()
-                if restricted.get(k, "") in feature_flags
-                or restricted.get(k) is None
-            }
-
-        return templates
-
     def _get_run_starter_pack(payload: InitSessionResponsePayload):
         return InitResponseBodyRun(
             mode="run",
@@ -216,10 +195,6 @@ def get_asgi_app(
     def _get_edit_starter_pack(payload: InitSessionResponsePayload):
         run_code: Optional[str] = app_runner.run_code
 
-        prepared_templates = _apply_feature_flags_to_templates(
-            abstract.templates, payload.featureFlags
-        )
-
         return InitResponseBodyEdit(
             mode="edit",
             sessionId=payload.sessionId,
@@ -231,7 +206,7 @@ def get_asgi_app(
             sourceFiles=app_runner.source_files,
             extensionPaths=cached_extension_paths,
             featureFlags=payload.featureFlags,
-            abstractTemplates=prepared_templates,
+            abstractTemplates=abstract.templates,
             writerApplication=payload.writerApplication,
         )
 

--- a/src/writer/ss_types.py
+++ b/src/writer/ss_types.py
@@ -291,6 +291,7 @@ class ComponentDefinition(TypedDict):
     outs: Optional[Dict[str, str]]
     x: Optional[int]
     y: Optional[int]
+    featureFlags: Optional[List[str]]
 
 
 class BlueprintExecutionLog(BaseModel):


### PR DESCRIPTION
Allows to define a list of feature flags required to be set in `writer.Config` in order to make those components available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced feature flag support to control the availability of specific component templates and features in the user interface.
  - Components and templates may now appear or be hidden based on active feature flags.

- **Bug Fixes**
  - Improved consistency in how templates are filtered and displayed based on feature flag settings.

- **Chores**
  - Updated internal data structures to support feature flag metadata for components and templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->