### PR TITLE
fix: string payloads in mail

### DIFF
--- a/src/writer/core.py
+++ b/src/writer/core.py
@@ -1116,6 +1116,9 @@ class WriterState(State):
     def _remove_duplicates_in_mail(self, id: str) -> None:
         new_mail = []
         for entry in self.mail:
+            if entry["type"] != "logEntry":
+                new_mail.append(entry)
+                continue
             log_id = entry["payload"].get("id")
             if log_id != id:
                 new_mail.append(entry)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate removal logic to ensure only log entries are checked for duplicates, while other mail types are left unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->