### PR TITLE
fix: switch to emit instead of accessing property of child - AB-180

### DIFF
--- a/src/ui/src/builder/BuilderApplicationSelect.vue
+++ b/src/ui/src/builder/BuilderApplicationSelect.vue
@@ -6,6 +6,7 @@ import {
 	inject,
 	onMounted,
 	PropType,
+	watch,
 } from "vue";
 import { useListResources } from "@/composables/useListResources";
 import type { Option } from "@/wds/WdsSelect.vue";
@@ -20,6 +21,10 @@ const WdsSelect = defineAsyncComponent({
 
 const wf = inject(injectionKeys.core);
 
+const emit = defineEmits<{
+	(event: "selected-data", data: WriterApplication | undefined): void;
+}>();
+
 defineProps({
 	enableMultiSelection: { type: Boolean, required: false },
 });
@@ -30,12 +35,12 @@ const currentValue = defineModel({
 });
 
 const {
-	load: loadGraphs,
-	data: graphs,
+	load: loadApps,
+	data: apps,
 	isLoading,
 } = useListResources<WriterApplication>(wf, "applications");
 
-onMounted(loadGraphs);
+onMounted(loadApps);
 
 function getAppType(app: WriterApplication) {
 	switch (app.type) {
@@ -51,7 +56,7 @@ function getAppType(app: WriterApplication) {
 }
 
 const options = computed(() =>
-	graphs.value
+	apps.value
 		.map<Option>((app) => ({
 			label: app.name,
 			value: app.id,
@@ -76,9 +81,14 @@ const currentValueStr = computed<string>({
 const selectedData = computed(() => {
 	if (currentValue.value === undefined) return undefined;
 
-	return typeof currentValue.value === "string"
-		? graphs.value.find((g) => g.id === currentValue.value)
-		: graphs.value.filter((g) => currentValue.value.includes(g.id));
+	// Application select should never support multi-selection
+	if (typeof currentValue.value !== "string") return undefined;
+
+	return apps.value.find((g) => g.id === currentValue.value);
+});
+
+watch(selectedData, (data) => {
+	emit("selected-data", data);
 });
 
 defineExpose({ selectedData });
@@ -87,7 +97,7 @@ defineExpose({ selectedData });
 <template>
 	<div class="BuilderGraphSelect--text">
 		<WdsSelect
-			v-if="graphs.length > 0 || isLoading"
+			v-if="apps.length > 0 || isLoading"
 			v-model="currentValue"
 			:options="options"
 			hide-icons

--- a/src/ui/src/builder/BuilderApplicationSelect.vue
+++ b/src/ui/src/builder/BuilderApplicationSelect.vue
@@ -87,9 +87,16 @@ const selectedData = computed(() => {
 	return apps.value.find((g) => g.id === currentValue.value);
 });
 
-watch(selectedData, (data) => {
-	emit("selected-data", data);
-});
+watch(
+	() => currentValue.value,
+	() => {
+		// Ignore empty states where apps haven't loaded yet
+		if (!apps.value.length) return;
+
+		const picked = apps.value.find((a) => a.id === currentValue.value);
+		emit("selected-data", picked);
+	},
+);
 
 defineExpose({ selectedData });
 </script>

--- a/src/ui/src/builder/settings/BuilderFieldsWriterResourceId.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsWriterResourceId.vue
@@ -8,6 +8,7 @@
 			ref="selectorEl"
 			v-model="selected"
 			:enable-multi-selection="enableMultiSelection"
+			@selected-data="onSelectedData"
 		/>
 		<a
 			v-if="ressourceUrl"
@@ -29,11 +30,12 @@ import {
 	PropType,
 	defineAsyncComponent,
 	useTemplateRef,
-	watch,
+	ref,
 } from "vue";
 import { useComponentActions } from "../useComponentActions";
 import injectionKeys from "@/injectionKeys";
 import WdsIcon from "@/wds/WdsIcon.vue";
+import { WriterApplication } from "@/writerTypes";
 
 const BuilderApplicationSelect = defineAsyncComponent(
 	() => import("../BuilderApplicationSelect.vue"),
@@ -149,20 +151,25 @@ const selected = computed<string | string[]>({
 	},
 });
 
-watch(selected, async (newAppId) => {
-	if (props.resourceType !== "application" || !newAppId) return;
+const selectedData = ref<WriterApplication | undefined>();
 
-	const appData = selectorEl.value?.selectedData;
-	const inputsList = appData?.inputs;
-
-	if (!inputsList || typeof inputsList !== "object") return;
+function onSelectedData(appData: WriterApplication | undefined) {
+	selectedData.value = appData; // for readability
+	if (
+		props.resourceType !== "application" ||
+		!appData ||
+		!appData.inputs ||
+		typeof appData.inputs !== "object"
+	) {
+		return;
+	}
 
 	setContentValue(
 		component.value.id,
 		"appInputs",
-		JSON.stringify(inputsList),
+		JSON.stringify(appData.inputs),
 	);
-});
+}
 </script>
 
 <style scoped>

--- a/src/ui/src/writerTypes.ts
+++ b/src/ui/src/writerTypes.ts
@@ -245,6 +245,7 @@ export type WriterApplication = {
 	type: string;
 	status: string;
 	organization_id?: string;
+	inputs?: Record<string, string>;
 };
 
 export type UserCollaborationPing = {


### PR DESCRIPTION
Accessing property enabled a race condition, where app data could be possibly not yet available upon retrieval. Switching to event listening allows to mitigate the issue and ensure that data is always available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated application selection to focus on single application selection instead of multiple graphs.
  * Improved event-driven handling for application selection updates.

* **New Features**
  * Application selection now emits an event with the selected application's details for easier integration.

* **Bug Fixes**
  * Ensured selected application data is accurately reflected and updated in related fields.

* **Other**
  * Extended application data type to optionally include input parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->