### PR TITLE
feat(BuilderSettingsProperties): Implement category tabs for settings fields - AB-100

### DIFF
--- a/src/ui/src/builder/settings/BuilderSettingsBinding.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsBinding.vue
@@ -1,5 +1,9 @@
 <template>
-	<div v-if="ssbm.isSingleSelectionActive" class="BuilderSettingsBinding">
+	<div
+		v-if="ssbm.isSingleSelectionActive"
+		:inert="isReadOnly"
+		class="BuilderSettingsBinding"
+	>
 		<WdsTitle2>Binding</WdsTitle2>
 		<WdsFieldWrapper
 			class="BuilderSettingsBinding__main"
@@ -30,6 +34,10 @@ import BuilderTemplateInput from "./BuilderTemplateInput.vue";
 import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
 import WdsTitle2 from "@/wds/WdsTitle2.vue";
 
+defineProps({
+	isReadOnly: { type: Boolean, required: true },
+});
+
 const hint =
 	"Connect the result of this block to a dynamic variable you can use across this agent";
 
@@ -47,6 +55,10 @@ const component = computed(() =>
 
 .BuilderSettingsBinding {
 	padding: 24px;
+}
+
+.BuilderSettingsBinding[inert] {
+	opacity: 0.7;
 }
 
 .BuilderSettingsBinding__main {

--- a/src/ui/src/builder/settings/BuilderSettingsHandlers.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsHandlers.vue
@@ -1,5 +1,9 @@
 <template>
-	<div v-if="shoudBeDisplayed" class="BuilderSettingsHandlers">
+	<div
+		v-if="shoudBeDisplayed"
+		:inert="isReadOnly"
+		class="BuilderSettingsHandlers"
+	>
 		<WdsTitle2 class="BuilderSettingsHandlers__title">Blueprints</WdsTitle2>
 		<div class="BuilderSettingsHandlers__list">
 			<div
@@ -23,6 +27,10 @@ import injectionKeys from "@/injectionKeys";
 import { WriterComponentDefinition } from "@/writerTypes";
 import BuilderSettingsHandlersBlueprint from "./BuilderSettingsHandlersBlueprint.vue";
 import WdsTitle2 from "@/wds/WdsTitle2.vue";
+
+defineProps({
+	isReadOnly: { type: Boolean, required: true },
+});
 
 const wf = inject(injectionKeys.core);
 const wfbm = inject(injectionKeys.builderManager);
@@ -57,6 +65,10 @@ const shoudBeDisplayed = computed(() => {
 
 .BuilderSettingsHandlers {
 	padding: 24px;
+}
+
+.BuilderSettingsHandlers[inert] {
+	opacity: 0.7;
 }
 
 .BuilderSettingsHandlers__title {

--- a/src/ui/src/builder/settings/BuilderSettingsMain.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsMain.vue
@@ -16,23 +16,22 @@
 			</span>
 		</p>
 
-		<div class="BuilderSettingsMain__section" :inert="isReadOnly">
-			<BuilderSettingsProperties />
-			<component
-				:is="artifactRegistry[a.key]"
-				v-for="a in artifactsTop"
-				:key="a.key"
-			/>
-			<template v-if="displaySettings">
-				<BuilderSettingsBinding v-if="isBindable" />
-				<BuilderSettingsHandlers />
-				<BuilderSettingsVisibility />
+		<div class="BuilderSettingsMain__section">
+			<BuilderSettingsProperties :is-read-only="isReadOnly" />
+			<template v-for="a in artifactsTop" :key="a.key">
+				<component :is="artifactRegistry[a.key]" :inert="isReadOnly" />
 			</template>
-			<component
-				:is="artifactRegistry[a.key]"
-				v-for="a in artifactsBottom"
-				:key="a.key"
-			/>
+			<template v-if="displaySettings">
+				<BuilderSettingsBinding
+					v-if="isBindable"
+					:is-read-only="isReadOnly"
+				/>
+				<BuilderSettingsHandlers :is-read-only="isReadOnly" />
+				<BuilderSettingsVisibility :is-read-only="isReadOnly" />
+			</template>
+			<template v-for="a in artifactsBottom" :key="a.key">
+				<component :is="artifactRegistry[a.key]" :inert="isReadOnly" />
+			</template>
 		</div>
 
 		<div class="BuilderSettingsMain__spacer"></div>
@@ -149,12 +148,12 @@ const artifactsBottom = computed(() =>
 	padding: 24px;
 }
 
-.BuilderSettingsMain__section > *:not(:first-child) {
-	border-top: 1px solid var(--builderSeparatorColor);
+.BuilderSettingsMain__section > *[inert] {
+	opacity: 0.7;
 }
 
-.BuilderSettingsMain__section[inert] {
-	opacity: 0.7;
+.BuilderSettingsMain__section > *:not(:first-child) {
+	border-top: 1px solid var(--builderSeparatorColor);
 }
 
 .BuilderSettingsMain__spacer {

--- a/src/ui/src/builder/settings/BuilderSettingsMain.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsMain.vue
@@ -18,9 +18,12 @@
 
 		<div class="BuilderSettingsMain__section">
 			<BuilderSettingsProperties :is-read-only="isReadOnly" />
-			<template v-for="a in artifactsTop" :key="a.key">
-				<component :is="artifactRegistry[a.key]" :inert="isReadOnly" />
-			</template>
+			<component
+				:is="artifactRegistry[a.key]"
+				v-for="a in artifactsTop"
+				:key="a.key"
+				:inert="isReadOnly"
+			/>
 			<template v-if="displaySettings">
 				<BuilderSettingsBinding
 					v-if="isBindable"
@@ -29,9 +32,12 @@
 				<BuilderSettingsHandlers :is-read-only="isReadOnly" />
 				<BuilderSettingsVisibility :is-read-only="isReadOnly" />
 			</template>
-			<template v-for="a in artifactsBottom" :key="a.key">
-				<component :is="artifactRegistry[a.key]" :inert="isReadOnly" />
-			</template>
+			<component
+				:is="artifactRegistry[a.key]"
+				v-for="a in artifactsBottom"
+				:key="a.key"
+				:inert="isReadOnly"
+			/>
 		</div>
 
 		<div class="BuilderSettingsMain__spacer"></div>

--- a/src/ui/src/builder/settings/BuilderSettingsProperties.spec.ts
+++ b/src/ui/src/builder/settings/BuilderSettingsProperties.spec.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { nextTick } from "vue";
 import BuilderSettingsProperties from "./BuilderSettingsProperties.vue";
 import BuilderFieldsCheckbox from "./BuilderFieldsCheckbox.vue";
-import { shallowMount } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
 import {
 	buildMockComponent,
 	buildMockCore,
@@ -14,11 +15,12 @@ import { flattenInstancePath } from "@/renderer/instancePath";
 import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
 import templateMap from "@/core/templateMap";
 import { useSecretsManager } from "@/core/useSecretsManager";
+import { FieldCategory, WriterComponentDefinitionField } from "@/writerTypes";
 
 describe("BuilderSettingsProperties", () => {
 	it.each(Object.keys(templateMap))(
 		"should render settings for %s",
-		(type) => {
+		async (type) => {
 			const { core } = buildMockCore();
 			const component = buildMockComponent({ type });
 			core.addComponent(component);
@@ -30,7 +32,7 @@ describe("BuilderSettingsProperties", () => {
 				"click",
 			);
 
-			const wrapper = shallowMount(BuilderSettingsProperties, {
+			const wrapper = mount(BuilderSettingsProperties, {
 				global: {
 					provide: {
 						...mockProvides,
@@ -42,19 +44,73 @@ describe("BuilderSettingsProperties", () => {
 				},
 			});
 
-			const wrapperFields = wrapper.findAllComponents(WdsFieldWrapper);
-			const checkboxFields = wrapper.findAllComponents(
-				BuilderFieldsCheckbox,
-			);
+			function getRenderedFieldsCount() {
+				const wrapperFields =
+					wrapper.findAllComponents(WdsFieldWrapper);
 
-			const renderedFieldsCount =
-				wrapperFields.length + checkboxFields.length;
+				const checkboxFields = wrapper.findAllComponents(
+					BuilderFieldsCheckbox,
+				);
 
-			// check that each fields is renderer
-			expect(renderedFieldsCount).toBe(
+				return wrapperFields.length + checkboxFields.length;
+			}
+
+			const fieldsByCategory: Record<
+				FieldCategory,
+				WriterComponentDefinitionField[]
+			> = {
+				[FieldCategory.General]: [],
+				[FieldCategory.Style]: [],
+				[FieldCategory.Tools]: [],
+			};
+
+			Object.values(
 				// @ts-expect-error TS doesn't infer the right type for the component
-				Object.keys(templateMap[type].writer.fields).length,
-			);
+				templateMap[type].writer.fields,
+			).forEach((field: WriterComponentDefinitionField) => {
+				switch (field.category) {
+					case FieldCategory.General:
+					case undefined: {
+						// fields with an empty category will be also rendered in General category
+						fieldsByCategory[FieldCategory.General].push(field);
+						break;
+					}
+					case FieldCategory.Style: {
+						fieldsByCategory[FieldCategory.Style].push(field);
+						break;
+					}
+					case FieldCategory.Tools: {
+						fieldsByCategory[FieldCategory.Tools].push(field);
+						break;
+					}
+					default: {
+						break;
+					}
+				}
+			});
+
+			const nonEmptyCategories = Object.entries(fieldsByCategory)
+				.filter(([_, fields]) => fields.length > 0)
+				.map(([category]) => category as FieldCategory);
+
+			if (nonEmptyCategories.length <= 1) {
+				expect(getRenderedFieldsCount()).toBe(
+					Object.values(fieldsByCategory).flat().length,
+				);
+				return;
+			}
+
+			for (const category of nonEmptyCategories) {
+				const categoryTab = wrapper.find(`button[value="${category}"]`);
+				expect(categoryTab.exists()).toBe(true);
+
+				await categoryTab.trigger("click");
+				await nextTick();
+
+				expect(getRenderedFieldsCount()).toBe(
+					fieldsByCategory[category].length,
+				);
+			}
 		},
 	);
 });

--- a/src/ui/src/builder/settings/BuilderSettingsProperties.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsProperties.vue
@@ -15,6 +15,7 @@
 				? [selectedCategoryTab]
 				: fieldCategories"
 			:key="propertyCategory"
+			:inert="isReadOnly"
 			class="BuilderSettingsProperties__category"
 		>
 			<div
@@ -248,6 +249,10 @@ import BuilderFieldsComponentEventType from "./BuilderFieldsComponentEventType.v
 import { useFieldsErrors } from "@/renderer/useFieldsErrors";
 import WdsTabs, { type WdsTabOptions } from "@/wds/WdsTabs.vue";
 
+defineProps({
+	isReadOnly: { type: Boolean, required: true },
+});
+
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
 const secretsManager = inject(injectionKeys.secretsManager);
@@ -290,20 +295,20 @@ const errorsByFields = useFieldsErrors(
 
 const selectedCategoryTab = ref<FieldCategory>(FieldCategory.General);
 
-const fieldCategoryTabOptions = computed<WdsTabOptions<FieldCategory>[]>(() => {
-	function categoryToLabel(category: FieldCategory) {
-		switch (category) {
-			case FieldCategory.General:
-				return "Configure";
-			case FieldCategory.Style:
-				return "Style";
-			case FieldCategory.Tools:
-				return "Tools";
-			default:
-				return category;
-		}
+function categoryToLabel(category: FieldCategory) {
+	switch (category) {
+		case FieldCategory.General:
+			return "Configure";
+		case FieldCategory.Style:
+			return "Style";
+		case FieldCategory.Tools:
+			return "Tools";
+		default:
+			return category;
 	}
+}
 
+const fieldCategoryTabOptions = computed<WdsTabOptions<FieldCategory>[]>(() => {
 	return fieldCategories.value.map((category) => ({
 		label: categoryToLabel(category),
 		value: category,
@@ -360,5 +365,9 @@ function handleShrink(fieldKey: string) {
 	display: flex;
 	flex-direction: column;
 	gap: 24px;
+}
+
+.BuilderSettingsProperties__category[inert] {
+	opacity: 0.7;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderSettingsProperties.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsProperties.vue
@@ -3,18 +3,20 @@
 		v-if="ssbm.isSingleSelectionActive && fields"
 		class="BuilderSettingsProperties"
 	>
+		<WdsTabs
+			v-if="fieldCategories.length > 1"
+			v-model="selectedCategoryTab"
+			variant="bar"
+			:tabs="fieldCategoryTabOptions"
+		/>
+
 		<div
-			v-for="propertyCategory in fieldCategories"
+			v-for="propertyCategory in fieldCategories.length > 1
+				? [selectedCategoryTab]
+				: fieldCategories"
 			:key="propertyCategory"
 			class="BuilderSettingsProperties__category"
 		>
-			<WdsTitle2
-				v-if="
-					fieldsByCategory[propertyCategory].length > 0 &&
-					propertyCategory !== 'General'
-				"
-				>{{ propertyCategory }}</WdsTitle2
-			>
 			<div
 				v-for="[fieldKey, fieldValue] in fieldsByCategory[
 					propertyCategory
@@ -244,7 +246,7 @@ import BuilderFieldsWriterResourceId from "./BuilderFieldsWriterResourceId.vue";
 import BuilderFieldsComponentId from "./BuilderFieldsComponentId.vue";
 import BuilderFieldsComponentEventType from "./BuilderFieldsComponentEventType.vue";
 import { useFieldsErrors } from "@/renderer/useFieldsErrors";
-import WdsTitle2 from "@/wds/WdsTitle2.vue";
+import WdsTabs, { type WdsTabOptions } from "@/wds/WdsTabs.vue";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -285,6 +287,28 @@ const errorsByFields = useFieldsErrors(
 	selectedInstancePath,
 	secretsManager,
 );
+
+const selectedCategoryTab = ref<FieldCategory>(FieldCategory.General);
+
+const fieldCategoryTabOptions = computed<WdsTabOptions<FieldCategory>[]>(() => {
+	function categoryToLabel(category: FieldCategory) {
+		switch (category) {
+			case FieldCategory.General:
+				return "Configure";
+			case FieldCategory.Style:
+				return "Style";
+			case FieldCategory.Tools:
+				return "Tools";
+			default:
+				return category;
+		}
+	}
+
+	return fieldCategories.value.map((category) => ({
+		label: categoryToLabel(category),
+		value: category,
+	}));
+});
 
 const fieldCategories = computed(() => {
 	return [
@@ -329,12 +353,12 @@ function handleShrink(fieldKey: string) {
 
 	display: flex;
 	flex-direction: column;
-	gap: 16px;
+	gap: 24px;
 }
 
 .BuilderSettingsProperties__category {
 	display: flex;
 	flex-direction: column;
-	gap: 16px;
+	gap: 24px;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderSettingsProperties.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsProperties.vue
@@ -295,22 +295,15 @@ const errorsByFields = useFieldsErrors(
 
 const selectedCategoryTab = ref<FieldCategory>(FieldCategory.General);
 
-function categoryToLabel(category: FieldCategory) {
-	switch (category) {
-		case FieldCategory.General:
-			return "Configure";
-		case FieldCategory.Style:
-			return "Style";
-		case FieldCategory.Tools:
-			return "Tools";
-		default:
-			return category;
-	}
-}
+const LABELS_BY_CATEGORY = Object.freeze<Record<FieldCategory, string>>({
+	[FieldCategory.General]: "Configure",
+	[FieldCategory.Style]: "Style",
+	[FieldCategory.Tools]: "Tools",
+});
 
 const fieldCategoryTabOptions = computed<WdsTabOptions<FieldCategory>[]>(() => {
 	return fieldCategories.value.map((category) => ({
-		label: categoryToLabel(category),
+		label: LABELS_BY_CATEGORY[category] ?? category,
 		value: category,
 	}));
 });

--- a/src/ui/src/builder/settings/BuilderSettingsVisibility.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsVisibility.vue
@@ -1,5 +1,9 @@
 <template>
-	<div v-if="ssbm.isSingleSelectionActive" class="BuilderSettingsVisibility">
+	<div
+		v-if="ssbm.isSingleSelectionActive"
+		:inert="isReadOnly"
+		class="BuilderSettingsVisibility"
+	>
 		<WdsTitle2>Visibility</WdsTitle2>
 		<div class="main">
 			<WdsTabs v-model="tab" :tabs="tabs" />
@@ -53,6 +57,10 @@ import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
 import WdsTabs, { WdsTabOptions } from "@/wds/WdsTabs.vue";
 import WdsTitle2 from "@/wds/WdsTitle2.vue";
 
+defineProps({
+	isReadOnly: { type: Boolean, required: true },
+});
+
 type Mode = "yes" | "no" | "custom";
 
 const tabs: WdsTabOptions<Mode>[] = [
@@ -98,6 +106,10 @@ const hint =
 
 <style scoped>
 @import "../sharedStyles.css";
+
+.BuilderSettingsVisibility[inert] {
+	opacity: 0.7;
+}
 
 .main {
 	margin-top: 16px;

--- a/src/ui/src/wds/WdsTab.vue
+++ b/src/ui/src/wds/WdsTab.vue
@@ -1,22 +1,36 @@
 <template>
 	<button
 		class="WdsTab"
-		:class="{ 'WdsTab--disabled': disabled, 'WdsTab--selected': selected }"
+		:class="{
+			'WdsTab--disabled': disabled,
+			'WdsTab--selected': selected,
+			'WdsTab--variant-bar': variant === 'bar',
+			'WdsTab--variant-chip': variant === 'chip',
+		}"
 		type="button"
 		:disabled="Boolean(disabled)"
 		:data-writer-tooltip="tooltip"
 		@click="$emit('click')"
 	>
 		<slot />
+		<div v-if="variant === 'bar'" class="WdsTab__indicator"></div>
 	</button>
 </template>
 
+<script lang="ts">
+export type WdsTabVariant = "chip" | "bar";
+</script>
+
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, PropType } from "vue";
 
 const props = defineProps({
 	disabled: { type: [Boolean, String], default: undefined },
 	selected: { type: Boolean },
+	variant: {
+		type: String as PropType<WdsTabVariant>,
+		required: true,
+	},
 });
 
 const tooltip = computed(() =>
@@ -31,25 +45,57 @@ defineEmits({
 <style scoped>
 .WdsTab {
 	/* reset button */
+	position: relative;
 	border: none;
 	background-color: transparent;
 	cursor: pointer;
-
-	padding: 4px 20px 4px 20px;
-	gap: 10px;
-	border-radius: 8px;
 }
 
-.WdsTab:hover {
-	background-color: var(--wdsColorBlue1);
+.WdsTab__indicator {
+	pointer-events: none;
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	height: 2px;
+	width: 100%;
+	background: currentColor;
+	opacity: 0;
 }
 
 .WdsTab--disabled {
-	color: var(--wdsColorGray4);
 	cursor: not-allowed;
 }
 
-.WdsTab--selected {
+.WdsTab--variant-bar {
+	padding: 10px 0;
+	font-size: 14px;
+	line-height: 180%;
+	color: var(--wdsColorGray5);
+}
+
+.WdsTab--variant-bar.WdsTab--selected {
+	color: var(--wdsColorBlack);
+}
+
+.WdsTab--variant-bar.WdsTab--selected .WdsTab__indicator {
+	opacity: 1;
+}
+
+.WdsTab--variant-chip {
+	padding: 4px 20px 4px 20px;
+	border-radius: 8px;
+}
+
+.WdsTab--variant-chip:hover {
+	background-color: var(--wdsColorBlue1);
+}
+
+.WdsTab--variant-chip.WdsTab--selected {
 	background-color: var(--wdsColorBlue2);
+}
+
+.WdsTab--variant-chip.WdsTab--disabled {
+	color: var(--wdsColorGray4);
 }
 </style>

--- a/src/ui/src/wds/WdsTabs.vue
+++ b/src/ui/src/wds/WdsTabs.vue
@@ -1,8 +1,15 @@
 <template>
-	<div class="WdsTabs">
+	<div
+		class="WdsTabs"
+		:class="{
+			'WdsTabs--variant-bar': variant === 'bar',
+			'WdsTabs--variant-chip': variant === 'chip',
+		}"
+	>
 		<WdsTab
 			v-for="tab of tabs"
 			:key="tab.value"
+			:variant
 			:disabled="tab.disabled"
 			:selected="tab.value === selected"
 			@click="selected = tab.value"
@@ -21,12 +28,16 @@ export interface WdsTabOptions<Value extends string = string> {
 
 <script setup lang="ts">
 import { PropType } from "vue";
-import WdsTab from "./WdsTab.vue";
+import WdsTab, { type WdsTabVariant } from "./WdsTab.vue";
 
 defineProps({
 	tabs: {
 		type: Array as PropType<WdsTabOptions[] | Readonly<WdsTabOptions[]>>,
 		required: true,
+	},
+	variant: {
+		type: String as PropType<WdsTabVariant>,
+		default: "chip",
 	},
 });
 
@@ -36,6 +47,15 @@ const selected = defineModel({ type: String });
 <style scoped>
 .WdsTabs {
 	display: flex;
+}
+
+.WdsTabs--variant-bar {
+	gap: 32px;
+	overflow-x: auto;
+	border-bottom: 1px solid var(--wdsColorGray2);
+}
+
+.WdsTabs--variant-chip {
 	gap: 16px;
 	flex-wrap: wrap;
 }

--- a/src/ui/src/wds/WdsTabs.vue
+++ b/src/ui/src/wds/WdsTabs.vue
@@ -9,6 +9,7 @@
 		<WdsTab
 			v-for="tab of tabs"
 			:key="tab.value"
+			:value="tab.value"
 			:variant
 			:disabled="tab.disabled"
 			:selected="tab.value === selected"

--- a/tests/e2e/tests/builderFieldValidation.spec.ts
+++ b/tests/e2e/tests/builderFieldValidation.spec.ts
@@ -25,6 +25,9 @@ test.describe("Builder field validation", () => {
 			.locator(`.BuilderSidebarToolkit [data-component-type="button"]`)
 			.dragTo(page.locator(".CoreSection"));
 		await page.locator(`button.CoreButton.component`).click();
+		await page
+			.locator(`.BuilderSettingsProperties button[value="Style"]`)
+			.click();
 
 		// css classes
 		const fieldWrapper = page.locator(

--- a/tests/e2e/tests/lowCode.spec.ts
+++ b/tests/e2e/tests/lowCode.spec.ts
@@ -86,29 +86,50 @@ with ui.find('results'):
 			`,
 				);
 				await execute(page);
-				await expect(
-					page.locator(`.results .wf-type-${type}.component`),
-				).toHaveCount(1);
 
-				await page
-					.locator(`.results .wf-type-${type}.component`)
-					.click({ force: true });
+				const componentLocator = page.locator(
+					`.results .wf-type-${type}.component`,
+				);
+
+				const settingsLocator = page.locator(".BuilderSettings");
+
+				await expect(componentLocator).toHaveCount(1);
+
+				await componentLocator.click({ force: true });
+
 				for (const [key, value] of Object.entries(props)) {
-					await expect(
-						page
-							.locator(".BuilderSettings")
-							.locator(`div[data-automation-key="${key}"]`),
-					).toHaveCount(1);
+					const fieldLocator = settingsLocator.locator(
+						`div[data-automation-key="${key}"]`,
+					);
+
+					let isFieldFound = (await fieldLocator.count()) > 0;
+
+					if (!isFieldFound) {
+						const categoryTabLocator = settingsLocator.locator(
+							`.WdsTabs.WdsTabs--variant-bar button`,
+						);
+						const categoryTabCount = await categoryTabLocator.count();
+
+						for (let i = 0; i < Math.max(1, categoryTabCount); i++) {
+							if (categoryTabCount > 0) {
+								await categoryTabLocator.nth(i).click({ force: true });
+								await page.waitForTimeout(100);
+							}
+
+							if ((await fieldLocator.count()) > 0) {
+								isFieldFound = true;
+								break;
+							}
+						}
+					}
+
+					expect(isFieldFound).toBe(true);
 				}
 
 				if (renderError) {
-					await expect(
-						page.locator(`.results .wf-type-${type}.component`),
-					).toHaveClass(/RenderError/);
+					await expect(componentLocator).toHaveClass(/RenderError/);
 				} else {
-					await expect(
-						page.locator(`.results .wf-type-${type}.component`),
-					).not.toHaveClass(/RenderError/);
+					await expect(componentLocator).not.toHaveClass(/RenderError/);
 				}
 			});
 		});

--- a/tests/e2e/tests/lowCode.spec.ts
+++ b/tests/e2e/tests/lowCode.spec.ts
@@ -106,14 +106,17 @@ with ui.find('results'):
 
 					if (!isFieldFound) {
 						const categoryTabLocator = settingsLocator.locator(
-							`.WdsTabs.WdsTabs--variant-bar button`,
+							`button.WdsTab.WdsTab--variant-bar`,
 						);
 						const categoryTabCount = await categoryTabLocator.count();
 
 						for (let i = 0; i < Math.max(1, categoryTabCount); i++) {
 							if (categoryTabCount > 0) {
-								await categoryTabLocator.nth(i).click({ force: true });
-								await page.waitForTimeout(100);
+								await categoryTabLocator.nth(i).click();
+
+								expect(categoryTabLocator.nth(i)).toHaveClass(
+									/WdsTab--selected/,
+								);
 							}
 
 							if ((await fieldLocator.count()) > 0) {
@@ -135,9 +138,13 @@ with ui.find('results'):
 		});
 	test("settings should be enabled for bmc", async ({ page }) => {
 		await page.locator(`.results`).click({ force: true });
-		await expect(
-			page.locator(`.BuilderSettingsMain > .BuilderSettingsMain__section`),
-		).not.toHaveAttribute("inert");
+
+		const readOnlySections = page.locator(
+			".BuilderSettingsMain > .BuilderSettingsMain__section *[inert]",
+		);
+
+		expect(await readOnlySections.count()).toBe(0);
+
 		await expect(
 			page.locator(`.BuilderSettingsMain > .cmc-warning`),
 		).toHaveCount(0);
@@ -155,9 +162,13 @@ with ui.find('results'):
 		await page
 			.locator(`.results .wf-type-text.component.out`)
 			.click({ force: true });
-		await expect(
-			page.locator(`.BuilderSettingsMain > .BuilderSettingsMain__section`),
-		).toHaveAttribute("inert");
+
+		const readOnlySections = page.locator(
+			".BuilderSettingsMain > .BuilderSettingsMain__section *[inert]",
+		);
+
+		expect(await readOnlySections.count()).toBeGreaterThan(0);
+
 		await expect(
 			page.locator(`.BuilderSettingsMain > .cmc-warning`),
 		).toHaveCount(1);

--- a/tests/e2e/tests/stateAutocompletion.spec.ts
+++ b/tests/e2e/tests/stateAutocompletion.spec.ts
@@ -150,6 +150,9 @@ test.describe("state autocompletion", () => {
 			const FIELD = `.${type}[data-automation-key="${key}"]`;
 			const field = page.locator(`.${type}[data-automation-key="${key}"]`);
 			await page.locator(componentSelector).click();
+			await page
+				.locator(`.BuilderSettingsProperties button[value="Style"]`)
+				.click();
 			await field.locator(`button.WdsTab:text-matches("CSS")`).click();
 			await field
 				.locator(`.BuilderTemplateInput`)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tabbed navigation for settings categories, allowing users to switch between "Configure", "Style", and "Tools" sections when multiple categories are present.
  * Introduced two visual styles for tabs: "bar" and "chip", enhancing the appearance and usability of tabbed interfaces.
  * Added a read-only mode to settings components that visually disables interaction by reducing opacity and applying inert behavior.

* **Style**
  * Updated spacing and visual treatments for tabs and settings layout to improve clarity and consistency.
  * Added distinct visual indicators and styling rules for the new tab variants.
  * Applied reduced opacity styling to settings sections when in read-only mode.

* **Bug Fixes**
  * Improved accuracy of settings display by ensuring only fields from the selected category are shown when using tabs.

* **Tests**
  * Enhanced tests to verify correct rendering and interaction with category tabs in the settings UI.
  * Improved test robustness by adding steps to navigate tabs when verifying field visibility and validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->