### PR TITLE
feat(ui): hilight nested value in template pills - AB-154

### DIFF
--- a/src/ui/src/builder/templateEditor/BuilderTemplateEditor.vue
+++ b/src/ui/src/builder/templateEditor/BuilderTemplateEditor.vue
@@ -43,19 +43,15 @@ const { bindings, blueprintsResults, blueprintsSetStates } =
 
 const backgroundTagColors = computed(() => {
 	return {
-		[WdsColor.Green2]: new Set(
-			extractObjectPaths(wf.userStateInitial.value),
-		),
-		[WdsColor.Gray2]: new Set(extractObjectPaths(bindings.value)),
-		[WdsColor.Blue2]: new Set([
+		[WdsColor.Green2]: [...extractObjectPaths(wf.userState.value)],
+		[WdsColor.Gray2]: [...extractObjectPaths(bindings.value)],
+		[WdsColor.Blue2]: [
 			...extractObjectPaths(blueprintsSetStates.value),
 			...extractObjectPaths(blueprintsResults.value),
-		]),
-		[WdsColor.Yellow2]: new Set(
-			[...extractObjectPaths(secretsManager.secrets.value)].map(
-				(v) => `vault.${v}`,
-			),
-		),
+		],
+		[WdsColor.Yellow2]: [
+			...extractObjectPaths(secretsManager.secrets.value),
+		].map((v) => `vault.${v}`),
 	};
 });
 

