### PR TITLE
fix(ui): replace material icon on binding field

### DIFF
--- a/src/ui/src/builder/settings/BuilderTemplateInputState.vue
+++ b/src/ui/src/builder/settings/BuilderTemplateInputState.vue
@@ -1,7 +1,7 @@
 <template>
 	<WdsTextInputLayout
 		class="BuilderTemplateInputState"
-		:left-icon="displayEmptyVariant ? 'alternate_email' : undefined"
+		:left-icon="displayEmptyVariant ? 'at-sign' : undefined"
 		:right-icon="rightIcon"
 		@right-icon-click="$emit('rightIconClick')"
 		@click="input.focus()"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the left icon in certain input fields to use a new symbol when a specific condition is met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->