### PR TITLE
chore: use blueprint ID instead of key for API calls - AB-127

### DIFF
--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -118,18 +118,18 @@ class BlueprintRunner:
         )
 
     def is_blueprint_api_available(
-        self, blueprint_key: str
+        self, blueprint_id: str
     ):
         """
         Checks if a blueprint with the given key is available for API execution.
 
-        :param blueprint_key: The blueprint identifier.
+        :param blueprint_id: The blueprint identifier.
         :return: True if the blueprint is available for API execution, False otherwise.
         """
-        return blueprint_key in self.api_blueprints
+        return blueprint_id in self.api_blueprints
 
     def get_blueprint_api_trigger(
-        self, blueprint_key: str
+        self, blueprint_id: str
     ):
         """
         Retrieves the API trigger for a given blueprint key.
@@ -137,11 +137,11 @@ class BlueprintRunner:
         :param blueprint_key: The blueprint identifier.
         :return: The API trigger component.
         """
-        if not self.is_blueprint_api_available(blueprint_key):
+        if not self.is_blueprint_api_available(blueprint_id):
             raise ValueError(
-                f'API trigger not found for blueprint "{blueprint_key}".'
+                f'API trigger not found for blueprint "{blueprint_id}".'
             )
-        return self.api_blueprints[blueprint_key]
+        return self.api_blueprints[blueprint_id]
 
     def _gather_api_blueprints(self):
         """
@@ -169,20 +169,20 @@ class BlueprintRunner:
                 parent_blueprint.type == "blueprints_blueprint"
             ):
                 # Store the blueprint key against its trigger ID
-                api_blueprints[parent_blueprint.content.get("key")] = \
+                api_blueprints[parent_blueprint_id] = \
                     trigger.id
 
         return api_blueprints
 
     def run_blueprint_via_api(
         self,
-        blueprint_key: str,
+        blueprint_id: str,
         execution_environment: Optional[Dict[str, Any]] = None
     ):
         """
         Executes a blueprint by its key via the API.
 
-        :param blueprint_key: The blueprint identifier.
+        :param blueprint_id: The blueprint identifier.
         :param execution_environment: The execution environment for
         the blueprint.
         :return: The result of the blueprint execution.
@@ -190,13 +190,13 @@ class BlueprintRunner:
         if execution_environment is None:
             execution_environment = {}
 
-        trigger_id = self.get_blueprint_api_trigger(blueprint_key)
+        trigger_id = self.get_blueprint_api_trigger(blueprint_id)
 
         return self.run_branch(
             trigger_id,
             None,
             execution_environment,
-            f"API trigger execution ({blueprint_key})"
+            f"API trigger execution ({blueprint_id})"
         )
 
     def run_blueprint_batch(self, blueprint_key: str, execution_environments: List[Dict]):

