### PR TITLE
fix: Add `v-else` to copy button to prevent double markdown render

### DIFF
--- a/src/ui/src/components/core/content/CoreText.vue
+++ b/src/ui/src/components/core/content/CoreText.vue
@@ -14,7 +14,7 @@
 				:style="contentStyle"
 			>
 			</BaseMarkdown>
-			<div class="text-container">
+			<div v-else class="text-container">
 				<p class="plainText" :style="contentStyle">
 					{{ fields.text.value }}
 				</p>

--- a/src/ui/src/components/core/content/__snapshots__/CoreText.spec.ts.snap
+++ b/src/ui/src/components/core/content/__snapshots__/CoreText.spec.ts.snap
@@ -14,21 +14,6 @@ exports[`CoreText > should render in markdown mode 1`] = `
 I'm the **content**."
     style="text-align: center;"
   />
-  <div
-    class="text-container"
-    data-v-810f69c0=""
-  >
-    <p
-      class="plainText"
-      data-v-810f69c0=""
-      style="text-align: center;"
-    >
-      # Hello
-
-I'm the **content**.
-    </p>
-    <!--v-if-->
-  </div>
   
 </div>
 `;
@@ -40,7 +25,6 @@ exports[`CoreText > should render in non-markdown mode 1`] = `
   style="cursor: pointer;"
 >
   
-  <!--v-if-->
   <div
     class="text-container"
     data-v-810f69c0=""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that only one of the Markdown or plain text containers is displayed at a time, preventing both from appearing simultaneously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->