### PR TITLE
fix: state should update immediately after stopping blueprint

### DIFF
--- a/src/ui/public/status/stopped.svg
+++ b/src/ui/public/status/stopped.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect y="0" width="24" height="24" rx="4" fill="#E4E7ED"/>
+<path d="M16.6667 6.5H7.33333C6.59695 6.5 6 7.09695 6 7.83333V17.1667C6 17.903 6.59695 18.5 7.33333 18.5H16.6667C17.403 18.5 18 17.903 18 17.1667V7.83333C18 7.09695 17.403 6.5 16.6667 6.5Z" stroke="#828282" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -782,13 +782,13 @@ class GraphRunner:
 
     def _cancel_all_jobs(self):
         self.queue.clear()
-        for future in self.futures:
-            if not future.done():
-                future.cancel()
         for node in self.graph.nodes:
             if node.outcome == "in_progress":
                 node.status = "stopped"
         self.status_logger.log("Stopped")
+        for future in self.futures:
+            if not future.done():
+                future.cancel()
         self.runner.cancel_blueprint_execution(self.run_id)
 
     def _generate_run_id(self):

--- a/tests/backend/test_blueprints.py
+++ b/tests/backend/test_blueprints.py
@@ -520,28 +520,26 @@ class TestBranchExecution:
 class TestCancellation:
     """Tests for execution cancellation scenarios"""
     
-    #def test_cancellation_simple(self):
-    #    runner = MockRunner()
-    #    event = Event()
+    def test_cancellation_simple(self):
+      runner = MockRunner()
+      event = Event()
 
-    #    graph  = GraphBuilder(components=[
-    #        create_component("N1", fields={
-    #            "event": event 
-    #        }),
-    #    ], tools=tools).build()
-    #    
-    #    with runner._get_executor() as executor:
-    #        future = run_graph_async(executor, graph, {"blueprint_run_id": "test"}, runner)
-    #        wait([future], timeout=0.1)
-    #        runner.cancel_blueprint_execution("test")
-    #        wait([future], timeout=0.1)
-
-    #        event.set()
-    #        wait([future], timeout=0.1)
-
-    #    node = graph.get_node("N1")
-    #    assert node is not None
-    #    assert node.outcome == "stopped"
+      graph  = GraphBuilder(components=[
+          create_component("N1", fields={
+              "event": event 
+          }),
+      ], tools=tools).build()
+      
+      with runner._get_executor() as executor:
+          future = run_graph_async(executor, graph, {"blueprint_run_id": "test"}, runner)
+          wait([future], timeout=0.1)
+          runner.cancel_blueprint_execution("test")
+          wait([future], timeout=0.1)
+          event.set()
+          wait([future], timeout=0.1)
+      node = graph.get_node("N1")
+      assert node is not None
+      assert node.outcome == "stopped"
 
     def test_cancel_nodes_on_error(self):
         runner = MockRunner()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the cancellation process to ensure node statuses are updated and logged correctly when stopping execution.

* **Tests**
  * Reactivated and updated a test to verify that cancelled executions properly mark nodes as "stopped".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->