### PR TITLE
fix(ui): improve handling binding in K/V editor - WF-582

### DIFF
--- a/src/ui/src/builder/BuilderVault.vue
+++ b/src/ui/src/builder/BuilderVault.vue
@@ -22,7 +22,7 @@ const {
 } = inject(injectionKeys.secretsManager);
 
 const {
-	currentValue,
+	currentValueObject: currentValue,
 	assistedEntries,
 	getAssistedEntryError,
 	updateAssistedEntryKey,

--- a/src/ui/src/builder/settings/BuilderFieldsKeyValue.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsKeyValue.vue
@@ -9,17 +9,16 @@
 				variant="neutral"
 				size="smallIcon"
 				data-automation-key="openAssistedMode"
-				@click="modalMode = 'assisted'"
+				@click="isModalOpen = true"
 			>
 				<i class="material-symbols-outlined">edit</i>
 			</WdsButton>
 		</div>
 		<BuilderFieldsKeyValueModal
-			v-if="modalMode"
+			v-if="isModalOpen"
 			:data="field"
-			:initial-mode="modalMode"
 			@submit="onModalSubmit"
-			@close="modalMode = undefined"
+			@close="isModalOpen = undefined"
 		/>
 
 		<div
@@ -30,7 +29,7 @@
 			<WdsButton
 				variant="special"
 				size="small"
-				@click="modalMode = 'assisted'"
+				@click="isModalOpen = true"
 			>
 				<i class="material-symbols-outlined">keyboard_backspace</i>
 				Edit
@@ -73,7 +72,6 @@ import type { InstancePath } from "@/writerTypes";
 import { useComponentActions } from "../useComponentActions";
 import WdsButton from "@/wds/WdsButton.vue";
 import BuilderFieldsKeyValueModal from "./BuilderFieldsKeyValueModal.vue";
-import type { Mode } from "./composables/useKeyValueEditor";
 
 const props = defineProps({
 	componentId: { type: String, required: true },
@@ -92,7 +90,7 @@ const { getEvaluatedFields } = useEvaluator(wf, secretsManager);
 const componentId = toRef(props, "componentId");
 const fieldKey = toRef(props, "fieldKey");
 
-const modalMode = ref<Mode | undefined>();
+const isModalOpen = ref(false);
 
 const evaluatedValue = computed<JSONValue>(
 	() => getEvaluatedFields(props.instancePath)[fieldKey.value].value,
@@ -100,24 +98,15 @@ const evaluatedValue = computed<JSONValue>(
 
 const component = computed(() => wf.getComponentById(componentId.value));
 
-const field = computed(() => {
-	const value = component.value.content?.[fieldKey.value];
-	if (value === undefined) return evaluatedValue.value;
+const field = computed(
+	() =>
+		component.value.content?.[fieldKey.value] ??
+		JSON.stringify(evaluatedValue.value),
+);
 
-	try {
-		return JSON.parse(value);
-	} catch {
-		return {};
-	}
-});
-
-function onModalSubmit(data: JSONValue) {
-	modalMode.value = undefined;
-	setContentValue(
-		component.value.id,
-		fieldKey.value,
-		JSON.stringify(data, null, 2),
-	);
+function onModalSubmit(data: string) {
+	isModalOpen.value = undefined;
+	setContentValue(component.value.id, fieldKey.value, String(data));
 }
 </script>
 

--- a/src/ui/src/builder/settings/BuilderFieldsKeyValueModal.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsKeyValueModal.vue
@@ -88,11 +88,10 @@
 </template>
 
 <script setup lang="ts">
-import { PropType, computed, defineAsyncComponent } from "vue";
+import { computed, defineAsyncComponent } from "vue";
 import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
 import WdsModal, { ModalAction } from "@/wds/WdsModal.vue";
 import BuilderAsyncLoader from "../BuilderAsyncLoader.vue";
-import type { JSONValue } from "./BuilderFieldsKeyValue.vue";
 import WdsButton from "@/wds/WdsButton.vue";
 import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
 import { Mode, useKeyValueEditor } from "./composables/useKeyValueEditor";
@@ -105,13 +104,8 @@ const BuilderEmbeddedCodeEditor = defineAsyncComponent({
 
 const props = defineProps({
 	data: {
-		type: [Object, String] as PropType<JSONValue>,
+		type: String,
 		required: true,
-	},
-	initialMode: {
-		type: String as PropType<Mode>,
-		required: false,
-		default: "assisted",
 	},
 });
 
@@ -121,17 +115,15 @@ const {
 	freehandValue,
 	isValid,
 	currentValue,
-	isInBindingMode,
 	addAssistedEntry,
 	updateAssistedEntryValue,
 	updateAssistedEntryKey,
 	removeAssistedEntry,
 	getAssistedEntryError,
 } = useKeyValueEditor(props.data);
-mode.value = props.initialMode;
 
 const emits = defineEmits({
-	submit: (data: JSONValue) => typeof data === "object" && data !== undefined,
+	submit: (data: string) => typeof data === "string",
 	close: () => true,
 });
 
@@ -139,26 +131,14 @@ const actions = computed<ModalAction[]>(() => [
 	{
 		desc: "Save",
 		fn: () => emits("submit", currentValue.value),
-		disabled:
-			JSON.stringify(props.data) === JSON.stringify(currentValue.value) ||
-			!isValid.value,
+		disabled: props.data === currentValue.value || !isValid.value,
 	},
 ]);
 
-const tabs = computed<WdsTabOptions<Mode>[]>(() => {
-	let listDisabled = undefined;
-
-	if (isInBindingMode.value) {
-		listDisabled = "The value is binded to the state";
-	} else if (mode.value === "freehand" && !isValid.value) {
-		listDisabled = "The JSON is not valid";
-	}
-
-	return [
-		{ label: "List", value: "assisted", disabled: listDisabled },
-		{ label: "JSON", value: "freehand" },
-	];
-});
+const tabs: WdsTabOptions<Mode>[] = [
+	{ label: "List", value: "assisted" },
+	{ label: "JSON", value: "freehand" },
+];
 </script>
 
 <style scoped>

--- a/src/ui/src/builder/settings/composables/useKeyValueEditor.spec.ts
+++ b/src/ui/src/builder/settings/composables/useKeyValueEditor.spec.ts
@@ -31,7 +31,7 @@ describe(useKeyValueEditor.name, () => {
 			);
 		});
 
-		it("shoul update an entry", () => {
+		it("should update an entry", () => {
 			const {
 				assistedEntries,
 				addAssistedEntry,
@@ -73,18 +73,6 @@ describe(useKeyValueEditor.name, () => {
 	});
 
 	describe("freehand mode", () => {
-		it("should handle invalid JSON", () => {
-			const { mode, freehandValue, currentValue, isValid } =
-				useKeyValueEditor({
-					foo: "bar",
-				});
-			mode.value = "freehand";
-
-			freehandValue.value = '{"foo';
-			expect(currentValue.value).toStrictEqual({});
-			expect(isValid.value).toBe(false);
-		});
-
 		it("should reflect changes when moving from freehand mode to assisted mode", () => {
 			const { assistedEntries, mode, freehandValue } = useKeyValueEditor({
 				foo: "bar",
@@ -121,7 +109,7 @@ describe(useKeyValueEditor.name, () => {
 			expect(freehandValue.value).toStrictEqual(
 				JSON.stringify({ hello: "bar" }, undefined, 2),
 			);
-			expect(currentValue.value).toStrictEqual({ hello: "bar" });
+			expect(currentValue.value).toBe(freehandValue.value);
 		});
 
 		it("should reflect changes when moving from freehand mode to assisted mode", () => {

--- a/src/ui/src/builder/settings/composables/useKeyValueEditor.ts
+++ b/src/ui/src/builder/settings/composables/useKeyValueEditor.ts
@@ -1,51 +1,57 @@
 import { computed, readonly, ref, shallowRef } from "vue";
 import type { JSONValue } from "../BuilderFieldsKeyValue.vue";
+import { TEMPLATE_REGEX } from "@/renderer/useEvaluator";
 
 type AssistedEntry = { key: string; value: string };
 export type Mode = "assisted" | "freehand";
 
-function isEvaluatedValue(value: unknown): value is string {
-	return typeof value === "string" && value.startsWith("@{");
+function isValidJSON(value: string) {
+	try {
+		JSON.parse(value);
+		return true;
+	} catch {
+		return false;
+	}
+}
+function tryToParse(value: string) {
+	try {
+		return JSON.parse(value);
+	} catch {
+		return {};
+	}
 }
 
-export function useKeyValueEditor(originalValue: JSONValue | string) {
+export function useKeyValueEditor(originalValue: string | JSONValue) {
 	const getId = useId();
 
-	const mode = ref<Mode>("assisted");
+	const mode = ref<Mode>(computeInitialMode(originalValue));
+	const freehandValue = ref(
+		typeof originalValue === "string"
+			? originalValue
+			: JSON.stringify(originalValue),
+	);
+	const assistedEntries = shallowRef<Record<string, AssistedEntry>>({});
+
+	initializeAssistedEntries(originalValue);
 
 	function setMode(newMode: Mode) {
 		if (mode.value === newMode) return;
 		switch (newMode) {
 			case "assisted":
-				if (isInBindingMode.value) {
-					mode.value = "freehand";
-					return;
-				}
 				initializeAssistedEntries(currentValue.value);
 				break;
 			case "freehand":
-				if (!isInBindingMode.value) {
-					freehandValue.value = JSON.stringify(
-						currentValue.value,
-						undefined,
-						2,
-					);
-				}
+				freehandValue.value = JSON.stringify(
+					currentValueObject.value,
+					undefined,
+					2,
+				);
 				break;
 		}
 		mode.value = newMode;
 	}
 
-	const freehandValue = ref("");
-
-	const isInBindingMode = computed(() =>
-		isEvaluatedValue(freehandValue.value),
-	);
-
 	// assisted entries
-
-	const assistedEntries = shallowRef<Record<string, AssistedEntry>>({});
-	initializeAssistedEntries(originalValue);
 
 	function updateAssistedEntries(value: Record<string, unknown>) {
 		assistedEntries.value = Object.entries(value).reduce(
@@ -98,13 +104,19 @@ export function useKeyValueEditor(originalValue: JSONValue | string) {
 		}
 	}
 
-	function initializeAssistedEntries(object: JSONValue | string) {
-		if (isEvaluatedValue(object)) {
-			assistedEntries.value = {};
-			freehandValue.value = object;
-			mode.value = "freehand";
-			return;
-		}
+	function computeInitialMode(objectOrString: string | JSONValue): Mode {
+		return typeof objectOrString === "string" &&
+			(TEMPLATE_REGEX.exec(objectOrString) ||
+				!isValidJSON(objectOrString))
+			? "freehand"
+			: "assisted";
+	}
+
+	function initializeAssistedEntries(objectOrString: string | JSONValue) {
+		const object =
+			typeof objectOrString === "string"
+				? tryToParse(objectOrString)
+				: objectOrString;
 
 		assistedEntries.value = Object.entries(object).reduce<
 			Record<string, AssistedEntry>
@@ -139,43 +151,38 @@ export function useKeyValueEditor(originalValue: JSONValue | string) {
 			case "assisted":
 				return assitedEntriesDuplicatedKeys.value.size === 0;
 			case "freehand":
-				if (isInBindingMode.value) return true;
-				try {
-					JSON.parse(freehandValue.value);
-					return true;
-				} catch {
-					return false;
-				}
+				return true;
 			default:
 				return false;
 		}
 	});
 
-	const currentValue = computed<JSONValue>(() => {
+	const currentValue = computed<string>(() => {
 		switch (mode.value) {
-			case "assisted":
-				return Object.values(assistedEntries.value).reduce((acc, v) => {
-					acc[v.key] = v.value;
-					return acc;
-				}, {});
+			case "assisted": {
+				const obj = Object.values(assistedEntries.value).reduce(
+					(acc, v) => {
+						acc[v.key] = v.value;
+						return acc;
+					},
+					{},
+				);
+				return JSON.stringify(obj);
+			}
 			case "freehand":
-				if (isInBindingMode.value) {
-					return freehandValue.value;
-				}
+				return freehandValue.value;
 
-				try {
-					return JSON.parse(freehandValue.value);
-				} catch {
-					return {};
-				}
 			default:
-				return {};
+				return "";
 		}
 	});
 
+	const currentValueObject = computed<JSONValue>(() =>
+		tryToParse(currentValue.value),
+	);
+
 	return {
 		mode: computed<Mode>({ get: () => mode.value, set: setMode }),
-		isInBindingMode,
 		assistedEntries: readonly(assistedEntries),
 		addEntryDisabled: addAssistedEntryDisabled,
 		addAssistedEntry,
@@ -187,6 +194,7 @@ export function useKeyValueEditor(originalValue: JSONValue | string) {
 		freehandValue,
 		isValid,
 		currentValue,
+		currentValueObject,
 	};
 }
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/84bd71da-09da-4011-b4a3-0b5e8960037e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified and unified key-value editor modal behavior, removing modal modes and treating all data as strings.
  - Streamlined modal open/close logic and removed unnecessary props and computed properties.
  - Improved handling of key-value data, eliminating legacy binding mode logic and clarifying separation between string and object representations.
- **Bug Fixes**
  - Fixed minor typos and improved test assertions for key-value editor functionality.
- **Style**
  - Cleaned up unused imports and simplified tab configuration in the modal interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->