### PR TITLE
fix(ui): prevent trailing breaking lines in field editor - AB-207

### DIFF
--- a/src/ui/src/builder/templateEditor/BuilderTemplateEditor.spec.ts
+++ b/src/ui/src/builder/templateEditor/BuilderTemplateEditor.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { useSecretsManager } from "@/core/useSecretsManager";
+import injectionKeys from "@/injectionKeys";
+import { buildMockCore } from "@/tests/mocks";
+import { generateBuilderManager } from "../builderManager";
+import BuilderTemplateEditor from "./BuilderTemplateEditor.vue";
+
+describe("BuilderTemplateEditor", () => {
+	let mockCore: ReturnType<typeof buildMockCore>;
+	let wfbm: ReturnType<typeof generateBuilderManager>;
+	let mockUseSecretsManager: ReturnType<typeof useSecretsManager>;
+
+	beforeEach(() => {
+		mockCore = buildMockCore();
+		mockCore.userState.value = {
+			var: "1",
+		};
+		wfbm = generateBuilderManager();
+
+		mockUseSecretsManager = useSecretsManager(mockCore.core);
+	});
+
+	async function mountWrapper(
+		props: InstanceType<typeof BuilderTemplateEditor>["$props"],
+	) {
+		const wrapper = mount(BuilderTemplateEditor, {
+			props,
+			global: {
+				provide: {
+					[injectionKeys.core]: mockCore.core,
+					[injectionKeys.builderManager]: wfbm,
+					[injectionKeys.secretsManager]: mockUseSecretsManager,
+				},
+			},
+		});
+		await flushPromises();
+		return wrapper;
+	}
+
+	describe("single line", () => {
+		it("should render var", async () => {
+			const wrapper = await mountWrapper({
+				modelValue: "This is a single line with a @{var}!",
+			});
+			expect(
+				wrapper.get(".BuilderTemplateEditorInterpolation").text(),
+			).toBe("@{var}");
+			expect(wrapper.find("br").exists()).toBeFalsy();
+
+			expect(wrapper.element).toMatchSnapshot();
+		});
+	});
+
+	describe("multi line", () => {
+		it("should render var", async () => {
+			const wrapper = await mountWrapper({
+				modelValue: "This is a single line with a @{var}!",
+				multiline: true,
+			});
+
+			expect(
+				wrapper.get(".BuilderTemplateEditorInterpolation").text(),
+			).toBe("@{var}");
+			expect(wrapper.find("br").exists()).toBeFalsy();
+
+			expect(wrapper.element).toMatchSnapshot();
+		});
+
+		it("should render multiline", async () => {
+			const wrapper = await mountWrapper({
+				modelValue: [
+					"This is a single line with a @{var}!",
+					"with a @{second} line",
+				].join("\n"),
+				multiline: true,
+			});
+
+			expect(
+				wrapper.get(".BuilderTemplateEditorInterpolation").text(),
+			).toBe("@{var}");
+			expect(wrapper.findAll("br")).toHaveLength(1);
+
+			expect(wrapper.element).toMatchSnapshot();
+		});
+
+		it("should render multiples multiline", async () => {
+			const wrapper = await mountWrapper({
+				modelValue: ["", "", "", "line 3", "", "line 5"].join("\n"),
+				multiline: true,
+			});
+
+			expect(wrapper.findAll("br")).toHaveLength(5);
+
+			expect(wrapper.element).toMatchSnapshot();
+		});
+	});
+});

