### PR TITLE
Dropdwon UX Improvements

### DIFF
--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -273,7 +273,7 @@ async function handleKeydown(ev: KeyboardEvent) {
 	const { componentId: selectedId, instancePath: selectedInstancePath } =
 		ssbm.firstSelectedItem.value;
 
-	if (ev.key == "Delete") {
+	if (ev.key == (isPlatformMac() ? "Backspace" : "Delete")) {
 		const componentIds = ssbm.selection.value
 			.filter((s) => isDeleteAllowed(s.componentId))
 			.map((s) => s.componentId);

--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -253,7 +253,7 @@ async function handleKeydown(ev: KeyboardEvent) {
 
 	const isModifierKeyActive = isPlatformMac() ? ev.metaKey : ev.ctrlKey;
 	const targetEl = ev.target as HTMLElement;
-	if (targetEl.closest("textarea, input, select")) return;
+	if (targetEl.closest("textarea, input, select, [contenteditable]")) return;
 
 	if (ev.key == "z" && isModifierKeyActive) {
 		ev.preventDefault();

--- a/src/ui/src/builder/settings/useBuilderSettingsActions.ts
+++ b/src/ui/src/builder/settings/useBuilderSettingsActions.ts
@@ -1,7 +1,7 @@
 import { computed } from "vue";
 import { useComponentActions } from "../useComponentActions";
 import { Core, BuilderManager } from "@/writerTypes";
-import { getModifierKeyName } from "@/core/detectPlatform";
+import { getModifierKeyName, isPlatformMac } from "@/core/detectPlatform";
 import { useWriterTracking } from "@/composables/useWriterTracking";
 import { useToasts } from "../useToast";
 import { Option } from "@/components/shared/SharedMoreDropdown.vue";
@@ -130,7 +130,7 @@ export function useBuilderSettingsActions(
 			},
 			{
 				value: BuilderSettingsDropdownActions.GoToParent,
-				label: `Go to parent`,
+				label: `View parent`,
 				shortcut: `${getModifierKeyName()}⇧↑`,
 				icon: "move_up",
 				disabled: !shortcutsInfo.value.isGoToParentEnabled,
@@ -138,7 +138,7 @@ export function useBuilderSettingsActions(
 			{
 				value: BuilderSettingsDropdownActions.Delete,
 				label: "Delete",
-				shortcut: "Del",
+				shortcut: isPlatformMac() ? "⌫" : "Del",
 				icon: "delete",
 				variant: "danger",
 				disabled: !shortcutsInfo.value.isDeleteEnabled,

--- a/src/ui/src/components/shared/SharedMoreDropdown.vue
+++ b/src/ui/src/components/shared/SharedMoreDropdown.vue
@@ -111,6 +111,6 @@ function onSelect(value: string) {
 	position: relative;
 }
 .BuilderMoreDropdown__dropdown {
-	min-width: 150px;
+	min-width: 180px;
 }
 </style>


### PR DESCRIPTION
- Changed OSX keybind from `Fn + Backspace` (Delete) to `Backspace`, a more widely used convention
- UI copy changes to dropdown
- Dropdown menu size increase

Before:
<img width="168" alt="Screenshot 2025-07-01 at 1 18 44 PM" src="https://github.com/user-attachments/assets/c8df8893-7c23-4a2b-9233-a203a91e52f3" />


After:
<img width="199" alt="Screenshot 2025-07-01 at 1 18 05 PM" src="https://github.com/user-attachments/assets/4ba2e5e4-8f5b-43fb-a172-d3b035a8f0e3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved keyboard shortcut handling for deletion, adapting to Mac and non-Mac platforms for a more intuitive experience.
  * Updated the label for the "Go to parent" action to "View parent" in builder settings.
  * Shortcut key display for the "Delete" action now shows the appropriate symbol for Mac users.
  * Increased the minimum width of dropdown menus for better visibility.
  * Disabled keyboard shortcuts when editing content in editable areas for smoother text input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->