### PR TITLE
Revert "feat(ui): allow copying multi-select in blueprint - WF-502"

### DIFF
--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -266,23 +266,23 @@ async function handleKeydown(ev: KeyboardEvent) {
 		return;
 	}
 
+	if (!ssbm.isSingleSelectionActive.value || !ssbm.firstSelectedItem.value) {
+		return;
+	}
+
 	const { componentId: selectedId, instancePath: selectedInstancePath } =
 		ssbm.firstSelectedItem.value;
-	const selectedIds = ssbm.selection.value.map((c) => c.componentId);
 
 	if (ev.key == "Delete") {
-		const componentIds = selectedIds.filter((i) => isDeleteAllowed(i));
+		const componentIds = ssbm.selection.value
+			.filter((s) => isDeleteAllowed(s.componentId))
+			.map((s) => s.componentId);
 		removeComponentsSubtree(...componentIds);
 		return;
 	}
 	if (!isModifierKeyActive) return;
 
-	const isMultipeSelection =
-		ssbm.selectionStatus.value === SelectionStatus.Multiple;
-
 	if (ev.shiftKey) {
-		if (isMultipeSelection) return;
-
 		switch (ev.key) {
 			case "ArrowDown":
 				ev.preventDefault();
@@ -307,27 +307,22 @@ async function handleKeydown(ev: KeyboardEvent) {
 	} else {
 		switch (ev.key) {
 			case "ArrowDown":
-				if (isMultipeSelection) return;
 				ev.preventDefault();
 				moveComponentDown(selectedId);
 				break;
 			case "ArrowUp":
-				if (isMultipeSelection) return;
 				ev.preventDefault();
 				moveComponentUp(selectedId);
 				break;
 			case "ArrowLeft":
-				if (isMultipeSelection) return;
 				ev.preventDefault();
 				moveComponentToParent(selectedId);
 				break;
 			case "ArrowRight":
-				if (isMultipeSelection) return;
 				ev.preventDefault();
 				moveComponentInsideNextSibling(selectedId);
 				break;
 			case "v":
-				if (isMultipeSelection) return;
 				if (!isPasteAllowed(selectedId)) return;
 				try {
 					await pasteComponent(selectedId);
@@ -336,11 +331,10 @@ async function handleKeydown(ev: KeyboardEvent) {
 				}
 				break;
 			case "c":
-				if (isCopyAllowed(...selectedIds))
-					copyComponent(...selectedIds);
+				if (isCopyAllowed(selectedId)) copyComponent(selectedId);
 				break;
 			case "x":
-				if (isCutAllowed(...selectedIds)) cutComponent(...selectedIds);
+				if (isCutAllowed(selectedId)) cutComponent(selectedId);
 				break;
 		}
 	}

--- a/src/ui/src/builder/settings/BuilderSettingsActions.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsActions.vue
@@ -13,21 +13,6 @@
 			<i class="material-symbols-outlined">close</i>
 		</WdsButton>
 		<WdsButton
-			v-if="
-				ssbm.selectionStatus.value === SelectionStatus.Multiple &&
-				ssbm.mode.value === 'blueprints'
-			"
-			class="actionButton"
-			variant="neutral"
-			size="small"
-			:data-writer-tooltip="`Copy (${getModifierKeyName()}C)`"
-			data-writer-tooltip-placement="left"
-			:disabled="isCopyDisabled"
-			@click="copySelectedComponents"
-		>
-			<i class="material-symbols-outlined">content_copy</i>
-		</WdsButton>
-		<WdsButton
 			class="BuilderSettingsActions__btn BuilderSettingsActions__btn--delete"
 			variant="neutral"
 			size="small"
@@ -45,7 +30,6 @@
 <script setup lang="ts">
 import { computed, inject } from "vue";
 import injectionKeys from "@/injectionKeys";
-import { getModifierKeyName } from "@/core/detectPlatform";
 import WdsButton from "@/wds/WdsButton.vue";
 import { SelectionStatus } from "../builderManager";
 import { useWriterTracking } from "@/composables/useWriterTracking";
@@ -68,20 +52,10 @@ const { dropdownOptions, handleDropdownSelect } = useBuilderSettingsActions(
 function deleteSelectedComponents() {
 	handleDropdownSelect(BuilderSettingsDropdownActions.Delete);
 }
-function copySelectedComponents() {
-	handleDropdownSelect(BuilderSettingsDropdownActions.Copy);
-}
 
 const isDeleteDisabled = computed(() => {
 	const option = dropdownOptions.value.find(
 		(o) => o.value === BuilderSettingsDropdownActions.Delete,
-	);
-	if (!option) return true;
-	return option.disabled;
-});
-const isCopyDisabled = computed(() => {
-	const option = dropdownOptions.value.find(
-		(o) => o.value === BuilderSettingsDropdownActions.Copy,
 	);
 	if (!option) return true;
 	return option.disabled;

--- a/src/ui/src/builder/settings/useBuilderSettingsActions.ts
+++ b/src/ui/src/builder/settings/useBuilderSettingsActions.ts
@@ -5,7 +5,6 @@ import { getModifierKeyName } from "@/core/detectPlatform";
 import { useWriterTracking } from "@/composables/useWriterTracking";
 import { useToasts } from "../useToast";
 import { Option } from "@/components/shared/SharedMoreDropdown.vue";
-import { SelectionStatus } from "../builderManager";
 
 export enum BuilderSettingsDropdownActions {
 	Add = "add",
@@ -20,7 +19,7 @@ export enum BuilderSettingsDropdownActions {
 
 export function useBuilderSettingsActions(
 	wf: Core,
-	wfbm: BuilderManager,
+	ssbm: BuilderManager,
 	tracking?: ReturnType<typeof useWriterTracking>,
 	callbacks: Partial<Record<BuilderSettingsDropdownActions, () => void>> = {},
 ) {
@@ -39,16 +38,13 @@ export function useBuilderSettingsActions(
 		getEnabledMoves,
 		removeComponentsSubtree,
 		goToParent,
-	} = useComponentActions(wf, wfbm, tracking);
+	} = useComponentActions(wf, ssbm, tracking);
 
 	const toasts = useToasts();
 
-	const selectedId = wfbm.firstSelectedId;
+	const selectedId = ssbm.firstSelectedId;
 	const selectedInstancePath = computed(
-		() => wfbm.firstSelectedItem.value?.instancePath,
-	);
-	const selectedIds = computed(() =>
-		wfbm.selection.value.map((c) => c.componentId),
+		() => ssbm.firstSelectedItem.value?.instancePath,
 	);
 
 	const shortcutsInfo = computed(() => {
@@ -56,16 +52,12 @@ export function useBuilderSettingsActions(
 		if (!component) return {};
 		const { up: isMoveUpEnabled, down: isMoveDownEnabled } =
 			getEnabledMoves(selectedId.value);
-
-		const isMutlipte =
-			wfbm.selectionStatus.value === SelectionStatus.Multiple;
-
 		return {
-			isAddEnabled: !isMutlipte && isAddAllowed(selectedId.value),
+			isAddEnabled: isAddAllowed(selectedId.value),
 			componentTypeName: wf.getComponentDefinition(component.type)?.name,
 			toolkit: wf.getComponentDefinition(component.type)?.toolkit,
-			isMoveUpEnabled: !isMutlipte && isMoveUpEnabled,
-			isMoveDownEnabled: !isMutlipte && isMoveDownEnabled,
+			isMoveUpEnabled,
+			isMoveDownEnabled,
 			isCopyEnabled: isCopyAllowed(selectedId.value),
 			isCutEnabled: isCutAllowed(selectedId.value),
 			isGoToParentEnabled: isGoToParentAllowed(selectedId.value),
@@ -74,8 +66,8 @@ export function useBuilderSettingsActions(
 	});
 
 	const isPasteEnabled = computed(() => {
-		if (!wfbm.firstSelectedId.value) return false;
-		return isPasteAllowed(wfbm.firstSelectedId.value);
+		if (!ssbm.firstSelectedId.value) return false;
+		return isPasteAllowed(ssbm.firstSelectedId.value);
 	});
 
 	async function handlePasteComponent() {
@@ -88,7 +80,7 @@ export function useBuilderSettingsActions(
 
 	function deleteSelectedComponents() {
 		if (!shortcutsInfo.value.isDeleteEnabled) return;
-		const componentIds = wfbm.selection.value.map((c) => c.componentId);
+		const componentIds = ssbm.selection.value.map((c) => c.componentId);
 		if (componentIds.length === 0) return;
 		removeComponentsSubtree(...componentIds);
 	}
@@ -156,14 +148,8 @@ export function useBuilderSettingsActions(
 		return options;
 	});
 
-	function handleDropdownSelect(action: BuilderSettingsDropdownActions) {
-		const dropdownOption = dropdownOptions.value.find(
-			(o) => o.value === action,
-		);
-
-		if (!dropdownOption || dropdownOption?.disabled) return;
-
-		switch (action) {
+	function handleDropdownSelect(selected: BuilderSettingsDropdownActions) {
+		switch (selected) {
 			case BuilderSettingsDropdownActions.Add:
 				// Handled by callback
 				break;
@@ -174,10 +160,10 @@ export function useBuilderSettingsActions(
 				moveComponentDown(selectedId.value);
 				break;
 			case BuilderSettingsDropdownActions.Cut:
-				cutComponent(...selectedIds.value);
+				cutComponent(selectedId.value);
 				break;
 			case BuilderSettingsDropdownActions.Copy:
-				copyComponent(...selectedIds.value);
+				copyComponent(selectedId.value);
 				break;
 			case BuilderSettingsDropdownActions.Paste:
 				handlePasteComponent();
@@ -190,7 +176,7 @@ export function useBuilderSettingsActions(
 				break;
 		}
 
-		callbacks[action]?.();
+		callbacks[selected]?.();
 	}
 
 	return {

--- a/src/ui/src/builder/useComponentActions.ts
+++ b/src/ui/src/builder/useComponentActions.ts
@@ -373,39 +373,24 @@ export function useComponentActions(
 	/**
 	 * Whether a component can be copied into the clipboard.
 	 */
-	function isCopyAllowed(...targetIds: Component["id"][]): boolean {
-		if (targetIds.length === 0) return false;
-		if (targetIds.length > 1 && ssbm.mode.value !== "blueprints")
-			return false;
-		return !targetIds.some(isRoot);
+	function isCopyAllowed(targetId: Component["id"]): boolean {
+		return !isRoot(targetId);
 	}
 
 	/**
 	 * Whether a component can be cut and placed in the clipboard.
 	 */
-	function isCutAllowed(...targetIds: Component["id"][]): boolean {
-		if (targetIds.length === 0) return false;
-		if (targetIds.length > 1 && ssbm.mode.value !== "blueprints")
-			return false;
-
-		for (const targetId of targetIds) {
-			const component = wf.getComponentById(targetId);
-			const isAllowed = !isRoot(targetId) && !component?.isCodeManaged;
-			if (!isAllowed) return false;
-		}
-		return true;
+	function isCutAllowed(targetId: Component["id"]): boolean {
+		const component = wf.getComponentById(targetId);
+		return !isRoot(targetId) && !component?.isCodeManaged;
 	}
 
 	/**
 	 * Whether a component can be deleted.
 	 */
-	function isDeleteAllowed(...targetIds: Component["id"][]): boolean {
-		for (const targetId of targetIds) {
-			const component = wf.getComponentById(targetId);
-			const isAllowed = !isRoot(targetId) && !component?.isCodeManaged;
-			if (!isAllowed) return false;
-		}
-		return true;
+	function isDeleteAllowed(targetId: Component["id"]): boolean {
+		const component = wf.getComponentById(targetId);
+		return !isRoot(targetId) && !component?.isCodeManaged;
 	}
 
 	/** Whether it's possible to go to (select) a component's parent. */
@@ -587,10 +572,13 @@ export function useComponentActions(
 	 * Cuts a component and its descendents and places them in the internal clipboard.
 	 * @param componentId Id of the component to be cut
 	 */
-	function cutComponent(...componentIds: Component["id"][]): void {
-		copyComponent(...componentIds);
+	function cutComponent(componentId: Component["id"]): void {
+		const component = wf.getComponentById(componentId);
+		if (!component) return;
+		const components = getFlatComponentSubtree(componentId);
+		componentClipboard.set(components);
 		ssbm.setSelection(null);
-		removeComponentsSubtree(...componentIds);
+		removeComponentSubtree(componentId);
 		wf.sendComponentUpdate();
 	}
 
@@ -631,14 +619,12 @@ export function useComponentActions(
 	 * @param componentId Id of the component to be copied
 	 * @returns
 	 */
-	function copyComponent(...componentIds: Component["id"][]): void {
-		const components = componentIds.flatMap((componentId) => {
-			const component = wf.getComponentById(componentId);
-			if (!component) return;
-			const subtree = getFlatComponentSubtree(componentId);
-			return getNewSubtreeWithRegeneratedIds(subtree);
-		});
-		componentClipboard.set(components);
+	function copyComponent(componentId: Component["id"]): void {
+		const component = wf.getComponentById(componentId);
+		if (!component) return;
+		const subtree = getFlatComponentSubtree(componentId);
+		const newSubtree = getNewSubtreeWithRegeneratedIds(subtree);
+		componentClipboard.set(newSubtree);
 	}
 
 	/**


### PR DESCRIPTION
This reverts commit 171d18324302490ecf342fbe972f1888fac9aad8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Actions such as add, move, cut, copy, and delete can now be performed regardless of how many components are selected.
- **Bug Fixes**
	- Resolved issues where certain actions were previously disabled when multiple components were selected.
- **Refactor**
	- Simplified selection and action logic to focus on single component operations, streamlining the user experience.
- **Style**
	- Removed the "Copy" button from the settings actions when multiple items are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->