--- a/src/ui/src/builder/templateEditor/BuilderTemplateEditorContent.vue
+++ b/src/ui/src/builder/templateEditor/BuilderTemplateEditorContent.vue
@@ -16,7 +16,7 @@ export default defineComponent({
 	props: {
 		content: { type: String, required: false, default: undefined },
 		backgroundColors: {
-			type: Object as PropType<Record<string, Set<string>>>,
+			type: Object as PropType<Record<string, string[]>>,
 			required: false,
 			default: () => {},
 		},

--- a/src/ui/src/builder/templateEditor/BuilderTemplateEditorContentTag.spec.ts
+++ b/src/ui/src/builder/templateEditor/BuilderTemplateEditorContentTag.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+
+import BuilderTemplateEditorContentTag from "./BuilderTemplateEditorContentTag.vue";
+import { shallowMount } from "@vue/test-utils";
+
+describe(BuilderTemplateEditorContentTag, () => {
+	it("should display basic", () => {
+		const wrapper = shallowMount(BuilderTemplateEditorContentTag, {
+			props: {
+				backgroundColors: {
+					red: ["foo"],
+				},
+				tag: "foo",
+			},
+		});
+		expect(wrapper.element.style.backgroundColor).toBe("red");
+	});
+
+	it("should handle nested", () => {
+		const wrapper = shallowMount(BuilderTemplateEditorContentTag, {
+			props: {
+				backgroundColors: {
+					red: ["foo"],
+				},
+				tag: "foo.bar",
+			},
+		});
+		expect(wrapper.element.style.backgroundColor).toBe("red");
+	});
+
+	it("should handle no match", () => {
+		const wrapper = shallowMount(BuilderTemplateEditorContentTag, {
+			props: {
+				backgroundColors: {
+					red: ["foo"],
+				},
+				tag: "bar.foo",
+			},
+		});
+		expect(wrapper.element.style.backgroundColor).toBe("");
+	});
+});

--- a/src/ui/src/builder/templateEditor/BuilderTemplateEditorContentTag.spec.ts
+++ b/src/ui/src/builder/templateEditor/BuilderTemplateEditorContentTag.spec.ts
@@ -34,7 +34,7 @@ describe(BuilderTemplateEditorContentTag, () => {
 				backgroundColors: {
 					red: ["foo"],
 				},
-				tag: "bar.foo",
+				tag: "fooBar",
 			},
 		});
 		expect(wrapper.element.style.backgroundColor).toBe("");

--- a/src/ui/src/builder/templateEditor/BuilderTemplateEditorContentTag.vue
+++ b/src/ui/src/builder/templateEditor/BuilderTemplateEditorContentTag.vue
@@ -4,15 +4,15 @@ import { computed, CSSProperties, PropType, useTemplateRef } from "vue";
 const props = defineProps({
 	tag: { type: String, required: false, default: undefined },
 	backgroundColors: {
-		type: Object as PropType<Record<string, Set<string>>>,
+		type: Object as PropType<Record<string, string[]>>,
 		required: false,
 		default: () => {},
 	},
 });
 
 const style = computed<CSSProperties>(() => {
-	const type = Object.entries(props.backgroundColors ?? {}).find(([, v]) =>
-		v.has(props.tag),
+	const type = Object.entries(props.backgroundColors ?? {}).find(([, keys]) =>
+		keys.some((k) => props.tag === k || props.tag.startsWith(`${k}`)),
 	)?.[0];
 
 	if (!type) return {};

--- a/src/ui/src/builder/templateEditor/BuilderTemplateEditorContentTag.vue
+++ b/src/ui/src/builder/templateEditor/BuilderTemplateEditorContentTag.vue
@@ -12,7 +12,7 @@ const props = defineProps({
 
 const style = computed<CSSProperties>(() => {
 	const type = Object.entries(props.backgroundColors ?? {}).find(([, keys]) =>
-		keys.some((k) => props.tag === k || props.tag.startsWith(`${k}`)),
+		keys.some((k) => props.tag === k || props.tag.startsWith(`${k}.`)),
 	)?.[0];
 
 	if (!type) return {};
@@ -21,6 +21,8 @@ const style = computed<CSSProperties>(() => {
 		backgroundColor: type,
 	};
 });
+
+const content = computed(() => `@{${props.tag}}`);
 
 const root = useTemplateRef("root");
 
@@ -41,10 +43,8 @@ function onDblClick() {
 		:style
 		@dblclick="onDblClick"
 	>
-		<span class="BuilderTemplateEditorContentTag__sign">@</span
-		><span class="BuilderTemplateEditorContentTag__bracket">{</span>{{ tag
-		}}<span class="BuilderTemplateEditorContentTag__bracket">}</span></span
-	>
+		{{ content }}
+	</span>
 </template>
 
 <style lang="css" scoped>
@@ -53,15 +53,5 @@ function onDblClick() {
 	color: var(--wdsColorBlack);
 	padding: 2px 8px;
 	border-radius: 4px;
-}
-.BuilderTemplateEditorContentTag::selection {
-	background: var(--wdsColorBlue3);
-}
-
-.BuilderTemplateEditorContentTag__bracket {
-	color: transparent;
-	caret-color: var(--wdsColorBlack);
-	display: inline-block;
-	width: 0;
 }
 </style>

--- a/src/ui/src/builder/templateEditor/__snapshots__/BuilderTemplateEditorContent.spec.ts.snap
+++ b/src/ui/src/builder/templateEditor/__snapshots__/BuilderTemplateEditorContent.spec.ts.snap
@@ -20,25 +20,7 @@ exports[`BuilderTemplateEditorContent > should render text with breaking lines 1
     data-v-4e6e767a=""
     data-v-f4c188f2=""
   >
-    <span
-      class="BuilderTemplateEditorContentTag__sign"
-      data-v-4e6e767a=""
-    >
-      @
-    </span>
-    <span
-      class="BuilderTemplateEditorContentTag__bracket"
-      data-v-4e6e767a=""
-    >
-      {
-    </span>
-    tag
-    <span
-      class="BuilderTemplateEditorContentTag__bracket"
-      data-v-4e6e767a=""
-    >
-      }
-    </span>
+    @{tag}
   </span>
   
   <br
@@ -60,25 +42,7 @@ exports[`BuilderTemplateEditorContent > should render text with one tag 1`] = `
     data-v-4e6e767a=""
     data-v-f4c188f2=""
   >
-    <span
-      class="BuilderTemplateEditorContentTag__sign"
-      data-v-4e6e767a=""
-    >
-      @
-    </span>
-    <span
-      class="BuilderTemplateEditorContentTag__bracket"
-      data-v-4e6e767a=""
-    >
-      {
-    </span>
-    tag
-    <span
-      class="BuilderTemplateEditorContentTag__bracket"
-      data-v-4e6e767a=""
-    >
-      }
-    </span>
+    @{tag}
   </span>
 </div>
 `;

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -145,7 +145,7 @@ export function generateCore() {
 		mode.value = initData.mode;
 		components.value = initData.components;
 		userState.value = initData.userState;
-		userStateInitial.value = initData.userState;
+		userStateInitial.value = structuredClone(initData.userState);
 		collateMail(initData.mail);
 		sessionId = initData.sessionId;
 		sessionTimestamp.value = new Date().getTime();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated background color mapping logic to use arrays instead of sets, improving tag matching flexibility.
  * Enhanced tag matching to support tags that start with any entry in the color mapping array.
  * Updated prop types for background color mappings in relevant components for consistency.
  * Simplified tag display formatting and removed related bracket styling.
  * Changed initial user state handling to prevent unintended mutations by deep cloning the state.

* **Tests**
  * Added new tests to verify correct background color application for tags, including nested and unmatched cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->