### PR TITLE
fix(BuilderFieldsWriterResourceId): stretches the field as wide as the container - AB-214

### DIFF
--- a/src/ui/src/builder/settings/BuilderFieldsWriterResourceId.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsWriterResourceId.vue
@@ -187,9 +187,14 @@ function onSelectedData(appData: WriterApplication | undefined) {
 @import "../sharedStyles.css";
 
 .BuilderFieldsWriterResourceId {
-	display: flex;
+	display: grid;
+	grid-template-columns: 1fr;
 	align-items: center;
 	gap: 12px;
+}
+
+.BuilderFieldsWriterResourceId:has(.BuilderFieldsWriterResourceId__link) {
+	grid-template-columns: 1fr auto;
 }
 
 .BuilderFieldsWriterResourceId__link {

--- a/src/ui/src/builder/settings/BuilderFieldsWriterResourceId.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsWriterResourceId.vue
@@ -48,7 +48,6 @@ import {
 	PropType,
 	defineAsyncComponent,
 	useTemplateRef,
-	ref,
 	toRef,
 } from "vue";
 import { useComponentFieldViewModel } from "../useComponentFieldViewModel";
@@ -166,10 +165,7 @@ const selected = computed<string | string[]>({
 	},
 });
 
-const selectedData = ref<WriterApplication | undefined>();
-
 function onSelectedData(appData: WriterApplication | undefined) {
-	selectedData.value = appData; // for readability
 	if (
 		props.resourceType !== "application" ||
 		!appData ||


### PR DESCRIPTION
<img width="351" height="170" alt="Screenshot 2025-08-07 at 19 36 04" src="https://github.com/user-attachments/assets/b83c6a8f-0069-4d34-ad53-7f7412c6cb7b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout of the Builder Fields Writer Resource ID section by switching from a flex to a grid display, allowing dynamic adjustment when a link is present.

* **Bug Fixes**
  * Enhanced reliability when updating application inputs, ensuring updates only occur for valid application resources with proper input data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->