### PR TITLE
chore: clean up tests to use unified `tests.backend` path

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package

--- a/tests/backend/test_app_runner.py
+++ b/tests/backend/test_app_runner.py
@@ -10,8 +10,8 @@ from writer.ss_types import (
     WriterEvent,
 )
 
-from backend.fixtures.app_runner_fixtures import init_app_session
 from tests.backend import test_app_dir
+from tests.backend.fixtures.app_runner_fixtures import init_app_session
 
 
 class TestAppRunner:

--- a/tests/backend/test_audit_and_fix.py
+++ b/tests/backend/test_audit_and_fix.py
@@ -2,7 +2,7 @@ import json
 
 from writer import audit_and_fix
 
-from backend.fixtures import load_fixture_content
+from tests.backend.fixtures import load_fixture_content
 
 
 def test_fix_components_should_fix_visible_fields():

--- a/tests/backend/test_core_ui.py
+++ b/tests/backend/test_core_ui.py
@@ -3,7 +3,7 @@ from typing import List
 from writer import core_ui
 from writer.ss_types import ComponentDefinition
 
-from backend.fixtures import load_fixture_content
+from tests.backend.fixtures import load_fixture_content
 
 
 def test_filter_components_by_should_retrieve_a_list_of_components_that_fit_the_parent():

--- a/tests/backend/test_deploy.py
+++ b/tests/backend/test_deploy.py
@@ -4,7 +4,7 @@ import re
 from click.testing import CliRunner
 from writer.command_line import main
 
-from backend.fixtures.cloud_deploy_fixtures import use_fake_cloud_deploy_server
+from tests.backend.fixtures.cloud_deploy_fixtures import use_fake_cloud_deploy_server
 
 
 def _assert_warning(result, url = "https://my-app.com"):

--- a/tests/backend/test_middleware.py
+++ b/tests/backend/test_middleware.py
@@ -2,8 +2,8 @@ import pytest
 from writer.app_runner import AppRunner
 from writer.ss_types import WriterEvent
 
-from backend import test_app_dir
-from backend.fixtures.app_runner_fixtures import init_app_session
+from tests.backend import test_app_dir
+from tests.backend.fixtures.app_runner_fixtures import init_app_session
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_ui.py
+++ b/tests/backend/test_ui.py
@@ -13,8 +13,8 @@ from writer.core_ui import (
 )
 from writer.ui import WriterUIManager
 
-from backend.fixtures import core_ui_fixtures
 from tests.backend import test_app_dir
+from tests.backend.fixtures import core_ui_fixtures
 
 _, sc = wf_project.read_files(test_app_dir)
 sc = audit_and_fix.fix_components(sc)


### PR DESCRIPTION
Unify paths access in all backend tests to `tests.backend` & add `__init__.py` to `tests/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated import paths in several test files to reference fixtures within the test directory structure.
  * Added an initializer file to the tests package for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->