### PR TITLE
fix(ui): graceful handling for refused websocket connection; error display w/ reason catching

### DIFF
--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -129,7 +129,7 @@ export function generateCore() {
 			} catch {
 				if (attempt >= maxRetries - 1) {
 					throw new Error(
-						`Failed to acquire initialization data. Server responded with ${response.status} status.`,
+						`Failed to acquire initialization data. Server responded with ${response?.status ?? "no response"} status.`,
 					);
 				}
 				await new Promise((r) => setTimeout(r, RECONNECT_DELAY_MS * (attempt + 1)));
@@ -362,8 +362,25 @@ export function generateCore() {
 		};
 
 		return new Promise((resolve, reject) => {
-			webSocket.addEventListener("open", () => resolve(), { once: true });
-			webSocket.addEventListener("close", () => reject(), { once: true });
+			function handleOpen() {
+				cleanup();
+				resolve();
+			}
+			function handleClose() {
+				cleanup();
+				reject(
+					new Error(
+						"WebSocket connection closed before establishing.",
+					),
+				);
+			}
+			function cleanup() {
+				webSocket.removeEventListener("open", handleOpen);
+				webSocket.removeEventListener("close", handleClose);
+			}
+
+			webSocket.addEventListener("open", handleOpen);
+			webSocket.addEventListener("close", handleClose);
 		});
 	}
 

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -362,25 +362,10 @@ export function generateCore() {
 		};
 
 		return new Promise((resolve, reject) => {
-			function handleOpen() {
-				cleanup();
-				resolve();
-			}
-			function handleClose() {
-				cleanup();
-				reject(
-					new Error(
-						"WebSocket connection closed before establishing.",
-					),
-				);
-			}
-			function cleanup() {
-				webSocket.removeEventListener("open", handleOpen);
-				webSocket.removeEventListener("close", handleClose);
-			}
-
-			webSocket.addEventListener("open", handleOpen);
-			webSocket.addEventListener("close", handleClose);
+			webSocket.addEventListener("open", () => resolve(), { once: true });
+			webSocket.addEventListener("close", () => {
+				reject(new Error("WebSocket connection closed before establishing."));
+			}, { once: true });
 		});
 	}
 

--- a/src/ui/src/main.ts
+++ b/src/ui/src/main.ts
@@ -91,6 +91,9 @@ load()
 	.catch((reason) => {
 		logger.error("Core initialisation failed.", reason);
 		const errorDiv = document.createElement("div");
+		errorDiv.className = "error-message";
+		errorDiv.setAttribute("role", "alert");
+		errorDiv.style.cssText = "padding: 20px; color: #d32f2f; background: #ffebee; border: 1px solid #e57373; border-radius: 4px; margin: 20px; font-family: system-ui, sans-serif;";
 		errorDiv.textContent =
 				"Failed to initialise application" +
 				(reason?.message ? `: ${reason.message}` : "");

--- a/src/ui/src/main.ts
+++ b/src/ui/src/main.ts
@@ -90,5 +90,11 @@ load()
 	})
 	.catch((reason) => {
 		logger.error("Core initialisation failed.", reason);
-		document.write(reason);
+		const errorDiv = document.createElement("div");
+		errorDiv.textContent =
+				"Failed to initialise application" +
+				(reason?.message ? `: ${reason.message}` : "");
+		const loadingSpinner = document.getElementById("loading_L1");
+		loadingSpinner?.remove();
+		document.body.appendChild(errorDiv);
 	});

--- a/src/ui/src/main.ts
+++ b/src/ui/src/main.ts
@@ -93,10 +93,29 @@ load()
 		const errorDiv = document.createElement("div");
 		errorDiv.className = "error-message";
 		errorDiv.setAttribute("role", "alert");
-		errorDiv.style.cssText = "padding: 20px; color: #d32f2f; background: #ffebee; border: 1px solid #e57373; border-radius: 4px; margin: 20px; font-family: system-ui, sans-serif;";
-		errorDiv.textContent =
-				"Failed to initialise application" +
-				(reason?.message ? `: ${reason.message}` : "");
+		errorDiv.style.cssText = "padding: 20px; color: #d32f2f; background: #ffebee; border: 1px solid #e57373; border-radius: 4px; margin: 20px; font-family: \"Poppins\", \"Helvetica Neue\", \"Lucida Grande\", sans-serif;";
+
+		const message = document.createElement("div");
+		message.textContent =
+			"Failed to initialise application" +
+			(reason?.message ? `: ${reason.message}` : "");
+
+		const instructions = document.createElement("div");
+		instructions.style.marginTop = "12px";
+		instructions.textContent =
+			"This might mean the Agent Builder is still being prepared. Try reloading the page in a few seconds.";
+
+		const reloadButton = document.createElement("button");
+		reloadButton.textContent = "Reload page";
+		reloadButton.className = "WdsButton WdsButton--small WdsButton--tertiary";
+		reloadButton.style.cssText =
+			"margin-top: 16px; font-size: .875rem; font-weight: 600; border-radius: 300px; padding: 4px 16px; height: 32px; background: var(--wdsColorWhite); color: var(--wdsColorBlack); border-color: var(--wdsColorGray2); border-width: 1px; border-style: solid; box-shadow: var(--buttonShadow); cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 8px; outline: none; position: relative; overflow: hidden; max-width: 100%; width: fit-content;";
+		reloadButton.onclick = () => window.location.reload();
+
+		errorDiv.appendChild(message);
+		errorDiv.appendChild(instructions);
+		errorDiv.appendChild(reloadButton);
+
 		const loadingSpinner = document.getElementById("loading_L1");
 		loadingSpinner?.remove();
 		document.body.appendChild(errorDiv);


### PR DESCRIPTION
- Replaced the previous error handling with a div that shows a message explaining why initialization failed, removing the loading spinner before displaying it; div now potentially can be extended with a class name and additional design
- Updated the WebSocket startup logic to cleanly remove temporary listeners and provide an explicit error when the socket closes before establishing a connection
- Added error logging and improved the thrown error message in the retry loop of initSession to handle cases where no response is received

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during initialization to prevent runtime errors and provide clearer error messages if initialization fails.
  * Enhanced WebSocket connection handling to provide explicit error messages when connections close prematurely.
  * Updated error display to present user-friendly, accessible messages with retry instructions and a reload button, replacing the previous page overwrite and removing the loading spinner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->