### PR TITLE
fix: missing timer cancellation in sync.py for graceful shutdown

### DIFF
--- a/src/writer/sync.py
+++ b/src/writer/sync.py
@@ -419,6 +419,8 @@ class FileBuffering:
         self.running = False
         if self.sync_timer:
             self.sync_timer.cancel()
+        if self.check_timer:
+            self.check_timer.cancel()
         if self.observer:
             self.observer.stop()
             self.observer.join()

--- a/src/writer/sync.py
+++ b/src/writer/sync.py
@@ -419,8 +419,12 @@ class FileBuffering:
         self.running = False
         if self.sync_timer:
             self.sync_timer.cancel()
+            self.sync_timer.join()
+            self.sync_timer = None
         if self.check_timer:
             self.check_timer.cancel()
+            self.check_timer.join()
+            self.check_timer = None
         if self.observer:
             self.observer.stop()
             self.observer.join()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization process to ensure all timers are properly stopped and their threads fully terminated when halting, enhancing reliability and preventing potential background activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->