--- a/src/writer/core.py
+++ b/src/writer/core.py
@@ -1239,13 +1239,13 @@ class EventHandlerRegistry:
         This handler is used to run a blueprint via the API.
         It is used by the frontend to run a blueprint when the user clicks on a button.
         """
-        blueprint_key = payload.pop("blueprint_key", None)
-        if not blueprint_key:
-            raise ValueError("Missing blueprint_key in payload")
+        blueprint_id = payload.pop("blueprint_id", None)
+        if not blueprint_id:
+            raise ValueError("Missing blueprint_id in payload")
         execution_environment = EventHandler._get_blueprint_execution_environment(
             payload, context, session, vault
         )
-        return blueprint_runner.run_blueprint_via_api(blueprint_key=blueprint_key, execution_environment=execution_environment)
+        return blueprint_runner.run_blueprint_via_api(blueprint_id=blueprint_id, execution_environment=execution_environment)
 
     @staticmethod
     def run_blueprint_branch(payload: dict, context: dict, session: dict, blueprint_runner: 'BlueprintRunner', vault: Dict):

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -361,8 +361,8 @@ def get_asgi_app(
 
         return JSONResponse(content=blueprints)
 
-    @app.post("/private/api/blueprint/{blueprint_key}")
-    async def create_blueprint_job(blueprint_key: str, request: Request, response: Response):
+    @app.post("/private/api/blueprint/{blueprint_id}")
+    async def create_blueprint_job(blueprint_id: str, request: Request, response: Response):
         # Keep-alive interval for SSE streaming
         KEEPALIVE_INTERVAL = 15
         payload = await _get_payload_as_json(request)
@@ -387,19 +387,11 @@ def get_asgi_app(
 
         # --- Blueprint discovery logic ---
 
-        def find_blueprint_id(app_runner: AppRunner, key: str) -> Optional[str]:
+        def check_blueprint(app_runner: AppRunner, blueprint_id: str) -> bool:
             # Locate blueprint component by its key
             if not app_runner.bmc_components:
-                return None
-            return next(
-                (
-                    comp["id"]
-                    for comp in app_runner.bmc_components.values()
-                    if comp["type"] == "blueprints_blueprint"
-                    and comp.get("content", {}).get("key") == key
-                ),
-                None
-            )
+                return False
+            return blueprint_id in app_runner.bmc_components
 
         # --- Result serialization (recursive) ---
 
@@ -443,22 +435,22 @@ def get_asgi_app(
                 if not app_runner.bmc_components:
                     raise RuntimeError("No blueprints defined in the agent.")
 
-                blueprint_id = find_blueprint_id(app_runner, blueprint_key)
-                if not blueprint_id:
+                blueprint_exists = check_blueprint(app_runner, blueprint_id)
+                if not blueprint_exists:
                     await queue.put(await format_event("error", {
-                        "msg": f"Blueprint '{blueprint_key}' was not found.",
+                        "msg": f"Blueprint '{blueprint_id}' was not found.",
                         "finished_at": int(time.time())
                     }))
                     return
 
                 if not has_api_trigger(app_runner, blueprint_id):
                     await queue.put(await format_event("error", {
-                        "msg": f"Blueprint '{blueprint_key}' lacks an API trigger.",
+                        "msg": f"Blueprint '{blueprint_id}' lacks an API trigger.",
                         "finished_at": int(time.time())
                     }))
                     return
 
-                await queue.put(await format_event("status", {"status": "executing", "msg": f"Executing blueprint: {blueprint_key}..."}))
+                await queue.put(await format_event("status", {"status": "executing", "msg": f"Executing blueprint: {blueprint_id}..."}))
 
                 # Kick off actual blueprint execution as background task
                 task = asyncio.create_task(
@@ -468,7 +460,7 @@ def get_asgi_app(
                             type="wf-run-blueprint-via-api",
                             isSafe=True,
                             handler="run_blueprint_via_api",
-                            payload={"blueprint_key": blueprint_key, **(payload or {})},
+                            payload={"blueprint_id": blueprint_id, **(payload or {})},
                         )
                     )
                 )

--- a/tests/backend/test_serve.py
+++ b/tests/backend/test_serve.py
@@ -241,10 +241,10 @@ class TestServe:
     def test_create_blueprint_job_api(self, monkeypatch):
         asgi_app = writer.serve.get_asgi_app(test_app_dir, "run")
         monkeypatch.setenv("WRITER_SECRET_KEY", "abc")
-        blueprint_key = "blueprint2"
+        blueprint_id = "8ffkuce0ermsm9dr"
 
         with fastapi.testclient.TestClient(asgi_app) as client:
-            with client.stream("POST", f"/private/api/blueprint/{blueprint_key}",
+            with client.stream("POST", f"/private/api/blueprint/{blueprint_id}",
                                 json={"proposedSessionId": None},
                                 headers={"Content-Type": "application/json"}) as response:
 
@@ -291,11 +291,11 @@ class TestServe:
     def test_create_blueprint_job_api_streaming_events(self, monkeypatch):
         asgi_app = writer.serve.get_asgi_app(test_app_dir, "run")
         monkeypatch.setenv("WRITER_SECRET_KEY", "abc")
-        blueprint_key = "blueprint2"
+        blueprint_id = "8ffkuce0ermsm9dr"
 
         with fastapi.testclient.TestClient(asgi_app) as client:
             with client.stream(
-                "POST", f"/private/api/blueprint/{blueprint_key}",
+                "POST", f"/private/api/blueprint/{blueprint_id}",
                 json={"proposedSessionId": None},
                 headers={"Content-Type": "application/json"}
             ) as response:


### PR DESCRIPTION
Switches to use blueprint ID in API calls as an identifier instead of the key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated all references from "blueprint_key" to "blueprint_id" throughout the application for blueprint identification.
  * Simplified blueprint validation to use direct ID checks instead of key-based searches.
  * Adjusted error and status messages to reflect the use of blueprint IDs.

* **Tests**
  * Updated test cases to use blueprint IDs in API requests and variable names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->