### PR TITLE
fix: update metric empty value

### DIFF
--- a/src/ui/src/components/core/content/CoreMetric.vue
+++ b/src/ui/src/components/core/content/CoreMetric.vue
@@ -34,7 +34,7 @@ export default {
 			},
 			metricValue: {
 				name: "Value",
-				default: "0",
+				default: "-",
 				type: FieldType.Text,
 				desc: "The main value to be displayed. It's not limited to numbers.",
 			},
@@ -134,6 +134,7 @@ const rootStyle = computed(() => {
 h2.value {
 	overflow: hidden;
 	text-overflow: ellipsis;
+	white-space: pre-wrap;
 }
 
 .note {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved metric value display to preserve whitespace and enable line wrapping.
* **Refactor**
  * Updated the default metric value display from "0" to "-".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->