### PR TITLE
fix: revert PR 1031; exposing base URL for cURL generation

### DIFF
--- a/src/ui/src/builder/settings/BuilderFieldsBlueprintId.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsBlueprintId.vue
@@ -1,0 +1,27 @@
+<template>
+	<div class="BuilderFieldsBlueprintId" :data-automation-key="props.fieldKey">
+		<WdsTextInput :model-value="blueprintId" disabled />
+	</div>
+</template>
+
+<script setup lang="ts">
+import { inject, computed } from "vue";
+import injectionKeys from "@/injectionKeys";
+import WdsTextInput from "@/wds/WdsTextInput.vue";
+
+const wf = inject(injectionKeys.core);
+
+const props = defineProps({
+	componentId: { type: String, required: true },
+	fieldKey: { type: String, required: true },
+});
+
+const component = computed(() => wf.getComponentById(props.componentId));
+const blueprintId = computed(() => component.value?.parentId ?? "");
+</script>
+
+<style scoped>
+.BuilderFieldsBlueprintId {
+	display: flex;
+}
+</style>

--- a/src/ui/src/builder/settings/BuilderSettingsArtifactAPITriggerDetails.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsArtifactAPITriggerDetails.vue
@@ -1,0 +1,215 @@
+<template>
+	<div class="BuilderSettingsArtifactAPITriggerDetails">
+		<WdsTitle2>Test your trigger</WdsTitle2>
+		<WdsTabs
+			v-model="tab"
+			class="BuilderSettingsArtifactAPITriggerDetails__tabs"
+			:tabs="tabs"
+		/>
+		<div
+			v-if="tab === 'builder'"
+			class="BuilderSettingsArtifactAPITriggerDetails__builder"
+		>
+			<div
+				v-for="[fieldKey, fieldValue] in artifactFields"
+				:key="fieldKey"
+				class="BuilderSettingsArtifactAPITriggerDetails__field"
+			>
+				<!-- Only one field expected in this artifact -->
+				<WdsFieldWrapper
+					:label="fieldValue.name ?? fieldKey"
+					:hint="fieldValue.desc"
+					:is-expansible="true"
+				>
+					<BuilderFieldsCode
+						v-if="fieldValue.type == FieldType.Code"
+						:field-key="fieldKey"
+						:component-id="component?.id ?? ''"
+						:is-expanded="false"
+						input-language="json"
+					/>
+				</WdsFieldWrapper>
+			</div>
+		</div>
+
+		<div v-else class="BuilderSettingsArtifactAPITriggerDetails__api">
+			<ol class="BuilderSettingsArtifactAPITriggerDetails__steps">
+				<li
+					id="stepCreate"
+					class="BuilderSettingsArtifactAPITriggerDetails__step"
+				>
+					<p
+						class="BuilderSettingsArtifactAPITriggerDetails__step__hint"
+					>
+						Paste the CURL command into your terminal
+					</p>
+					<WdsButton
+						variant="tertiary"
+						size="small"
+						@click="copyCreate"
+					>
+						<i class="material-symbols-outlined">{{
+							isCreateCopied ? "check" : "content_copy"
+						}}</i>
+						Copy cURL command
+					</WdsButton>
+				</li>
+				<li
+					id="stepPaste"
+					class="BuilderSettingsArtifactAPITriggerDetails__step"
+				>
+					<p
+						class="BuilderSettingsArtifactAPITriggerDetails__step__hint"
+					>
+						Once the job has run, paste the result here:
+					</p>
+					<WdsTextareaInput
+						v-model="apiOutput"
+						placeholder="Paste cURL output here"
+					/>
+				</li>
+				<li
+					id="stepPoll"
+					class="BuilderSettingsArtifactAPITriggerDetails__step"
+				>
+					<p
+						class="BuilderSettingsArtifactAPITriggerDetails__step__hint"
+					>
+						Lastly, paste the poll async into your terminal to
+						retrieve your artifact
+					</p>
+					<WdsButton
+						variant="tertiary"
+						size="small"
+						:disabled="isPollDisabled"
+						@click="copyPoll"
+					>
+						<i class="material-symbols-outlined">{{
+							isPollCopied ? "check" : "content_copy"
+						}}</i>
+						Copy poll async
+					</WdsButton>
+				</li>
+			</ol>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, ref } from "vue";
+import injectionKeys from "@/injectionKeys";
+import WdsButton from "@/wds/WdsButton.vue";
+import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
+import WdsTextareaInput from "@/wds/WdsTextareaInput.vue";
+import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
+import BuilderFieldsCode from "./BuilderFieldsCode.vue";
+import { useButtonClipboard } from "../useButtonClipboard";
+import WdsTitle2 from "@/wds/WdsTitle2.vue";
+import { FieldType } from "@/writerTypes";
+
+const wf = inject(injectionKeys.core);
+const ssbm = inject(injectionKeys.builderManager);
+
+const component = computed(() =>
+	wf.getComponentById(ssbm.firstSelectedId.value),
+);
+const blueprintId = computed(() => component.value?.parentId ?? "");
+
+const componentDefinition = computed(() => {
+	if (!component.value) return null;
+	return wf.getComponentDefinition(component.value.type);
+});
+
+const artifactFields = computed(() => {
+	const allFields = componentDefinition.value?.fields ?? {};
+	return Object.entries(allFields).filter(([, f]) => f.isArtifactField);
+});
+
+const baseURL = (wf.writerBaseUrl.value ?? "https://api.writer.com").replace(
+	/\/+$/,
+	"",
+);
+
+const curlCreate = computed(
+	() =>
+		`curl --location --request POST '${baseURL}/v1/agents/${wf.writerAppId.value}/blueprints/${blueprintId.value}/jobs' \\` +
+		`\n--header 'Authorization: Bearer ${wf.writerApiKey.value}' \\` +
+		`\n--header 'Content-Type: application/json' --data '{"inputs": []}'`,
+);
+
+type TabMode = "builder" | "api";
+const tabs: WdsTabOptions<TabMode>[] = [
+	{ label: "Run in Agent Builder", value: "builder" },
+	{ label: "Run via API", value: "api" },
+];
+const tab = ref<TabMode>("builder");
+
+const apiOutput = ref("");
+const parsedOutput = computed(() => {
+	try {
+		return JSON.parse(apiOutput.value);
+	} catch {
+		return null;
+	}
+});
+
+const { copyText: copyCreate, isCopied: isCreateCopied } =
+	useButtonClipboard(curlCreate);
+
+const isPollDisabled = computed(() => {
+	return !parsedOutput.value?.poll_url?.trim();
+});
+
+const curlPoll = computed(() => {
+	const pollUrl = parsedOutput.value?.poll_url ?? "/v1/agents/jobs/JOB_ID";
+	return (
+		`curl --location --request GET '${baseURL}${pollUrl}' \\` +
+		`\n--header 'Authorization: Bearer ${wf.writerApiKey.value}'`
+	);
+});
+
+const { copyText: copyPoll, isCopied: isPollCopied } =
+	useButtonClipboard(curlPoll);
+</script>
+
+<style scoped>
+.WdsTitle2 {
+	padding-bottom: 8px;
+}
+.BuilderSettingsArtifactAPITriggerDetails {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 24px;
+}
+.BuilderSettingsArtifactAPITriggerDetails__tabs {
+	gap: 10px;
+}
+.BuilderSettingsArtifactAPITriggerDetails__builder,
+.BuilderSettingsArtifactAPITriggerDetails__api {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-top: 8px;
+}
+.BuilderSettingsArtifactAPITriggerDetails__steps {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	list-style-type: decimal;
+	padding-left: 16px;
+}
+.BuilderSettingsArtifactAPITriggerDetails__step:first-of-type
+	> .BuilderSettingsArtifactAPITriggerDetails__step__hint {
+	margin-top: 0;
+}
+.BuilderSettingsArtifactAPITriggerDetails__step__hint {
+	margin: 12px 0;
+}
+</style>
+<style>
+.BuilderSettingsArtifactAPITriggerDetails__tabs > .WdsTab {
+	font-size: 12px;
+	padding: 2px 8px;
+}
+</style>