--- a/src/ui/src/builder/templateEditor/BuilderTemplateEditor.vue
+++ b/src/ui/src/builder/templateEditor/BuilderTemplateEditor.vue
@@ -144,16 +144,21 @@ const editor = useEditor({
  * TipTap doesn't handle when using `setContent` with a string containing breaklines (`\n`). The safest solution is to recreate the document as JSON representation
  */
 function computeJSONDocument(text: string) {
-	const paragraphContent = text.split("\n").reduce((acc, line, i, lines) => {
-		if (line === "") {
-			acc.push({ type: "hardBreak" });
-			return acc;
-		}
+	let paragraphContent = [];
+	if (text) {
+		paragraphContent = text.split("\n").reduce((acc, line, i, lines) => {
+			if (line === "" && props.multiline) {
+				acc.push({ type: "hardBreak" });
+				return acc;
+			}
 
-		acc.push({ type: "text", text: line });
-		if (i < lines.length - 1) acc.push({ type: "hardBreak" });
-		return acc;
-	}, []);
+			acc.push({ type: "text", text: line });
+			if (i < lines.length - 1 && props.multiline) {
+				acc.push({ type: "hardBreak" });
+			}
+			return acc;
+		}, []);
+	}
 
 	return {
 		type: "doc",

--- a/src/ui/src/builder/templateEditor/__snapshots__/BuilderTemplateEditor.spec.ts.snap
+++ b/src/ui/src/builder/templateEditor/__snapshots__/BuilderTemplateEditor.spec.ts.snap
@@ -1,0 +1,122 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`BuilderTemplateEditor > multi line > should render multiline 1`] = `
+<div
+  class="BuilderTemplateEditor"
+  data-v-a0921c0a=""
+  modelvalue="This is a single line with a @{var}!
+with a @{second} line"
+>
+  <div
+    class="tiptap ProseMirror"
+    contenteditable="true"
+    data-automation-key="template-editor"
+    tabindex="0"
+    translate="no"
+  >
+    <p>
+      This is a single line with a 
+      <span
+        class="BuilderTemplateEditorInterpolation"
+        style="background-color: rgb(212, 255, 242);"
+      >
+        @{var}
+      </span>
+      !
+      <br />
+      with a 
+      <span
+        class="BuilderTemplateEditorInterpolation"
+      >
+        @{second}
+      </span>
+       line
+    </p>
+  </div>
+</div>
+`;
+
+exports[`BuilderTemplateEditor > multi line > should render multiples multiline 1`] = `
+<div
+  class="BuilderTemplateEditor"
+  data-v-a0921c0a=""
+  modelvalue="
+
+
+line 3
+
+line 5"
+>
+  <div
+    class="tiptap ProseMirror"
+    contenteditable="true"
+    data-automation-key="template-editor"
+    tabindex="0"
+    translate="no"
+  >
+    <p>
+      <br />
+      <br />
+      <br />
+      line 3
+      <br />
+      <br />
+      line 5
+    </p>
+  </div>
+</div>
+`;
+
+exports[`BuilderTemplateEditor > multi line > should render var 1`] = `
+<div
+  class="BuilderTemplateEditor"
+  data-v-a0921c0a=""
+  modelvalue="This is a single line with a @{var}!"
+>
+  <div
+    class="tiptap ProseMirror"
+    contenteditable="true"
+    data-automation-key="template-editor"
+    tabindex="0"
+    translate="no"
+  >
+    <p>
+      This is a single line with a 
+      <span
+        class="BuilderTemplateEditorInterpolation"
+        style="background-color: rgb(212, 255, 242);"
+      >
+        @{var}
+      </span>
+      !
+    </p>
+  </div>
+</div>
+`;
+
+exports[`BuilderTemplateEditor > single line > should render var 1`] = `
+<div
+  class="BuilderTemplateEditor"
+  data-v-a0921c0a=""
+  modelvalue="This is a single line with a @{var}!"
+>
+  <div
+    class="tiptap ProseMirror"
+    contenteditable="true"
+    data-automation-key="template-editor"
+    tabindex="0"
+    translate="no"
+  >
+    <p>
+      This is a single line with a 
+      <span
+        class="BuilderTemplateEditorInterpolation"
+        style="background-color: rgb(212, 255, 242);"
+      >
+        @{var}
+      </span>
+      !
+    </p>
+  </div>
+</div>
+`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for the template editor to verify correct rendering of single-line and multi-line inputs, as well as proper display of variable interpolations.

* **Bug Fixes**
  * Improved handling of line breaks and text rendering in the template editor when multiline mode is enabled, ensuring more accurate display of content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->