### PR TITLE
feat(ui): move settings action in a dropdown - WF-502

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ playground/
 *.mp4
 .turbo
 styles.css
+.aider*

--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -266,23 +266,23 @@ async function handleKeydown(ev: KeyboardEvent) {
 		return;
 	}
 
-	if (!ssbm.isSingleSelectionActive.value || !ssbm.firstSelectedItem.value) {
-		return;
-	}
-
 	const { componentId: selectedId, instancePath: selectedInstancePath } =
 		ssbm.firstSelectedItem.value;
+	const selectedIds = ssbm.selection.value.map((c) => c.componentId);
 
 	if (ev.key == "Delete") {
-		const componentIds = ssbm.selection.value
-			.filter((s) => isDeleteAllowed(s.componentId))
-			.map((s) => s.componentId);
+		const componentIds = selectedIds.filter((i) => isDeleteAllowed(i));
 		removeComponentsSubtree(...componentIds);
 		return;
 	}
 	if (!isModifierKeyActive) return;
 
+	const isMultipeSelection =
+		ssbm.selectionStatus.value === SelectionStatus.Multiple;
+
 	if (ev.shiftKey) {
+		if (isMultipeSelection) return;
+
 		switch (ev.key) {
 			case "ArrowDown":
 				ev.preventDefault();
@@ -307,22 +307,27 @@ async function handleKeydown(ev: KeyboardEvent) {
 	} else {
 		switch (ev.key) {
 			case "ArrowDown":
+				if (isMultipeSelection) return;
 				ev.preventDefault();
 				moveComponentDown(selectedId);
 				break;
 			case "ArrowUp":
+				if (isMultipeSelection) return;
 				ev.preventDefault();
 				moveComponentUp(selectedId);
 				break;
 			case "ArrowLeft":
+				if (isMultipeSelection) return;
 				ev.preventDefault();
 				moveComponentToParent(selectedId);
 				break;
 			case "ArrowRight":
+				if (isMultipeSelection) return;
 				ev.preventDefault();
 				moveComponentInsideNextSibling(selectedId);
 				break;
 			case "v":
+				if (isMultipeSelection) return;
 				if (!isPasteAllowed(selectedId)) return;
 				try {
 					await pasteComponent(selectedId);
@@ -331,10 +336,11 @@ async function handleKeydown(ev: KeyboardEvent) {
 				}
 				break;
 			case "c":
-				if (isCopyAllowed(selectedId)) copyComponent(selectedId);
+				if (isCopyAllowed(...selectedIds))
+					copyComponent(...selectedIds);
 				break;
 			case "x":
-				if (isCutAllowed(selectedId)) cutComponent(selectedId);
+				if (isCutAllowed(...selectedIds)) cutComponent(...selectedIds);
 				break;
 		}
 	}

--- a/src/ui/src/builder/settings/BuilderSettings.vue
+++ b/src/ui/src/builder/settings/BuilderSettings.vue
@@ -42,8 +42,9 @@
 			<p class="BuilderSettings__titleBar__title">
 				{{ componentDefinition.name }}
 			</p>
-			<div v-if="resultId" class="BuilderSettings__titleBar__actions">
+			<div class="BuilderSettings__titleBar__actions">
 				<WdsButton
+					v-if="resultId"
 					size="smallIcon"
 					variant="neutral"
 					data-writer-tooltip-placement="bottom"
@@ -53,6 +54,13 @@
 					@click.prevent="copyComponentId"
 					>@</WdsButton
 				>
+				<SharedMoreDropdown
+					data-automation-action="settings-actions-dropdown"
+					:options="dropdownOptions"
+					trigger-custom-size="32px"
+					trigger-icon="more_vert"
+					@select="handleDropdownSelect"
+				/>
 			</div>
 		</div>
 		<div
@@ -63,21 +71,39 @@
 		>
 			<p>{{ selectionCount }}</p>
 		</div>
-		<BuilderSettingsActions class="BuilderSettings__actions" />
+		<BuilderSettingsActions
+			v-if="
+				collapsed &&
+				ssbm.selectionStatus.value === SelectionStatus.Multiple
+			"
+			class="BuilderSettings__actions"
+		/>
 		<BuilderSettingsMain class="BuilderSettings__main" :inert="collapsed" />
+		<BuilderSettingsAddComponentModal
+			v-if="ssbm.isSingleSelectionActive.value"
+			v-model:is-open="isAddModalOpen"
+			:selected-id="ssbm.firstSelectedId.value"
+		/>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { inject, computed, watch } from "vue";
+import { inject, computed, watch, ref } from "vue";
 import injectionKeys from "@/injectionKeys";
 
-import BuilderSettingsActions from "./BuilderSettingsActions.vue";
 import BuilderSettingsMain from "./BuilderSettingsMain.vue";
 import WdsButton from "@/wds/WdsButton.vue";
 import { SelectionStatus } from "../builderManager";
 import { useButtonClipboard } from "../useButtonClipboard";
 import { COMPONENT_TYPES_PAGE } from "@/constants/component";
+import SharedMoreDropdown from "@/components/shared/SharedMoreDropdown.vue";
+import { useWriterTracking } from "@/composables/useWriterTracking";
+import BuilderSettingsActions from "./BuilderSettingsActions.vue";
+import {
+	BuilderSettingsDropdownActions,
+	useBuilderSettingsActions,
+} from "./useBuilderSettingsActions";
+import BuilderSettingsAddComponentModal from "./BuilderSettingsAddComponentModal.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -100,6 +126,20 @@ const resultId = computed(() => {
 
 const { copyText: copyComponentId, isCopied: isComponentIdCopied } =
 	useButtonClipboard(resultId);
+
+const tracking = useWriterTracking(wf);
+
+const isAddModalOpen = ref(false);
+
+const { dropdownOptions, handleDropdownSelect } = useBuilderSettingsActions(
+	wf,
+	ssbm,
+	tracking,
+	{
+		[BuilderSettingsDropdownActions.Add]: () =>
+			(isAddModalOpen.value = true),
+	},
+);
 
 const collapsed = computed(() => {
 	if (ssbm.selectionStatus.value === SelectionStatus.Multiple) return true;
@@ -182,13 +222,17 @@ watch(component, (newComponent) => {
 	grid-row: 1;
 	grid-column: 2;
 	z-index: 2;
-	display: flex;
+	display: grid;
+	grid-template-columns: 1fr auto;
+	gap: 8px;
 	align-items: center;
 	padding-right: 12px;
-	overflow: hidden;
 	background: var(--builderSubtleSeparatorColor);
 }
 .BuilderSettings__titleBar__actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
 }
 
 .BuilderSettings__titleBar__title {
@@ -213,8 +257,7 @@ watch(component, (newComponent) => {
 .BuilderSettings__main {
 	width: 332px;
 	grid-row: 3;
-	grid-column: 2;
-	border-left: 1px solid var(--builderSeparatorColor);
+	grid-column: 1 / -1;
 	overflow-x: hidden;
 	overflow-y: auto;
 	margin-top: 0;
@@ -225,5 +268,6 @@ watch(component, (newComponent) => {
 	overflow: hidden;
 	max-height: 400px;
 	margin-top: -400px;
+	grid-column: 2;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderSettingsActions.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsActions.vue
@@ -13,6 +13,21 @@
 			<i class="material-symbols-outlined">close</i>
 		</WdsButton>
 		<WdsButton
+			v-if="
+				ssbm.selectionStatus.value === SelectionStatus.Multiple &&
+				ssbm.mode.value === 'blueprints'
+			"
+			class="actionButton"
+			variant="neutral"
+			size="small"
+			:data-writer-tooltip="`Copy (${getModifierKeyName()}C)`"
+			data-writer-tooltip-placement="left"
+			:disabled="isCopyDisabled"
+			@click="copySelectedComponents"
+		>
+			<i class="material-symbols-outlined">content_copy</i>
+		</WdsButton>
+		<WdsButton
 			class="BuilderSettingsActions__btn BuilderSettingsActions__btn--delete"
 			variant="neutral"
 			size="small"
@@ -30,6 +45,7 @@
 <script setup lang="ts">
 import { computed, inject } from "vue";
 import injectionKeys from "@/injectionKeys";
+import { getModifierKeyName } from "@/core/detectPlatform";
 import WdsButton from "@/wds/WdsButton.vue";
 import { SelectionStatus } from "../builderManager";
 import { useWriterTracking } from "@/composables/useWriterTracking";
@@ -52,10 +68,20 @@ const { dropdownOptions, handleDropdownSelect } = useBuilderSettingsActions(
 function deleteSelectedComponents() {
 	handleDropdownSelect(BuilderSettingsDropdownActions.Delete);
 }
+function copySelectedComponents() {
+	handleDropdownSelect(BuilderSettingsDropdownActions.Copy);
+}
 
 const isDeleteDisabled = computed(() => {
 	const option = dropdownOptions.value.find(
 		(o) => o.value === BuilderSettingsDropdownActions.Delete,
+	);
+	if (!option) return true;
+	return option.disabled;
+});
+const isCopyDisabled = computed(() => {
+	const option = dropdownOptions.value.find(
+		(o) => o.value === BuilderSettingsDropdownActions.Copy,
 	);
 	if (!option) return true;
 	return option.disabled;

--- a/src/ui/src/builder/settings/BuilderSettingsActions.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsActions.vue
@@ -1,120 +1,8 @@
 <template>
-	<div
-		class="BuilderSettingsActions"
-		:class="{
-			collapsed: ssbm.isSettingsBarCollapsed.value,
-		}"
-		:data-writer-id="selectedId"
-	>
-		<WdsButton
-			v-if="ssbm.isSingleSelectionActive.value"
-			data-writer-tooltip="Add child"
-			data-writer-tooltip-placement="left"
-			variant="neutral"
-			size="smallIcon"
-			class="actionButton"
-			:disabled="!shortcutsInfo?.isAddEnabled"
-			@click="
-				shortcutsInfo?.isAddEnabled
-					? (isAddModalOpen = true)
-					: undefined
-			"
-			><i class="material-symbols-outlined">add</i></WdsButton
-		>
-		<WdsButton
-			v-if="ssbm.isSingleSelectionActive.value"
-			class="actionButton"
-			size="small"
-			variant="neutral"
-			data-writer-tooltip-placement="left"
-			:data-writer-tooltip="`Move up (${getModifierKeyName()}↑)`"
-			:disabled="!shortcutsInfo?.isMoveUpEnabled"
-			@click="
-				shortcutsInfo?.isMoveUpEnabled
-					? moveComponentUp(selectedId)
-					: undefined
-			"
-			><i class="material-symbols-outlined">arrow_upward</i></WdsButton
-		>
-		<WdsButton
-			v-if="ssbm.isSingleSelectionActive.value"
-			class="actionButton"
-			variant="neutral"
-			size="small"
-			:data-writer-tooltip="`Move down (${getModifierKeyName()}↓)`"
-			data-writer-tooltip-placement="left"
-			:disabled="!shortcutsInfo?.isMoveDownEnabled"
-			@click="
-				shortcutsInfo?.isMoveDownEnabled
-					? moveComponentDown(selectedId)
-					: undefined
-			"
-		>
-			<i class="material-symbols-outlined">arrow_downward</i>
-		</WdsButton>
-		<WdsButton
-			v-if="ssbm.isSingleSelectionActive.value"
-			class="actionButton"
-			variant="neutral"
-			size="small"
-			:data-writer-tooltip="`Cut (${getModifierKeyName()}X)`"
-			data-writer-tooltip-placement="left"
-			:disabled="!shortcutsInfo?.isCutEnabled"
-			@click="
-				shortcutsInfo?.isCutEnabled
-					? cutComponent(selectedId)
-					: undefined
-			"
-		>
-			<i class="material-symbols-outlined">cut</i>
-		</WdsButton>
-		<WdsButton
-			v-if="ssbm.isSingleSelectionActive.value"
-			class="actionButton"
-			variant="neutral"
-			size="small"
-			:data-writer-tooltip="`Copy (${getModifierKeyName()}C)`"
-			data-writer-tooltip-placement="left"
-			:disabled="!shortcutsInfo?.isCopyEnabled"
-			@click="
-				shortcutsInfo?.isCopyEnabled
-					? copyComponent(selectedId)
-					: undefined
-			"
-		>
-			<i class="material-symbols-outlined">content_copy</i>
-		</WdsButton>
-		<WdsButton
-			v-if="ssbm.isSingleSelectionActive.value"
-			class="actionButton"
-			variant="neutral"
-			size="small"
-			:data-writer-tooltip="`Paste (${getModifierKeyName()}V)`"
-			data-writer-tooltip-placement="left"
-			:disabled="!isPasteEnabled"
-			@click="handlePasteComponent"
-		>
-			<i class="material-symbols-outlined">content_paste</i>
-		</WdsButton>
-		<WdsButton
-			v-if="ssbm.isSingleSelectionActive.value"
-			class="actionButton"
-			variant="neutral"
-			size="small"
-			:data-writer-tooltip="`Go to parent (${getModifierKeyName()}⇧↑)`"
-			data-writer-tooltip-placement="left"
-			:disabled="!shortcutsInfo?.isGoToParentEnabled"
-			@click="
-				shortcutsInfo?.isGoToParentEnabled
-					? goToParent(selectedId, selectedInstancePath)
-					: undefined
-			"
-		>
-			<i class="material-symbols-outlined">move_up</i>
-		</WdsButton>
+	<div class="BuilderSettingsActions" :data-writer-id="selectedId">
 		<WdsButton
 			v-if="ssbm.selectionStatus.value === SelectionStatus.Multiple"
-			class="actionButton"
+			class="BuilderSettingsActions__btn"
 			variant="neutral"
 			size="small"
 			data-automation-action="clear-selection"
@@ -125,181 +13,60 @@
 			<i class="material-symbols-outlined">close</i>
 		</WdsButton>
 		<WdsButton
-			class="actionButton delete"
+			class="BuilderSettingsActions__btn BuilderSettingsActions__btn--delete"
 			variant="neutral"
 			size="small"
 			data-automation-action="delete"
 			data-writer-tooltip="Delete (Del)"
 			data-writer-tooltip-placement="left"
-			:disabled="!shortcutsInfo?.isDeleteEnabled"
+			:disabled="isDeleteDisabled"
 			@click="deleteSelectedComponents"
 		>
 			<i class="material-symbols-outlined">delete</i>
 		</WdsButton>
-
-		<WdsModal
-			v-if="isAddModalOpen"
-			title="Add child component"
-			display-close-button
-			@close="isAddModalOpen = false"
-		>
-			<input
-				class="addModalInput"
-				type="text"
-				list="validChildrenTypes"
-				placeholder="Component..."
-				@change="addComponent"
-			/>
-			<datalist id="validChildrenTypes">
-				<option
-					v-for="(definition, type) in validChildrenTypes"
-					:key="type"
-					:value="definition.name"
-				>
-					{{ definition.name }}
-				</option>
-			</datalist>
-		</WdsModal>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { computed, inject, onMounted, Ref, ref, watch } from "vue";
-import { useComponentActions } from "../useComponentActions";
-import { WriterComponentDefinition } from "@/writerTypes";
+import { computed, inject } from "vue";
 import injectionKeys from "@/injectionKeys";
-import { getModifierKeyName } from "@/core/detectPlatform";
 import WdsButton from "@/wds/WdsButton.vue";
-import WdsModal from "@/wds/WdsModal.vue";
 import { SelectionStatus } from "../builderManager";
 import { useWriterTracking } from "@/composables/useWriterTracking";
-import { useToasts } from "../useToast";
+import {
+	BuilderSettingsDropdownActions,
+	useBuilderSettingsActions,
+} from "./useBuilderSettingsActions";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
 
 const tracking = useWriterTracking(wf);
 
-const {
-	createAndInsertComponent,
-	moveComponentUp,
-	moveComponentDown,
-	cutComponent,
-	pasteComponent,
-	copyComponent,
-	isAddAllowed,
-	isCopyAllowed,
-	isCutAllowed,
-	isGoToParentAllowed,
-	isPasteAllowed,
-	isDeleteAllowed,
-	getEnabledMoves,
-	removeComponentsSubtree,
-	goToParent,
-} = useComponentActions(wf, ssbm, tracking);
-
-const toasts = useToasts();
-
-async function handlePasteComponent() {
-	try {
-		await pasteComponent(selectedId.value);
-	} catch (error) {
-		toasts.pushToast({ type: "error", message: String(error) });
-	}
-}
+const { dropdownOptions, handleDropdownSelect } = useBuilderSettingsActions(
+	wf,
+	ssbm,
+	tracking,
+);
 
 function deleteSelectedComponents() {
-	if (!shortcutsInfo.value.isDeleteEnabled) return;
-	const componentIds = ssbm.selection.value.map((c) => c.componentId);
-	if (componentIds.length === 0) return;
-	removeComponentsSubtree(...componentIds);
+	handleDropdownSelect(BuilderSettingsDropdownActions.Delete);
 }
+
+const isDeleteDisabled = computed(() => {
+	const option = dropdownOptions.value.find(
+		(o) => o.value === BuilderSettingsDropdownActions.Delete,
+	);
+	if (!option) return true;
+	return option.disabled;
+});
 
 const selectedId = ssbm.firstSelectedId;
-const selectedInstancePath = computed(
-	() => ssbm.firstSelectedItem.value?.instancePath,
-);
-
-const isAddModalOpen = ref(false);
-
-const shortcutsInfo: Ref<{
-	componentTypeName: string;
-	toolkit?: WriterComponentDefinition["toolkit"];
-	isAddEnabled: boolean;
-	isMoveUpEnabled: boolean;
-	isMoveDownEnabled: boolean;
-	isCopyEnabled: boolean;
-	isCutEnabled: boolean;
-	isGoToParentEnabled: boolean;
-	isDeleteEnabled: boolean;
-}> = ref(null);
-
-const isPasteEnabled = computed(() => {
-	if (!ssbm.firstSelectedId.value) return false;
-	return isPasteAllowed(ssbm.firstSelectedId.value);
-});
-
-const validChildrenTypes = computed(() => {
-	const types = wf.getContainableTypes(selectedId.value);
-	const result: Record<string, WriterComponentDefinition> = {};
-
-	types.map((type) => {
-		const definition = wf.getComponentDefinition(type);
-		result[type] = definition;
-	});
-
-	return result;
-});
-
-function addComponent(event: Event) {
-	const definitionName = (event.target as HTMLInputElement).value;
-	const matchingTypes = Object.entries(validChildrenTypes.value).filter(
-		([_, definition]) => {
-			if (definition.name == definitionName) return true;
-			return false;
-		},
-	);
-	if (matchingTypes.length == 0) return;
-	const type = matchingTypes[0][0];
-	createAndInsertComponent(type, selectedId.value);
-	isAddModalOpen.value = false;
-}
-
-function reprocessShorcutsInfo(): void {
-	const component = wf.getComponentById(selectedId.value);
-	if (!component) return;
-	const { up: isMoveUpEnabled, down: isMoveDownEnabled } = getEnabledMoves(
-		selectedId.value,
-	);
-	shortcutsInfo.value = {
-		isAddEnabled: isAddAllowed(selectedId.value),
-		componentTypeName: wf.getComponentDefinition(component.type)?.name,
-		toolkit: wf.getComponentDefinition(component.type)?.toolkit,
-		isMoveUpEnabled,
-		isMoveDownEnabled,
-		isCopyEnabled: isCopyAllowed(selectedId.value),
-		isCutEnabled: isCutAllowed(selectedId.value),
-		isGoToParentEnabled: isGoToParentAllowed(selectedId.value),
-		isDeleteEnabled: isDeleteAllowed(selectedId.value),
-	};
-}
-
-watch(
-	() => wf.getComponentById(selectedId.value)?.position,
-	async (newPosition) => {
-		if (typeof newPosition == "undefined" || newPosition === null) return;
-		reprocessShorcutsInfo();
-	},
-	{ flush: "post" },
-);
-
-onMounted(() => {
-	reprocessShorcutsInfo();
-});
 </script>
 
 <style scoped>
 @import "../sharedStyles.css";
+
 .BuilderSettingsActions {
 	display: flex;
 	flex-direction: column;
@@ -312,34 +79,14 @@ onMounted(() => {
 	padding: 8px;
 	width: 50px;
 	transition: 0.2s gap linear;
-}
-
-.BuilderSettingsActions.collapsed {
 	gap: 0;
 }
 
-.type {
-	display: flex;
-	align-items: center;
-	padding-left: 16px;
-	padding-right: 16px;
-	height: 36px;
-	background: var(--builderSelectedColor);
-}
-
-.actionButton {
+.BuilderSettingsActions__btn {
 	min-height: 32px;
 }
 
-.actionButton:not([disabled]).delete {
+.BuilderSettingsActions__btn--delete:not([disabled]) {
 	color: var(--builderErrorColor);
-}
-
-.addModalInput {
-	outline: none;
-	border: 1px solid var(--builderSeparatorColor);
-	width: 100%;
-	border-radius: 8px;
-	padding: 8px;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderSettingsAddComponentModal.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsAddComponentModal.vue
@@ -1,0 +1,78 @@
+<template>
+	<WdsModal
+		v-if="isOpen"
+		title="Add child component"
+		display-close-button
+		@close="closeModal"
+	>
+		<WdsTextInput
+			type="text"
+			:list="datalistId"
+			placeholder="Component..."
+			@change="addComponent"
+		/>
+		<datalist :id="datalistId">
+			<option
+				v-for="(definition, type) in validChildrenTypes"
+				:key="type"
+				:value="definition.name"
+			>
+				{{ definition.name }}
+			</option>
+		</datalist>
+	</WdsModal>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, useId } from "vue";
+import { useComponentActions } from "../useComponentActions";
+import { WriterComponentDefinition } from "@/writerTypes";
+import injectionKeys from "@/injectionKeys";
+import WdsModal from "@/wds/WdsModal.vue";
+import { useWriterTracking } from "@/composables/useWriterTracking";
+import WdsTextInput from "@/wds/WdsTextInput.vue";
+
+const wf = inject(injectionKeys.core);
+const ssbm = inject(injectionKeys.builderManager);
+
+const datalistId = useId();
+
+const tracking = useWriterTracking(wf);
+
+const { createAndInsertComponent } = useComponentActions(wf, ssbm, tracking);
+
+const props = defineProps({
+	selectedId: { type: String, required: true },
+});
+
+const validChildrenTypes = computed(() => {
+	return wf
+		.getContainableTypes(props.selectedId)
+		.reduce<Record<string, WriterComponentDefinition>>((acc, type) => {
+			acc[type] = wf.getComponentDefinition(type);
+			return acc;
+		}, {});
+});
+
+const isOpen = defineModel("isOpen", { type: Boolean, default: false });
+
+function closeModal() {
+	isOpen.value = false;
+}
+
+function addComponent(event: Event) {
+	const definitionName = (event.target as HTMLInputElement).value;
+	if (!definitionName) return;
+
+	const matchingType = Object.entries(validChildrenTypes.value).find(
+		([_, definition]) => {
+			if (definition.name == definitionName) return true;
+			return false;
+		},
+	);
+	if (!matchingType) return;
+	const type = matchingType[0];
+	createAndInsertComponent(type, props.selectedId);
+	closeModal();
+}
+</script>

--- a/src/ui/src/builder/settings/useBuilderSettingsActions.spec.ts
+++ b/src/ui/src/builder/settings/useBuilderSettingsActions.spec.ts
@@ -1,0 +1,106 @@
+import {
+	BuilderSettingsDropdownActions,
+	useBuilderSettingsActions,
+} from "./useBuilderSettingsActions";
+import { BuilderManager } from "@/writerTypes";
+import { beforeEach, describe, expect, it } from "vitest";
+import { buildMockComponent, buildMockCore } from "@/tests/mocks";
+import { generateBuilderManager } from "../builderManager";
+import type { WdsDropdownMenuOption } from "@/wds/WdsDropdownMenu.vue";
+
+describe("useBuilderSettingsActions", () => {
+	let mockCore: ReturnType<typeof buildMockCore>;
+	let wfbm: BuilderManager;
+
+	function getOptionByValue(
+		options: WdsDropdownMenuOption[],
+		key: BuilderSettingsDropdownActions,
+	) {
+		return options.find((o) => o.value == key);
+	}
+
+	beforeEach(() => {
+		mockCore = buildMockCore();
+		wfbm = generateBuilderManager();
+	});
+
+	it("should disable everything when nnothing is selected", () => {
+		const { dropdownOptions } = useBuilderSettingsActions(
+			mockCore.core,
+			wfbm,
+		);
+
+		expect(dropdownOptions.value).toHaveLength(8);
+
+		for (const option of dropdownOptions.value) {
+			expect(option.disabled).toBe(true);
+		}
+	});
+
+	it("should get options for a root", () => {
+		mockCore.core.addComponent(
+			buildMockComponent({
+				id: "root",
+				type: "root",
+			}),
+		);
+
+		wfbm.setSelection("root");
+
+		const { dropdownOptions } = useBuilderSettingsActions(
+			mockCore.core,
+			wfbm,
+		);
+
+		expect(dropdownOptions.value).toHaveLength(8);
+
+		expect(
+			dropdownOptions.value.find(
+				(o) => o.value == BuilderSettingsDropdownActions.Delete,
+			).disabled,
+		).toBeTruthy();
+
+		expect(
+			dropdownOptions.value.find(
+				(o) => o.value == BuilderSettingsDropdownActions.Add,
+			).disabled,
+		).toBeFalsy();
+	});
+
+	it("should get options for a page", () => {
+		mockCore.core.addComponent(
+			buildMockComponent({
+				id: "1",
+				type: "root",
+			}),
+		);
+		mockCore.core.addComponent(
+			buildMockComponent({
+				id: "2",
+				parentId: "1",
+				type: "page",
+			}),
+		);
+
+		wfbm.setSelection("2");
+
+		const { dropdownOptions } = useBuilderSettingsActions(
+			mockCore.core,
+			wfbm,
+		);
+
+		expect(dropdownOptions.value).toHaveLength(8);
+
+		expect(
+			dropdownOptions.value.find(
+				(o) => o.value == BuilderSettingsDropdownActions.Delete,
+			).disabled,
+		).toBeFalsy();
+
+		expect(
+			dropdownOptions.value.find(
+				(o) => o.value == BuilderSettingsDropdownActions.Add,
+			).disabled,
+		).toBeFalsy();
+	});
+});

--- a/src/ui/src/builder/settings/useBuilderSettingsActions.ts
+++ b/src/ui/src/builder/settings/useBuilderSettingsActions.ts
@@ -5,6 +5,7 @@ import { getModifierKeyName } from "@/core/detectPlatform";
 import { useWriterTracking } from "@/composables/useWriterTracking";
 import { useToasts } from "../useToast";
 import { Option } from "@/components/shared/SharedMoreDropdown.vue";
+import { SelectionStatus } from "../builderManager";
 
 export enum BuilderSettingsDropdownActions {
 	Add = "add",
@@ -19,7 +20,7 @@ export enum BuilderSettingsDropdownActions {
 
 export function useBuilderSettingsActions(
 	wf: Core,
-	ssbm: BuilderManager,
+	wfbm: BuilderManager,
 	tracking?: ReturnType<typeof useWriterTracking>,
 	callbacks: Partial<Record<BuilderSettingsDropdownActions, () => void>> = {},
 ) {
@@ -38,13 +39,16 @@ export function useBuilderSettingsActions(
 		getEnabledMoves,
 		removeComponentsSubtree,
 		goToParent,
-	} = useComponentActions(wf, ssbm, tracking);
+	} = useComponentActions(wf, wfbm, tracking);
 
 	const toasts = useToasts();
 
-	const selectedId = ssbm.firstSelectedId;
+	const selectedId = wfbm.firstSelectedId;
 	const selectedInstancePath = computed(
-		() => ssbm.firstSelectedItem.value?.instancePath,
+		() => wfbm.firstSelectedItem.value?.instancePath,
+	);
+	const selectedIds = computed(() =>
+		wfbm.selection.value.map((c) => c.componentId),
 	);
 
 	const shortcutsInfo = computed(() => {
@@ -52,12 +56,16 @@ export function useBuilderSettingsActions(
 		if (!component) return {};
 		const { up: isMoveUpEnabled, down: isMoveDownEnabled } =
 			getEnabledMoves(selectedId.value);
+
+		const isMutlipte =
+			wfbm.selectionStatus.value === SelectionStatus.Multiple;
+
 		return {
-			isAddEnabled: isAddAllowed(selectedId.value),
+			isAddEnabled: !isMutlipte && isAddAllowed(selectedId.value),
 			componentTypeName: wf.getComponentDefinition(component.type)?.name,
 			toolkit: wf.getComponentDefinition(component.type)?.toolkit,
-			isMoveUpEnabled,
-			isMoveDownEnabled,
+			isMoveUpEnabled: !isMutlipte && isMoveUpEnabled,
+			isMoveDownEnabled: !isMutlipte && isMoveDownEnabled,
 			isCopyEnabled: isCopyAllowed(selectedId.value),
 			isCutEnabled: isCutAllowed(selectedId.value),
 			isGoToParentEnabled: isGoToParentAllowed(selectedId.value),
@@ -66,8 +74,8 @@ export function useBuilderSettingsActions(
 	});
 
 	const isPasteEnabled = computed(() => {
-		if (!ssbm.firstSelectedId.value) return false;
-		return isPasteAllowed(ssbm.firstSelectedId.value);
+		if (!wfbm.firstSelectedId.value) return false;
+		return isPasteAllowed(wfbm.firstSelectedId.value);
 	});
 
 	async function handlePasteComponent() {
@@ -80,7 +88,7 @@ export function useBuilderSettingsActions(
 
 	function deleteSelectedComponents() {
 		if (!shortcutsInfo.value.isDeleteEnabled) return;
-		const componentIds = ssbm.selection.value.map((c) => c.componentId);
+		const componentIds = wfbm.selection.value.map((c) => c.componentId);
 		if (componentIds.length === 0) return;
 		removeComponentsSubtree(...componentIds);
 	}
@@ -148,8 +156,14 @@ export function useBuilderSettingsActions(
 		return options;
 	});
 
-	function handleDropdownSelect(selected: BuilderSettingsDropdownActions) {
-		switch (selected) {
+	function handleDropdownSelect(action: BuilderSettingsDropdownActions) {
+		const dropdownOption = dropdownOptions.value.find(
+			(o) => o.value === action,
+		);
+
+		if (!dropdownOption || dropdownOption?.disabled) return;
+
+		switch (action) {
 			case BuilderSettingsDropdownActions.Add:
 				// Handled by callback
 				break;
@@ -160,10 +174,10 @@ export function useBuilderSettingsActions(
 				moveComponentDown(selectedId.value);
 				break;
 			case BuilderSettingsDropdownActions.Cut:
-				cutComponent(selectedId.value);
+				cutComponent(...selectedIds.value);
 				break;
 			case BuilderSettingsDropdownActions.Copy:
-				copyComponent(selectedId.value);
+				copyComponent(...selectedIds.value);
 				break;
 			case BuilderSettingsDropdownActions.Paste:
 				handlePasteComponent();
@@ -176,7 +190,7 @@ export function useBuilderSettingsActions(
 				break;
 		}
 
-		callbacks[selected]?.();
+		callbacks[action]?.();
 	}
 
 	return {

--- a/src/ui/src/builder/settings/useBuilderSettingsActions.ts
+++ b/src/ui/src/builder/settings/useBuilderSettingsActions.ts
@@ -1,0 +1,186 @@
+import { computed } from "vue";
+import { useComponentActions } from "../useComponentActions";
+import { Core, BuilderManager } from "@/writerTypes";
+import { getModifierKeyName } from "@/core/detectPlatform";
+import { useWriterTracking } from "@/composables/useWriterTracking";
+import { useToasts } from "../useToast";
+import { Option } from "@/components/shared/SharedMoreDropdown.vue";
+
+export enum BuilderSettingsDropdownActions {
+	Add = "add",
+	MoveUp = "moveUp",
+	MoveDown = "moveDown",
+	Cut = "cut",
+	Copy = "copy",
+	Paste = "paste",
+	GoToParent = "goToParent",
+	Delete = "delete",
+}
+
+export function useBuilderSettingsActions(
+	wf: Core,
+	ssbm: BuilderManager,
+	tracking?: ReturnType<typeof useWriterTracking>,
+	callbacks: Partial<Record<BuilderSettingsDropdownActions, () => void>> = {},
+) {
+	const {
+		moveComponentUp,
+		moveComponentDown,
+		cutComponent,
+		pasteComponent,
+		copyComponent,
+		isAddAllowed,
+		isCopyAllowed,
+		isCutAllowed,
+		isGoToParentAllowed,
+		isPasteAllowed,
+		isDeleteAllowed,
+		getEnabledMoves,
+		removeComponentsSubtree,
+		goToParent,
+	} = useComponentActions(wf, ssbm, tracking);
+
+	const toasts = useToasts();
+
+	const selectedId = ssbm.firstSelectedId;
+	const selectedInstancePath = computed(
+		() => ssbm.firstSelectedItem.value?.instancePath,
+	);
+
+	const shortcutsInfo = computed(() => {
+		const component = wf.getComponentById(selectedId.value);
+		if (!component) return {};
+		const { up: isMoveUpEnabled, down: isMoveDownEnabled } =
+			getEnabledMoves(selectedId.value);
+		return {
+			isAddEnabled: isAddAllowed(selectedId.value),
+			componentTypeName: wf.getComponentDefinition(component.type)?.name,
+			toolkit: wf.getComponentDefinition(component.type)?.toolkit,
+			isMoveUpEnabled,
+			isMoveDownEnabled,
+			isCopyEnabled: isCopyAllowed(selectedId.value),
+			isCutEnabled: isCutAllowed(selectedId.value),
+			isGoToParentEnabled: isGoToParentAllowed(selectedId.value),
+			isDeleteEnabled: isDeleteAllowed(selectedId.value),
+		};
+	});
+
+	const isPasteEnabled = computed(() => {
+		if (!ssbm.firstSelectedId.value) return false;
+		return isPasteAllowed(ssbm.firstSelectedId.value);
+	});
+
+	async function handlePasteComponent() {
+		try {
+			await pasteComponent(selectedId.value);
+		} catch (error) {
+			toasts.pushToast({ type: "error", message: String(error) });
+		}
+	}
+
+	function deleteSelectedComponents() {
+		if (!shortcutsInfo.value.isDeleteEnabled) return;
+		const componentIds = ssbm.selection.value.map((c) => c.componentId);
+		if (componentIds.length === 0) return;
+		removeComponentsSubtree(...componentIds);
+	}
+
+	const dropdownOptions = computed(() => {
+		const options: Option[] = [
+			{
+				value: BuilderSettingsDropdownActions.Add,
+				label: "Add child",
+				icon: "add",
+				disabled: !shortcutsInfo.value.isAddEnabled,
+			},
+			{
+				value: BuilderSettingsDropdownActions.MoveUp,
+				label: `Move up`,
+				shortcut: `${getModifierKeyName()}↑`,
+				icon: "arrow_upward",
+				disabled: !shortcutsInfo.value.isMoveUpEnabled,
+			},
+			{
+				value: BuilderSettingsDropdownActions.MoveDown,
+				label: `Move down`,
+				shortcut: `${getModifierKeyName()}↓`,
+				icon: "arrow_downward",
+				disabled: !shortcutsInfo.value.isMoveDownEnabled,
+			},
+			{
+				value: BuilderSettingsDropdownActions.Cut,
+				label: `Cut`,
+				shortcut: `${getModifierKeyName()}X`,
+				icon: "cut",
+				disabled: !shortcutsInfo.value.isCutEnabled,
+			},
+			{
+				value: BuilderSettingsDropdownActions.Copy,
+				label: `Copy`,
+				shortcut: `${getModifierKeyName()}C`,
+				icon: "content_copy",
+				disabled: !shortcutsInfo.value.isCopyEnabled,
+			},
+			{
+				value: BuilderSettingsDropdownActions.Paste,
+				label: `Paste`,
+				shortcut: `${getModifierKeyName()}V`,
+				icon: "content_paste",
+				disabled: !isPasteEnabled.value,
+			},
+			{
+				value: BuilderSettingsDropdownActions.GoToParent,
+				label: `Go to parent`,
+				shortcut: `${getModifierKeyName()}⇧↑`,
+				icon: "move_up",
+				disabled: !shortcutsInfo.value.isGoToParentEnabled,
+			},
+			{
+				value: BuilderSettingsDropdownActions.Delete,
+				label: "Delete",
+				shortcut: "Del",
+				icon: "delete",
+				variant: "danger",
+				disabled: !shortcutsInfo.value.isDeleteEnabled,
+			},
+		];
+
+		return options;
+	});
+
+	function handleDropdownSelect(selected: BuilderSettingsDropdownActions) {
+		switch (selected) {
+			case BuilderSettingsDropdownActions.Add:
+				// Handled by callback
+				break;
+			case BuilderSettingsDropdownActions.MoveUp:
+				moveComponentUp(selectedId.value);
+				break;
+			case BuilderSettingsDropdownActions.MoveDown:
+				moveComponentDown(selectedId.value);
+				break;
+			case BuilderSettingsDropdownActions.Cut:
+				cutComponent(selectedId.value);
+				break;
+			case BuilderSettingsDropdownActions.Copy:
+				copyComponent(selectedId.value);
+				break;
+			case BuilderSettingsDropdownActions.Paste:
+				handlePasteComponent();
+				break;
+			case BuilderSettingsDropdownActions.GoToParent:
+				goToParent(selectedId.value, selectedInstancePath.value);
+				break;
+			case BuilderSettingsDropdownActions.Delete:
+				deleteSelectedComponents();
+				break;
+		}
+
+		callbacks[selected]?.();
+	}
+
+	return {
+		dropdownOptions,
+		handleDropdownSelect,
+	};
+}

--- a/src/ui/src/builder/useComponentActions.ts
+++ b/src/ui/src/builder/useComponentActions.ts
@@ -373,24 +373,39 @@ export function useComponentActions(
 	/**
 	 * Whether a component can be copied into the clipboard.
 	 */
-	function isCopyAllowed(targetId: Component["id"]): boolean {
-		return !isRoot(targetId);
+	function isCopyAllowed(...targetIds: Component["id"][]): boolean {
+		if (targetIds.length === 0) return false;
+		if (targetIds.length > 1 && ssbm.mode.value !== "blueprints")
+			return false;
+		return !targetIds.some(isRoot);
 	}
 
 	/**
 	 * Whether a component can be cut and placed in the clipboard.
 	 */
-	function isCutAllowed(targetId: Component["id"]): boolean {
-		const component = wf.getComponentById(targetId);
-		return !isRoot(targetId) && !component?.isCodeManaged;
+	function isCutAllowed(...targetIds: Component["id"][]): boolean {
+		if (targetIds.length === 0) return false;
+		if (targetIds.length > 1 && ssbm.mode.value !== "blueprints")
+			return false;
+
+		for (const targetId of targetIds) {
+			const component = wf.getComponentById(targetId);
+			const isAllowed = !isRoot(targetId) && !component?.isCodeManaged;
+			if (!isAllowed) return false;
+		}
+		return true;
 	}
 
 	/**
 	 * Whether a component can be deleted.
 	 */
-	function isDeleteAllowed(targetId: Component["id"]): boolean {
-		const component = wf.getComponentById(targetId);
-		return !isRoot(targetId) && !component?.isCodeManaged;
+	function isDeleteAllowed(...targetIds: Component["id"][]): boolean {
+		for (const targetId of targetIds) {
+			const component = wf.getComponentById(targetId);
+			const isAllowed = !isRoot(targetId) && !component?.isCodeManaged;
+			if (!isAllowed) return false;
+		}
+		return true;
 	}
 
 	/** Whether it's possible to go to (select) a component's parent. */
@@ -572,13 +587,10 @@ export function useComponentActions(
 	 * Cuts a component and its descendents and places them in the internal clipboard.
 	 * @param componentId Id of the component to be cut
 	 */
-	function cutComponent(componentId: Component["id"]): void {
-		const component = wf.getComponentById(componentId);
-		if (!component) return;
-		const components = getFlatComponentSubtree(componentId);
-		componentClipboard.set(components);
+	function cutComponent(...componentIds: Component["id"][]): void {
+		copyComponent(...componentIds);
 		ssbm.setSelection(null);
-		removeComponentSubtree(componentId);
+		removeComponentsSubtree(...componentIds);
 		wf.sendComponentUpdate();
 	}
 
@@ -619,12 +631,14 @@ export function useComponentActions(
 	 * @param componentId Id of the component to be copied
 	 * @returns
 	 */
-	function copyComponent(componentId: Component["id"]): void {
-		const component = wf.getComponentById(componentId);
-		if (!component) return;
-		const subtree = getFlatComponentSubtree(componentId);
-		const newSubtree = getNewSubtreeWithRegeneratedIds(subtree);
-		componentClipboard.set(newSubtree);
+	function copyComponent(...componentIds: Component["id"][]): void {
+		const components = componentIds.flatMap((componentId) => {
+			const component = wf.getComponentById(componentId);
+			if (!component) return;
+			const subtree = getFlatComponentSubtree(componentId);
+			return getNewSubtreeWithRegeneratedIds(subtree);
+		});
+		componentClipboard.set(components);
 	}
 
 	/**

--- a/src/ui/src/components/shared/SharedMoreDropdown.vue
+++ b/src/ui/src/components/shared/SharedMoreDropdown.vue
@@ -7,7 +7,7 @@
 			:custom-size="triggerCustomSize"
 			@click.stop="isOpen = !isOpen"
 		>
-			<i class="material-symbols-outlined">more_horiz</i>
+			<i class="material-symbols-outlined">{{ triggerIcon }}</i>
 		</WdsButton>
 		<WdsDropdownMenu
 			v-if="isOpen"
@@ -55,6 +55,7 @@ const props = defineProps({
 		default: () => [],
 	},
 	triggerCustomSize: { type: String, default: "smallIcon" },
+	triggerIcon: { type: String, default: "more_horiz" },
 	disabled: { type: Boolean },
 	hideIcons: { type: Boolean, required: false },
 	dropdownPlacement: {

--- a/src/ui/src/wds/WdsDropdownMenu.vue
+++ b/src/ui/src/wds/WdsDropdownMenu.vue
@@ -97,7 +97,12 @@
 					:data-writer-tooltip="option.label"
 					data-writer-tooltip-strategy="overflow"
 				>
-					{{ option.label }}
+					<span>{{ option.label }}</span>
+					<span
+						v-if="option.shortcut"
+						class="WdsDropdownMenu__item__label__shortcut"
+						>{{ option.shortcut }}</span
+					>
 				</div>
 				<div
 					v-if="option.detail"
@@ -123,6 +128,7 @@ export type WdsDropdownMenuOption = {
 	value: string;
 	label: string;
 	detail?: string;
+	shortcut?: string;
 	/**
 	 * A font icon or an array of image URL
 	 */
@@ -265,6 +271,10 @@ watch(searchTerm, () => emits("search", searchTerm.value));
 	transition: all 0.2s;
 	pointer-events: all;
 }
+.WdsDropdownMenu__item:disabled {
+	opacity: 40%;
+	cursor: not-allowed !important;
+}
 .WdsDropdownMenu__item:has(.WdsDropdownMenu__item__icon) {
 	grid-template-columns: auto 1fr auto;
 }
@@ -300,6 +310,16 @@ watch(searchTerm, () => emits("search", searchTerm.value));
 	white-space: nowrap;
 	overflow: hidden;
 	text-align: left;
+}
+
+.WdsDropdownMenu__item__label {
+	display: flex;
+	justify-content: space-between;
+	gap: 4px;
+	width: 100%;
+}
+.WdsDropdownMenu__item__label__shortcut {
+	color: var(--wdsColorGray4);
 }
 
 .WdsDropdownMenu__item:has(.WdsDropdownMenu__item__detail) {

--- a/tests/e2e/tests/components.spec.ts
+++ b/tests/e2e/tests/components.spec.ts
@@ -131,10 +131,13 @@ function fullTest({ type, locator }: ComponentTestData) {
 			);
 
 			await page.locator(COMPONENT_LOCATOR).click();
-			await page
-				.locator(
-					'.BuilderSettingsActions .actionButton[data-automation-action="delete"]',
-				)
+
+			const actionDropdown = page
+				.locator(".BuilderSettings")
+				.locator('[data-automation-action="settings-actions-dropdown"]');
+			await actionDropdown.locator("button").click();
+			await actionDropdown
+				.locator('button[data-automation-key="delete"]')
 				.click();
 			await expect(page.locator(COMPONENT_LOCATOR)).not.toBeVisible();
 			await expect(page.locator(COMPONENT_LOCATOR)).toHaveCount(0);
@@ -174,10 +177,12 @@ function basicTest({ type, locator }: ComponentTestData) {
 			);
 
 			await page.locator(COMPONENT_LOCATOR).click();
-			await page
-				.locator(
-					'.BuilderSettingsActions .actionButton[data-automation-action="delete"]',
-				)
+			const actionDropdown = page
+				.locator(".BuilderSettings")
+				.locator('[data-automation-action="settings-actions-dropdown"]');
+			await actionDropdown.locator("button").click();
+			await actionDropdown
+				.locator('button[data-automation-key="delete"]')
 				.click();
 			await expect(page.locator(COMPONENT_LOCATOR)).toHaveCount(0);
 		});

--- a/tests/e2e/tests/reuse.spec.ts
+++ b/tests/e2e/tests/reuse.spec.ts
@@ -75,11 +75,8 @@ test.describe("Reuse component", () => {
 	const removeComponent = async (page: Page, selector: string) => {
 		await page.locator(".CorePage").click();
 		await page.locator(selector).click();
-		await page
-			.locator(
-				'.BuilderSettingsActions .actionButton[data-automation-action="delete"]',
-			)
-			.click();
+		await page.keyboard.press("Delete");
+
 		await expect(page.locator(selector)).not.toBeVisible();
 		await expect(page.locator(selector)).toHaveCount(0);
 	};
@@ -151,7 +148,6 @@ test.describe("Reuse component", () => {
 			await expect(page.locator(COMPONENT_LOCATOR)).toHaveClass(
 				/invalid-context/,
 			);
-			collapseSettingsBar(page);
 		});
 	});
 

--- a/tests/e2e/tests/undoRedo.spec.ts
+++ b/tests/e2e/tests/undoRedo.spec.ts
@@ -69,10 +69,12 @@ test.describe("undo and redo", () => {
 		await expect(page.locator(COMPONENT_LOCATOR)).toHaveText("cool text");
 
 		await page.locator(COMPONENT_LOCATOR).click();
-		await page
-			.locator(
-				'.BuilderSettingsActions .actionButton[data-automation-action="delete"]',
-			)
+		const actionDropdown = page
+			.locator(".BuilderSettings")
+			.locator('[data-automation-action="settings-actions-dropdown"]');
+		await actionDropdown.locator("button").click();
+		await actionDropdown
+			.locator('button[data-automation-key="delete"]')
 			.click();
 		await page.locator('[data-automation-key="undo"]').click();
 		await expect(page.locator(COMPONENT_LOCATOR)).toHaveCount(1);


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/fceb78e1-3bd5-4c0d-84c7-af47f07947ed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dropdown menu in builder settings for additional actions.
  - Introduced a modal dialog for adding child components to the builder.
  - Dropdown actions now display keyboard shortcuts and visually distinguish disabled options.

- **Improvements**
  - Builder settings UI updated for better alignment and spacing using CSS grid and flexbox.
  - Dropdown trigger icons can now be customized.
  - Conditional rendering logic for action buttons streamlined for clarity and reduced complexity.
  - Simplified multiple selection action buttons and delegated action handling to a centralized composable.
  - Enabled multi-selection support for keyboard shortcuts including batch delete, copy, and cut operations.
  - Enhanced component action permissions and operations to support multiple components simultaneously.

- **Bug Fixes**
  - Enhanced end-to-end tests to interact with the new dropdown-based delete action.
  - Simplified test component removal by using keyboard shortcuts instead of UI buttons.

- **Chores**
  - Updated `.gitignore` to exclude files or directories starting with `.aider`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->