### PR TITLE
fix(ui): allow XML tags in template editor - AB-206

### DIFF
--- a/src/ui/src/builder/templateEditor/BuilderTemplateEditor.vue
+++ b/src/ui/src/builder/templateEditor/BuilderTemplateEditor.vue
@@ -125,7 +125,7 @@ if (props.multiline) {
 
 const editor = useEditor({
 	extensions: editorExtensions,
-	content: model.value,
+	content: computeJSONDocument(model.value ?? ""),
 	editorProps: {
 		attributes: {
 			"data-automation-key": "template-editor",


### PR DESCRIPTION
<img width="1188" height="522" alt="image" src="https://github.com/user-attachments/assets/d3308cd4-9eee-4559-bff0-c275ca4a9ac8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multiline content in the template editor, ensuring line breaks are correctly displayed when initializing the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->