### PR TITLE
chore: bump default model to `palmyra-x5`

### DIFF
--- a/src/writer/ai/__init__.py
+++ b/src/writer/ai/__init__.py
@@ -56,8 +56,8 @@ from writerai.types.shared_params.tool_param import LlmTool as SDKLlmTool
 
 from writer.core import get_app_process
 
-DEFAULT_CHAT_MODEL = "palmyra-x-004"
-DEFAULT_COMPLETION_MODEL = "palmyra-x-004"
+DEFAULT_CHAT_MODEL = "palmyra-x5"
+DEFAULT_COMPLETION_MODEL = "palmyra-x5"
 
 
 _ai_client: ContextVar[Optional[Writer]] = ContextVar("ai_client", default=None)

--- a/src/writer/blocks/writerchatmanager.py
+++ b/src/writer/blocks/writerchatmanager.py
@@ -2,7 +2,7 @@ from writer.abstract import register_abstract_template
 from writer.blocks.base_block import WriterBlock
 from writer.ss_types import AbstractTemplate, WriterConfigurationError
 
-DEFAULT_MODEL = "palmyra-x-004"
+DEFAULT_MODEL = "palmyra-x5"
 
 
 class WriterChatManager(WriterBlock):

--- a/src/writer/blocks/writercompletion.py
+++ b/src/writer/blocks/writercompletion.py
@@ -2,7 +2,7 @@ from writer.abstract import register_abstract_template
 from writer.blocks.base_block import WriterBlock
 from writer.ss_types import AbstractTemplate
 
-DEFAULT_MODEL = "palmyra-x-004"
+DEFAULT_MODEL = "palmyra-x5"
 
 class WriterCompletion(WriterBlock):
     @classmethod

--- a/src/writer/blocks/writerinitchat.py
+++ b/src/writer/blocks/writerinitchat.py
@@ -2,7 +2,7 @@ from writer.abstract import register_abstract_template
 from writer.blocks.base_block import WriterBlock
 from writer.ss_types import AbstractTemplate, WriterConfigurationError
 
-DEFAULT_MODEL = "palmyra-x-004"
+DEFAULT_MODEL = "palmyra-x5"
 
 
 class WriterInitChat(WriterBlock):

--- a/src/writer/blocks/writertoolcalling.py
+++ b/src/writer/blocks/writertoolcalling.py
@@ -2,7 +2,7 @@ from writer.abstract import register_abstract_template
 from writer.blocks.base_block import WriterBlock
 from writer.ss_types import AbstractTemplate
 
-DEFAULT_MODEL = "palmyra-x-004"
+DEFAULT_MODEL = "palmyra-x5"
 
 class WriterToolCalling(WriterBlock):
     @classmethod


### PR DESCRIPTION
Sets Palmyra X5 as the default model for all AI functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the default AI model across chat and completion features from "palmyra-x-004" to "palmyra-x5". This affects the default model used in chat, completion, and tool-calling blocks when no specific model is selected. No other functionality or behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->