### PR TITLE
feat(ui): autocomplete `@` instead of `@{` - WF-577

### DIFF
--- a/src/ui/src/builder/settings/BuilderTemplateInput.spec.ts
+++ b/src/ui/src/builder/settings/BuilderTemplateInput.spec.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, it, expect } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import BuilderTemplateInput from "./BuilderTemplateInput.vue";
+import { buildMockCore, buildMockSecretsManager } from "@/tests/mocks";
+import injectionKeys from "@/injectionKeys";
+import { ExtractPropTypes } from "vue";
+
+describe("BuilderTemplateInput", () => {
+	let mockCore: ReturnType<typeof buildMockCore>;
+	let mockSecretManager: ReturnType<typeof buildMockSecretsManager>;
+
+	beforeEach(() => {
+		mockCore = buildMockCore();
+		mockSecretManager = buildMockSecretsManager(mockCore.core);
+		mockCore.userState.value = {
+			obj: {
+				a: 1,
+				b: 1,
+			},
+			text: "foo",
+			array: ["a", "b", "c"],
+		};
+	});
+
+	function mountWrapper(
+		props: ExtractPropTypes<typeof BuilderTemplateInput> = {
+			type: "template",
+			value: "",
+		},
+	) {
+		return mount(BuilderTemplateInput, {
+			props,
+			global: {
+				provide: {
+					[injectionKeys.core]: mockCore.core,
+					[injectionKeys.secretsManager]:
+						mockSecretManager.secretsManager,
+				},
+				directives: {
+					"capture-tabs": {},
+				},
+			},
+		});
+	}
+
+	describe("in template mode", () => {
+		it.each(["@", "@{"])('should autocomplete with "%s"', async (input) => {
+			const wrapper = mountWrapper();
+
+			await wrapper.get("input").setValue(input);
+
+			const options = wrapper
+				.get(".fieldStateAutocomplete")
+				.findAll(".fieldStateAutocompleteOption");
+
+			expect(options).toHaveLength(5);
+			expect(options.at(0).get(".prop").text()).toBe("array");
+			expect(options.at(0).get(".type").text()).toBe("object");
+			expect(options.at(1).get(".prop").text()).toBe("obj");
+			expect(options.at(1).get(".type").text()).toBe("object");
+			expect(options.at(2).get(".prop").text()).toBe("obj.a");
+			expect(options.at(2).get(".type").text()).toBe("number");
+			expect(options.at(3).get(".prop").text()).toBe("obj.b");
+			expect(options.at(4).get(".prop").text()).toBe("text");
+			expect(options.at(4).get(".type").text()).toBe("string");
+
+			await options.at(0).trigger("click");
+
+			await flushPromises();
+
+			expect(wrapper.emitted("update:value").at(-1)).toStrictEqual([
+				"@{array}",
+			]);
+		});
+
+		it("should autocomplete an array items", async () => {
+			const wrapper = mountWrapper();
+
+			await wrapper.get("input").setValue("@{array.");
+
+			const options = wrapper
+				.get(".fieldStateAutocomplete")
+				.findAll(".fieldStateAutocompleteOption");
+
+			expect(options).toHaveLength(3);
+			expect(options.at(0).get(".prop").text()).toBe("0");
+			expect(options.at(1).get(".prop").text()).toBe("1");
+			expect(options.at(2).get(".prop").text()).toBe("2");
+
+			await options.at(0).trigger("click");
+
+			await flushPromises();
+
+			expect(wrapper.emitted("update:value").at(-1)).toStrictEqual([
+				"@{array.0}",
+			]);
+		});
+
+		it("should autocomplete object items", async () => {
+			const wrapper = mountWrapper();
+
+			await wrapper.get("input").setValue("@{obj.");
+
+			const options = wrapper
+				.get(".fieldStateAutocomplete")
+				.findAll(".fieldStateAutocompleteOption");
+
+			expect(options).toHaveLength(2);
+			expect(options.at(0).get(".prop").text()).toBe("a");
+			expect(options.at(1).get(".prop").text()).toBe("b");
+
+			await options.at(0).trigger("click");
+
+			await flushPromises();
+
+			expect(wrapper.emitted("update:value").at(-1)).toStrictEqual([
+				"@{obj.a}",
+			]);
+		});
+
+		it("should autocomplete with templating", async () => {
+			const wrapper = mountWrapper();
+
+			await wrapper.get("input").setValue("foo @{tex");
+
+			const options = wrapper
+				.get(".fieldStateAutocomplete")
+				.findAll(".fieldStateAutocompleteOption");
+
+			expect(options).toHaveLength(1);
+			expect(options.at(0).get(".prop").text()).toBe("text");
+
+			await options.at(0).trigger("click");
+
+			await flushPromises();
+
+			expect(wrapper.emitted("update:value").at(-1)).toStrictEqual([
+				"foo @{text}",
+			]);
+		});
+
+		it("should autocomplete vault", async () => {
+			mockSecretManager.secrets.value = {
+				GOOGLE_API_KEY: "foo",
+			};
+			const wrapper = mountWrapper();
+
+			await wrapper.get("input").setValue("@{vault.");
+
+			const options = wrapper
+				.get(".fieldStateAutocomplete")
+				.findAll(".fieldStateAutocompleteOption");
+
+			expect(options).toHaveLength(1);
+			expect(options.at(0).get(".prop").text()).toBe("GOOGLE_API_KEY");
+			expect(options.at(0).get(".type").text()).toBe("string");
+
+			await options.at(0).trigger("click");
+
+			await flushPromises();
+
+			expect(wrapper.emitted("update:value").at(-1)).toStrictEqual([
+				"@{vault.GOOGLE_API_KEY}",
+			]);
+		});
+
+		it("should not autocomplete vault when empty", async () => {
+			mockSecretManager.secrets.value = {};
+			const wrapper = mountWrapper();
+
+			await wrapper.get("input").setValue("@{vault.");
+
+			expect(
+				wrapper.find(".fieldStateAutocomplete").exists(),
+			).toBeFalsy();
+		});
+	});
+
+	describe("in state mode", () => {
+		it("should autocomplete an array items", async () => {
+			const wrapper = mountWrapper({
+				type: "state",
+				value: "",
+			});
+
+			await wrapper.get("input").setValue("array.");
+
+			const options = wrapper
+				.get(".fieldStateAutocomplete")
+				.findAll(".fieldStateAutocompleteOption");
+
+			expect(options).toHaveLength(3);
+			expect(options.at(0).get(".prop").text()).toBe("0");
+			expect(options.at(1).get(".prop").text()).toBe("1");
+			expect(options.at(2).get(".prop").text()).toBe("2");
+
+			await options.at(0).trigger("click");
+
+			await flushPromises();
+
+			expect(wrapper.emitted("update:value").at(-1)).toStrictEqual([
+				"array.0",
+			]);
+		});
+
+		it("should autocomplete object items", async () => {
+			const wrapper = mountWrapper({
+				type: "state",
+				value: "",
+			});
+
+			await wrapper.get("input").setValue("obj.");
+
+			const options = wrapper
+				.get(".fieldStateAutocomplete")
+				.findAll(".fieldStateAutocompleteOption");
+
+			expect(options).toHaveLength(2);
+			expect(options.at(0).get(".prop").text()).toBe("a");
+			expect(options.at(1).get(".prop").text()).toBe("b");
+
+			await options.at(0).trigger("click");
+
+			await flushPromises();
+
+			expect(wrapper.emitted("update:value").at(-1)).toStrictEqual([
+				"obj.a",
+			]);
+		});
+
+		it("should not autocomplete vault", async () => {
+			mockSecretManager.secrets.value = {
+				GOOGLE_API_KEY: "foo",
+			};
+			const wrapper = mountWrapper();
+
+			await wrapper.get("input").setValue("vault.");
+
+			expect(
+				wrapper.find(".fieldStateAutocomplete").exists(),
+			).toBeFalsy();
+		});
+	});
+});

