### PR TITLE
fix(ui): use default value for `BuilderFieldsCheckbox` - AB-208

### DIFF
--- a/src/ui/src/builder/settings/BuilderFieldsCheckbox.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsCheckbox.vue
@@ -65,7 +65,17 @@ const ssbm = inject(injectionKeys.builderManager);
 const { setContentValue: _setContentValue } = useComponentActions(wf, ssbm);
 
 const component = computed(() => wf.getComponentById(props.componentId));
-const contentValue = computed(() => component.value.content[props.fieldKey]);
+const templateField = computed(() => {
+	const type = component.value?.type;
+	if (!type) return;
+	const definition = wf.getComponentDefinition(type);
+	if (!definition) return;
+	return definition.fields[props.fieldKey];
+});
+const contentValue = computed(
+	() =>
+		component.value.content[props.fieldKey] ?? templateField.value?.default,
+);
 
 function setContentValue(value: string) {
 	_setContentValue(component.value.id, props.fieldKey, value);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of checkbox field values by providing a default fallback when no value is set, ensuring more consistent behavior in the settings interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->