--- a/src/ui/src/builder/settings/BuilderSettingsMain.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsMain.vue
@@ -18,11 +18,21 @@
 
 		<div class="BuilderSettingsMain__section" :inert="isReadOnly">
 			<BuilderSettingsProperties />
+			<component
+				:is="artifactRegistry[a.key]"
+				v-for="a in artifactsTop"
+				:key="a.key"
+			/>
 			<template v-if="displaySettings">
 				<BuilderSettingsBinding v-if="isBindable" />
 				<BuilderSettingsHandlers />
 				<BuilderSettingsVisibility />
 			</template>
+			<component
+				:is="artifactRegistry[a.key]"
+				v-for="a in artifactsBottom"
+				:key="a.key"
+			/>
 		</div>
 
 		<div class="BuilderSettingsMain__spacer"></div>
@@ -61,6 +71,7 @@ import BuilderAsyncLoader from "../BuilderAsyncLoader.vue";
 import WdsButton from "@/wds/WdsButton.vue";
 import WdsIcon from "@/wds/WdsIcon.vue";
 import { useButtonClipboard } from "../useButtonClipboard";
+import { artifactRegistry } from "./artifacts";
 
 const BuilderSettingsHandlers = defineAsyncComponent({
 	loader: () => import("./BuilderSettingsHandlers.vue"),
@@ -100,6 +111,17 @@ const { copyText: copyComponentId, isCopied: isComponentIdCopied } =
 const isBindable = computed(() =>
 	Object.values(componentDefinition.value?.events ?? {}).some(
 		(e) => e.bindable,
+	),
+);
+
+const artifactsTop = computed(() =>
+	(componentDefinition.value?.settingsArtifacts ?? []).filter(
+		(a) => a.position !== "bottom",
+	),
+);
+const artifactsBottom = computed(() =>
+	(componentDefinition.value?.settingsArtifacts ?? []).filter(
+		(a) => a.position === "bottom",
 	),
 );
 </script>

--- a/src/ui/src/builder/settings/BuilderSettingsProperties.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsProperties.vue
@@ -85,6 +85,12 @@
 						:error="errorsByFields[fieldKey]"
 					/>
 
+					<BuilderFieldsBlueprintId
+						v-if="fieldValue.type == FieldType.BlueprintId"
+						:field-key="fieldKey"
+						:component-id="selectedComponent.id"
+					/>
+
 					<BuilderFieldsBlueprintKey
 						v-if="fieldValue.type == FieldType.BlueprintKey"
 						:field-key="fieldKey"
@@ -232,6 +238,7 @@ import BuilderFieldsTools from "./BuilderFieldsTools.vue";
 import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
 import BuilderFieldsCode from "./BuilderFieldsCode.vue";
 import BuilderFieldsBlueprintKey from "./BuilderFieldsBlueprintKey.vue";
+import BuilderFieldsBlueprintId from "./BuilderFieldsBlueprintId.vue";
 import BuilderFieldsHandler from "./BuilderFieldsHandler.vue";
 import BuilderFieldsWriterResourceId from "./BuilderFieldsWriterResourceId.vue";
 import BuilderFieldsComponentId from "./BuilderFieldsComponentId.vue";
@@ -258,7 +265,10 @@ const componentDefinition = computed(() => {
 	return wf.getComponentDefinition(type);
 });
 const fields = computed(() => {
-	return componentDefinition.value?.fields;
+	const allFields = componentDefinition.value?.fields ?? {};
+	return Object.fromEntries(
+		Object.entries(allFields).filter(([, f]) => !f.isArtifactField),
+	);
 });
 
 function isExpansible(field: WriterComponentDefinitionField) {

--- a/src/ui/src/builder/settings/artifacts.ts
+++ b/src/ui/src/builder/settings/artifacts.ts
@@ -1,0 +1,11 @@
+import { defineAsyncComponent } from "vue";
+import BuilderAsyncLoader from "../BuilderAsyncLoader.vue";
+
+export const artifactRegistry = {
+    apiTriggerDetails: defineAsyncComponent({
+        loader: () => import("./BuilderSettingsArtifactAPITriggerDetails.vue"),
+        loadingComponent: BuilderAsyncLoader,
+    })
+};
+
+export type ArtifactKey = keyof typeof artifactRegistry;

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -54,7 +54,7 @@ export function generateCore() {
 	 */
 	const mode: Ref<"run" | "edit"> = ref(null);
 	const writerApplication = ref<
-		{ id: string; organizationId: string } | undefined
+		{ id: string; organizationId: string; apiKey?: string; baseUrl?: string } | undefined
 	>();
 	const featureFlags = shallowRef<string[]>([]);
 	const runCode: Ref<string> = ref(null);
@@ -83,6 +83,8 @@ export function generateCore() {
 		() => Number(writerApplication.value?.organizationId) || undefined,
 	);
 	const writerAppId = computed(() => writerApplication.value?.id);
+	const writerApiKey = computed(() => writerApplication.value?.apiKey);
+	const writerBaseUrl = computed(() => writerApplication.value?.baseUrl ?? "https://api.writer.com");
 	const isWriterCloudApp = computed(() =>
 		Boolean(writerAppId.value || writerOrgId.value),
 	);
@@ -917,6 +919,8 @@ export function generateCore() {
 		isWriterCloudApp,
 		writerOrgId,
 		writerAppId,
+		writerApiKey,
+		writerBaseUrl
 	};
 
 	return core;

--- a/src/ui/src/writerTypes.ts
+++ b/src/ui/src/writerTypes.ts
@@ -80,6 +80,7 @@ export type WriterComponentDefinitionField = {
 	category?: FieldCategory;
 	/** Use the value of this field as a CSS variable */
 	applyStyleVariable?: boolean;
+	isArtifactField?: boolean;
 	validator?:
 		| SchemaObject
 		| ((wf?: Core, componentId?: ComponentId) => SchemaObject); // dynamic schema depending on the context;
@@ -117,15 +118,19 @@ export type WriterComponentDefinition = {
 	previewField?: string; // Which field to use for previewing in the Component Tree
 	positionless?: boolean; // Whether this type of component is positionless (like Sidebar)
 	outs?: Record<
-			string,
-			{
-					name: string;
-					description: string;
-					style: string;
-					field?: keyof WriterComponentDefinition["fields"];
-			}
+		string,
+		{
+			name: string;
+			description: string;
+			style: string;
+			field?: keyof WriterComponentDefinition["fields"];
+		}
 	>;
 	featureFlags?: string[];
+	settingsArtifacts?: {
+		key: string;
+		position?: "top" | "bottom";
+	}[];
 };
 
 export type BuilderManager = ReturnType<typeof generateBuilderManager>;
@@ -155,6 +160,7 @@ export const enum FieldType {
 	ComponentPicker = "Component",
 	Code = "Code",
 	BlueprintKey = "Blueprint Key",
+	BlueprintId = "Blueprint Id",
 	Handler = "Handler",
 	WriterGraphId = "Graph Id",
 	WriterGraphIds = "Graph Ids",

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -181,10 +181,16 @@ class AppProcess(multiprocessing.Process):
         writer_application: Optional[WriterApplicationInformation] = None
         writer_app_id = os.getenv("WRITER_APP_ID")
         writer_org_id = os.getenv("WRITER_ORG_ID")
+        writer_base_url = \
+            os.getenv("WRITER_BASE_URL", "https://api.writer.com")
         if writer_app_id is not None and writer_org_id is not None:
             writer_application = WriterApplicationInformation(
-                id=writer_app_id, organizationId=writer_org_id
+                id=writer_app_id,
+                organizationId=writer_org_id,
+                baseUrl=writer_base_url
             )
+            if writer.Config.mode == "edit":
+                writer_application.apiKey = os.getenv("WRITER_API_KEY")
 
         res_payload = InitSessionResponsePayload(
             userState=user_state,

--- a/src/writer/blocks/apitrigger.py
+++ b/src/writer/blocks/apitrigger.py
@@ -16,10 +16,15 @@ class APITrigger(BlueprintTrigger):
                     "description": "Triggers an event via API call.",
                     "category": "Triggers",
                     "fields": {
+                        "blueprintId": {
+                            "name": "Blueprint ID",
+                            "type": "Blueprint Id",
+                        },
                         "defaultResult": {
-                            "name": "Default payload",
+                            "name": "Default result",
                             "type": "Code",
-                            "desc": 'The payload that is used when the blueprint is triggered from the "Run blueprint" button',
+                            "desc": 'The result that is used when the blueprint is triggered from the "Run blueprint" button',
+                            "isArtifactField": True,
                         },
                     },
                     "outs": {
@@ -30,9 +35,11 @@ class APITrigger(BlueprintTrigger):
                     },
                     "featureFlags": [
                         "api_trigger"
+                    ],
+                    "settingsArtifacts": [
+                        {"key": "apiTriggerDetails", "position": "bottom"}
                     ]
                 },
-                
             ),
         )
 

--- a/src/writer/ss_types.py
+++ b/src/writer/ss_types.py
@@ -71,6 +71,8 @@ SourceFiles = Union[SourceFilesFile, SourceFilesDirectory, SourceFilesBinary]
 class WriterApplicationInformation(BaseModel):
     id: str
     organizationId: str
+    baseUrl: Optional[str] = None
+    apiKey: Optional[str] = None
 
 
 class AutogenRequestBody(BaseModel):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying and copying API trigger details, including cURL commands and job polling, in the builder UI.
  * Introduced a new field type for displaying Blueprint IDs in the settings UI.
  * Enabled dynamic rendering of configurable artifact components in builder settings, with position-based placement.
  * Added clipboard copy functionality for API commands in the artifact API trigger details UI.

* **Improvements**
  * Artifact fields are now filtered out from the main settings properties view.
  * Writer application metadata now includes optional API key and base URL fields, available in both backend and frontend.

* **Bug Fixes**
  * Corrected the naming and description of the default result field in the API trigger metadata.
  * Improved registration metadata for API triggers, including artifact and settings artifact configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->