### PR TITLE
Fix tool choice being assigned `NOT GIVEN`

### DIFF
--- a/src/writer/ai/__init__.py
+++ b/src/writer/ai/__init__.py
@@ -1708,7 +1708,7 @@ class Conversation:
             stream=stream,
             logprobs=request_data.get('logprobs', NotGiven()),
             tools=request_data.get('tools', NotGiven()),
-            tool_choice=request_data.get('tool_choice', NotGiven()),
+            tool_choice=request_data.get('tool_choice', cast(ToolChoice, 'auto')),
             response_format=request_data.get('response_format', NotGiven()),
             max_tokens=request_data.get('max_tokens', NotGiven()),
             n=request_data.get('n', NotGiven()),


### PR DESCRIPTION
When `tool_choice` is not specified, the fallback value is `NOT GIVEN`. For some reason, this was causing the model to call tools like its life depended on it, disregarding whether or not calling the tool made sense.

Now, the fallback is `auto` which allows the LLM to decide when to use tools as expected.