### PR TITLE
fix(blueprints): icon and status name for stopped nodes

### DIFF
--- a/src/ui/src/builder/panels/BuilderLogBlueprintExecution.vue
+++ b/src/ui/src/builder/panels/BuilderLogBlueprintExecution.vue
@@ -150,7 +150,7 @@ const outcomeSeverity = {
 	in_progress: 5,
 	error: 4,
 	success: 3,
-	cancelled: 2,
+	stopped: 2,
 	skipped: 1,
 	none: 0,
 };

--- a/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
+++ b/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
@@ -8,7 +8,7 @@
 			'BlueprintsNode--running': completionStyle == 'running',
 			'BlueprintsNode--success': completionStyle == 'success',
 			'BlueprintsNode--skipped': completionStyle == 'skipped',
-			'BlueprintsNode--cancelled': completionStyle == 'cancelled',
+			'BlueprintsNode--stopped': completionStyle == 'stopped',
 			'BlueprintsNode--error': completionStyle == 'error',
 		}"
 	>
@@ -137,7 +137,7 @@ const isDeprecated = computed(() => {
 const completionStyle = computed(() => {
 	if (latestKnownOutcome.value == null) return null;
 	if (latestKnownOutcome.value == "skipped") return "skipped";
-	if (latestKnownOutcome.value == "cancelled") return "cancelled";
+	if (latestKnownOutcome.value == "stopped") return "stopped";
 	if (latestKnownOutcome.value == "in_progress") return "running";
 
 	// Any dynamic out is considered success
@@ -162,7 +162,7 @@ const outcomeSeverity = {
 	in_progress: 5,
 	error: 4,
 	success: 3,
-	cancelled: 2,
+	stopped: 2,
 	skipped: 1,
 	none: 0,
 };
@@ -289,7 +289,7 @@ function handleOutMousedown(ev: DragEvent, outId: string | number) {
 
 const possibleImageUrls = computed(() => {
 	if (
-		["success", "error", "skipped", "cancelled"].includes(
+		["success", "error", "skipped", "stopped"].includes(
 			completionStyle.value,
 		)
 	) {
@@ -332,7 +332,7 @@ watch(isEngaged, () => {
 	background: var(--wdsColorGray3) !important;
 }
 
-.BlueprintsNode--cancelled {
+.BlueprintsNode--stopped {
 	background: var(--wdsColorGray3) !important;
 }
 

--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -352,7 +352,7 @@ class GraphNode:
         try:
             tool.outcome = "in_progress"
             tool.run()
-            if self.outcome == "cancelled":
+            if self.outcome == "stopped":
                 return self
             tool.outcome = tool.outcome or "success"
         except BlueprintExecutionError as e:
@@ -631,7 +631,7 @@ class StatusLogger:
                         "executionTimeInSeconds": 0,
                     })
                     continue
-            if node.outcome == "cancelled":
+            if node.outcome == "stopped":
                 exec_log.summary.append(
                     {
                         "componentId": node.id,
@@ -758,9 +758,9 @@ class GraphRunner:
                     self._cancel_all_jobs()
                     self.status_logger.log("Execution failed.", entry_type="error", exit=str(e))
                     raise BlueprintExecutionError(
-                        f"Blueprint execution was cancelled due to an error - {e.__class__.__name__}: {e}"
+                        f"Blueprint execution was stopped due to an error - {e.__class__.__name__}: {e}"
                     ) from e 
-                if result_node.outcome == "cancelled":
+                if result_node.outcome == "stopped":
                     continue 
                 if result_node.return_value is not None:
                     abort_event.set()
@@ -787,8 +787,8 @@ class GraphRunner:
                 future.cancel()
         for node in self.graph.nodes:
             if node.outcome == "in_progress":
-                node.status = "cancelled"
-        self.status_logger.log("Cancelled")
+                node.status = "stopped"
+        self.status_logger.log("Stopped")
         self.runner.cancel_blueprint_execution(self.run_id)
 
     def _generate_run_id(self):

--- a/tests/backend/test_blueprints.py
+++ b/tests/backend/test_blueprints.py
@@ -266,7 +266,7 @@ class TestErrorHandling:
         try:
             run_graph(graph)
         except Exception as e:
-            assert str(e) == "Blueprint execution was cancelled due to an error - Exception: Error"
+            assert str(e) == "Blueprint execution was stopped due to an error - Exception: Error"
         else:
             assert False, "Expected an exception to be raised"
 
@@ -316,7 +316,7 @@ class TestErrorHandling:
         with pytest.raises(Exception) as exc_info:
            call_graph({})
         assert type(exc_info.value).__name__ == "BlueprintExecutionError"
-        assert str(exc_info.value) == "Blueprint execution was cancelled due to an error - RuntimeError: Maximum call depth ({0}) exceeded. Check that you don't have any unintended circular references.".format(MAX_DAG_DEPTH)
+        assert str(exc_info.value) == "Blueprint execution was stopped due to an error - RuntimeError: Maximum call depth ({0}) exceeded. Check that you don't have any unintended circular references.".format(MAX_DAG_DEPTH)
 
 
 class TestComplexGraphs:
@@ -541,7 +541,7 @@ class TestCancellation:
 
     #    node = graph.get_node("N1")
     #    assert node is not None
-    #    assert node.outcome == "cancelled"
+    #    assert node.outcome == "stopped"
 
     def test_cancel_nodes_on_error(self):
         runner = MockRunner()
@@ -566,7 +566,7 @@ class TestCancellation:
         node2 = graph.get_node("N2")
         
         assert node1 is not None
-        assert node1.outcome == "cancelled"
+        assert node1.outcome == "stopped"
         
         assert node2 is not None
         assert node2.outcome == "error"
@@ -602,7 +602,7 @@ class TestCancellation:
 
         node = nested_graph.get_node("nested")
         assert node is not None
-        assert node.outcome == "cancelled"
+        assert node.outcome == "stopped"
 
     def test_cancelation_on_nested_workflows_error(self):
         runner = MockRunner()
@@ -631,7 +631,7 @@ class TestCancellation:
 
         node = graph.get_node("N1")
         assert node is not None
-        assert node.outcome == "cancelled"
+        assert node.outcome == "stopped"
     def test_nested_cancel(self):
         runner = MockRunner()
         event = Event()
@@ -664,6 +664,6 @@ class TestCancellation:
         node = graph.get_node("N1")
         nested = nested_graph.get_node("nested")
         assert node is not None
-        assert node.outcome == "cancelled"
+        assert node.outcome == "stopped"
         assert nested is not None
-        assert nested.outcome == "cancelled"
+        assert nested.outcome == "stopped"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated all user-facing references of the status "cancelled" to "stopped" throughout the application, including labels, status messages, and icons.

* **Tests**
  * Adjusted test cases to expect the outcome "stopped" instead of "cancelled" for relevant scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->