### PR TITLE
fix(ui): allow `CorePDF` to loads from URL - WF-616

### DIFF
--- a/src/ui/src/components/core/embed/CorePDF.vue
+++ b/src/ui/src/components/core/embed/CorePDF.vue
@@ -111,7 +111,7 @@ import "@tato30/vue-pdf/style.css";
 
 type MatchType = { str: string; page: number; index: number };
 
-const fields = inject(injectionKeys.evaluatedFields);
+const fields = inject(injectionKeys.evaluatedFields, {});
 
 let pdf, pages, VuePDF;
 
@@ -146,10 +146,17 @@ const pdfData = computed(() => {
 	}
 });
 
-const pdfSource = computed<PDFSrc>(() => ({
-	data: pdfData.value, // convert source to binary data to avoid fetching DataURL (which is forbidden by some CSP rules)
-	isEvalSupported: false,
-}));
+const pdfSource = computed<PDFSrc>(() => {
+	return pdfData.value === undefined
+		? {
+				url: fields.source.value,
+				isEvalSupported: false,
+			}
+		: {
+				data: pdfData.value, // convert source to binary data to avoid fetching DataURL (which is forbidden by some CSP rules)
+				isEvalSupported: false,
+			};
+});
 
 onMounted(async () => {
 	// @ts-expect-error usage of Vite env


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fa07b21d-0ebe-4959-8df6-f6f37b74f1d9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or undefined PDF data, ensuring the PDF viewer works reliably whether loading from a URL or binary data.
  * Enhanced stability by providing a default value for injected fields, preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->