### PR TITLE
fix: context priority over state

### DIFF
--- a/src/writer/evaluator.py
+++ b/src/writer/evaluator.py
@@ -229,11 +229,9 @@ class Evaluator:
         if not accessors:
             return state_ref
         
-        result = self._apply_accessor(accessors[0], state_ref)
+        result = self._apply_accessor(accessors[0], context_ref)
         if result is None:
-            result = self._apply_accessor(accessors[0], context_ref)
-        if result is None:
-            return None
+            result = self._apply_accessor(accessors[0], state_ref)
 
         for accessor in accessors[1:]:
             result = self._apply_accessor(accessor, result)

--- a/tests/backend/test_evaluator.py
+++ b/tests/backend/test_evaluator.py
@@ -202,6 +202,8 @@ class TestEvaluator:
         assert e.evaluate_expression("context.interests.1", instance_path, {"context": {"interests": ["A"]}}) is None
         assert e.evaluate_expression("context.interests.2", instance_path, {"context": {"interests": ["A", "B","C"]}}) == "C"
 
+        assert e.evaluate_expression("features", instance_path, {"features": "takes priority"}) == "takes priority"
+
     def test_get_context_data_should_return_the_target_of_event(self) -> None:
         """
         Test that the target of the event is correctly returned by the get_context_data method


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted evaluation logic so that context values now take precedence over session state when resolving expressions.

* **Tests**
  * Added a test to verify that context keys are prioritized over session state during expression evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->