--- a/src/ui/src/builder/settings/BuilderTemplateInput.vue
+++ b/src/ui/src/builder/settings/BuilderTemplateInput.vue
@@ -178,13 +178,17 @@ function handleComplete(selectedText: string) {
 	let newValue = input.value?.value ?? "";
 	const { selectionStart, selectionEnd } = input.value?.getSelection() ?? {};
 	const text = newValue.slice(0, selectionStart);
-	const full = getPath(text);
-	if (full === null) return;
-	const keyword = full.at(-1);
+	const path = getPath(text);
+	if (path === undefined) return;
+	const keyword = path.at(-1);
 	const regexKeyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "$"; // escape the keyword to handle properly on a regex
+
+	const replacePrefix =
+		props.type === "template" && /@\{[^}]*$/.exec(text) === null ? "{" : "";
+
 	const replaced = text.replace(
 		new RegExp(regexKeyword),
-		`${selectedText}${props.type === "template" ? "}" : ""}`,
+		`${replacePrefix}${selectedText}${props.type === "template" ? "}" : ""}`,
 	);
 	const afterText = newValue.slice(selectionEnd).replace(/^(\})+/, ""); // merge the closing bracket to avoid duplicates
 	newValue = replaced.concat(afterText);
@@ -208,12 +212,15 @@ function getPath(text: string) {
 	if ((props.type ?? "template") === "state") {
 		return text.split(".");
 	}
-	const m = text.match(/@\{([^}{@]*)$/);
-	if (!m) {
-		return null;
+
+	// support autocompletion for `@{` and `@`
+	for (const re of [/@\{([^}{@]*)$/, /@([^@]*)$/]) {
+		const m = text.match(re);
+		if (m) {
+			const raw = m?.[1] ?? "";
+			return raw.split(".");
+		}
 	}
-	const raw = m?.[1] ?? "";
-	return raw.split(".");
 }
 
 /**
@@ -236,7 +243,13 @@ const autoCompletionState = computed(() => {
 		...(wf.userState.value ?? {}),
 	};
 
-	if (secrets.value) state.vault = secrets.value;
+	if (
+		props.type === "template" &&
+		secrets.value &&
+		Object.values(secrets.value).length > 0
+	) {
+		state.vault = secrets.value;
+	}
 
 	return state;
 });
@@ -251,7 +264,7 @@ function showAutocomplete() {
 	}
 	const text = newValue.slice(0, selectionStart);
 	const full = getPath(text);
-	if (full === null) {
+	if (full === undefined) {
 		autocompleteOptions.value = [];
 		return;
 	}

--- a/src/ui/src/renderer/useFieldsErrors.ts
+++ b/src/ui/src/renderer/useFieldsErrors.ts
@@ -33,6 +33,7 @@ export function useFieldsErrors(
 	});
 
 	const componentFields = computed(() => {
+		if (!component.value?.type) return {};
 		return wf.getComponentDefinition(component.value.type).fields ?? {};
 	});
 

--- a/src/ui/src/tests/mocks.ts
+++ b/src/ui/src/tests/mocks.ts
@@ -1,10 +1,16 @@
 import { generateCore } from "@/core";
 import injectionKeys from "@/injectionKeys";
 import { flattenInstancePath } from "@/renderer/instancePath";
-import type { Component, InstancePath, UserFunction } from "@/writerTypes";
+import type {
+	Component,
+	Core,
+	InstancePath,
+	UserFunction,
+} from "@/writerTypes";
 import { vi } from "vitest";
 import { computed, ref, shallowRef } from "vue";
 import { SourceFiles } from "../writerTypes";
+import { useSecretsManager } from "@/core/useSecretsManager";
 
 export const mockComponentId = "component-id-test";
 
@@ -66,6 +72,20 @@ export function buildMockCore() {
 		userFunctions,
 		featureFlags,
 		writerApplication,
+	};
+}
+
+export function buildMockSecretsManager(core: Core) {
+	const secretsManager = useSecretsManager(core);
+	const secrets = shallowRef<Record<string, string>>({});
+
+	secretsManager.secrets = secrets;
+
+	vi.spyOn(secretsManager, "load").mockImplementation(async () => {});
+
+	return {
+		secretsManager,
+		secrets,
 	};
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved autocomplete behavior in template input fields, including enhanced handling of triggers and bracket insertion for template expressions.
- **Bug Fixes**
  - Resolved an issue where errors could occur if a component type was missing during field validation.
- **Tests**
  - Added comprehensive tests for the template input component, covering autocomplete scenarios and user interactions.
- **Chores**
  - Introduced a utility to mock the secrets manager for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->