### PR TITLE
fix(ui): use `smallIcon` size for WdsButton to fix icon spacing

### DIFF
--- a/src/ui/src/builder/settings/BuilderFieldsTools.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsTools.vue
@@ -13,7 +13,7 @@
 				<div class="toolName">{{ toolName }}</div>
 				<WdsButton
 					variant="primary"
-					size="small"
+					size="smallIcon"
 					class="delete"
 					@click.stop="deleteTool(toolName)"
 				>
@@ -326,11 +326,11 @@ const modalActions = computed<ModalAction[]>(() => [
 }
 
 .tool .delete {
-	display: none;
+	visibility: hidden;
 }
 
 .tool:hover .delete {
-	display: unset;
+	visibility: visible;
 }
 
 .addToolForm {

--- a/src/ui/src/builder/settings/BuilderSettingsActions.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsActions.vue
@@ -4,7 +4,7 @@
 			v-if="ssbm.selectionStatus.value === SelectionStatus.Multiple"
 			class="BuilderSettingsActions__btn"
 			variant="neutral"
-			size="small"
+			size="smallIcon"
 			data-automation-action="clear-selection"
 			data-writer-tooltip="Clear selection"
 			data-writer-tooltip-placement="left"
@@ -15,7 +15,7 @@
 		<WdsButton
 			class="BuilderSettingsActions__btn BuilderSettingsActions__btn--delete"
 			variant="neutral"
-			size="small"
+			size="smallIcon"
 			data-automation-action="delete"
 			data-writer-tooltip="Delete (Del)"
 			data-writer-tooltip-placement="left"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the appearance and size of delete and action buttons for improved consistency.
  * Modified how the delete button is shown or hidden on hover for smoother visual transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->