### PR TITLE
fix: remove empty folders

### DIFF
--- a/src/ui/src/core/sourceFiles.spec.ts
+++ b/src/ui/src/core/sourceFiles.spec.ts
@@ -194,10 +194,6 @@ describe(moveFileToSourceFiles.name, () => {
 		expect(result).toStrictEqual({
 			type: "directory",
 			children: {
-				a: {
-					type: "directory",
-					children: {},
-				},
 				b: {
 					type: "directory",
 					children: {
@@ -235,10 +231,6 @@ describe(moveFileToSourceFiles.name, () => {
 		expect(result).toStrictEqual({
 			type: "directory",
 			children: {
-				a: {
-					type: "directory",
-					children: {},
-				},
 				b: {
 					type: "directory",
 					children: {
@@ -274,12 +266,7 @@ describe(deleteFileToSourceFiles.name, () => {
 
 		expect(result).toStrictEqual({
 			type: "directory",
-			children: {
-				a: {
-					type: "directory",
-					children: {},
-				},
-			},
+			children: {},
 		});
 	});
 
@@ -296,5 +283,97 @@ describe(deleteFileToSourceFiles.name, () => {
 		const result = deleteFileToSourceFiles(["x", "y"], initial);
 
 		expect(result).toStrictEqual(initial);
+	});
+
+	const initialComplex: SourceFiles = {
+		type: "directory",
+		children: {
+			a1: {
+				type: "directory",
+				children: {
+					a2: {
+						type: "directory",
+						children: {
+							a3: {
+								type: "directory",
+								children: {
+									"a4.txt": {
+										type: "file",
+										content: "",
+										complete: true,
+									},
+								},
+							},
+						},
+					},
+					"a2.txt": {
+						type: "file",
+						content: "",
+						complete: true,
+					},
+				},
+			},
+			b1: {
+				type: "directory",
+				children: {
+					"b2.txt": {
+						type: "file",
+						content: "",
+						complete: true,
+					},
+				},
+			},
+		},
+	};
+
+	it("should delete the file and empty folders", () => {
+		const result = deleteFileToSourceFiles(
+			["a1", "a2", "a3"],
+			initialComplex,
+		);
+
+		expect(result).toStrictEqual({
+			type: "directory",
+			children: {
+				a1: {
+					type: "directory",
+					children: {
+						"a2.txt": {
+							type: "file",
+							content: "",
+							complete: true,
+						},
+					},
+				},
+				b1: {
+					type: "directory",
+					children: {
+						"b2.txt": {
+							type: "file",
+							content: "",
+							complete: true,
+						},
+					},
+				},
+			},
+		});
+
+		expect(deleteFileToSourceFiles(["a1", "a2.txt"], result)).toStrictEqual(
+			{
+				type: "directory",
+				children: {
+					b1: {
+						type: "directory",
+						children: {
+							"b2.txt": {
+								type: "file",
+								content: "",
+								complete: true,
+							},
+						},
+					},
+				},
+			},
+		);
 	});
 });

--- a/src/ui/src/core/sourceFiles.ts
+++ b/src/ui/src/core/sourceFiles.ts
@@ -140,24 +140,26 @@ export function moveFileToSourceFiles(
 }
 
 export function deleteFileToSourceFiles(path: string[], tree: SourceFiles) {
-	const copy = structuredClone(tree);
-	let node = copy;
+	return deleteFile(path, structuredClone(tree));
+}
 
-	for (let i = 0; i < path.length; i++) {
-		if (!isSourceFilesDirectory(node)) return copy;
+function deleteFile(path: string[], tree: SourceFiles) {
+	if (!isSourceFilesDirectory(tree)) return tree;
 
-		const key = path.at(i);
+	if (!(path.at(0) in tree.children)) return tree;
 
-		if (!(key in node.children)) return copy;
-
-		if (i === path.length - 1) {
-			delete node.children[key];
-			return copy;
-		} else {
-			node.children[key] ??= { type: "directory", children: {} };
-			node = node.children[key];
-		}
+	if (path.length === 1) {
+		delete tree.children[path.at(0)];
+		return tree;
 	}
 
-	return copy;
+	const child = deleteFile(path.slice(1), tree.children[path.at(0)]);
+
+	if (
+		child.type === "directory" &&
+		Object.keys(child.children).length === 0
+	) {
+		delete tree.children[path.at(0)];
+	}
+	return tree;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the file deletion process to automatically remove empty directories after file or directory deletions, ensuring a cleaner directory structure.  
* **Tests**
  * Added new test cases to verify correct removal of nested directories and pruning of empty folders after deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->