### PR TITLE
fix: increase maximum temperature for WRITER blocks

### DIFF
--- a/src/writer/blocks/writerchatreply.py
+++ b/src/writer/blocks/writerchatreply.py
@@ -57,7 +57,7 @@ class WriterChatReply(WriterBlock):
                             "validator": {
                                 "type": "number",
                                 "minimum": 0,
-                                "maximum": 1,
+                                "maximum": 2,
                             },
                         },
                         "initMaxTokens": {


### PR DESCRIPTION
Updates temperature settings in `WriterChatReply` to have the maximum value of 2, in sync with WRITER API.
Note: `WriterCompletion` and `WriterInitChat` were not updated due to being deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum allowed value for the initial temperature setting to 2, providing greater flexibility for users when adjusting this parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->