### PR TITLE
feat(ui): recreate an empty page on deleting last page - AB-190

### DIFF
--- a/src/ui/src/builder/useComponentAction.spec.ts
+++ b/src/ui/src/builder/useComponentAction.spec.ts
@@ -158,6 +158,28 @@ describe(useComponentActions.name, () => {
 				"Delete",
 			);
 		});
+
+		it("should recreate an empty page when removing all pages", () => {
+			const { removeComponentsSubtree } = useComponentActions(
+				mockCore.core,
+				wfbm,
+			);
+			removeComponentsSubtree("pageId");
+
+			expect(mockCore.core.getComponents("root")).toHaveLength(1);
+		});
+
+		it("should recreate an empty page when removing all pages", () => {
+			const { removeComponentsSubtree } = useComponentActions(
+				mockCore.core,
+				wfbm,
+			);
+			removeComponentsSubtree("blueprints_blueprint-id");
+
+			expect(mockCore.core.getComponents("blueprints_root")).toHaveLength(
+				1,
+			);
+		});
 	});
 
 	describe("components movements", () => {

--- a/src/ui/src/builder/useComponentActions.ts
+++ b/src/ui/src/builder/useComponentActions.ts
@@ -385,6 +385,23 @@ export function useComponentActions(
 			}
 		}
 
+		// recreate an empty `page` or `blueprints_blueprint` if the root becomes empty
+		for (const { pageType, rootId } of [
+			{ rootId: "root", pageType: "page" },
+			{ rootId: "blueprints_root", pageType: "blueprints_blueprint" },
+		]) {
+			const pages = wf.getComponents(rootId, {
+				includeBMC: true,
+				includeCMC: true,
+			});
+			if (pages.length > 0) continue;
+
+			const newPage = createComponent(pageType, rootId);
+			wf.addComponent(newPage);
+			ssbm.registerPostMutation(newPage);
+			wf.setActivePageId(newPage.id);
+		}
+
 		ssbm.closeMutationTransaction(transactionId);
 		wf.sendComponentUpdate();
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically recreates an empty page if all pages are deleted, ensuring there is always at least one page present.  
* **Tests**
  * Added test cases to verify that an empty page is recreated when all pages are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->