### PR TITLE
fix(writer): use session header for `/init` data - AB-179

### DIFF
--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -178,11 +178,11 @@ class AppProcess(multiprocessing.Process):
             session.session_component_tree, mode=writer.Config.mode
         )
 
+        headers = session.headers or {}
         writer_application: Optional[WriterApplicationInformation] = None
-        writer_app_id = os.getenv("WRITER_APP_ID")
-        writer_org_id = os.getenv("WRITER_ORG_ID")
-        writer_base_url = \
-            os.getenv("WRITER_BASE_URL", "https://api.writer.com")
+        writer_app_id = headers.get("x-agent-id") or os.getenv("WRITER_APP_ID")
+        writer_org_id = headers.get("x-organization-id") or os.getenv("WRITER_ORG_ID")
+        writer_base_url = os.getenv("WRITER_BASE_URL", "https://api.writer.com")
         if writer_app_id is not None and writer_org_id is not None:
             writer_application = WriterApplicationInformation(
                 id=writer_app_id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection of application and organization IDs during session initialization by supporting retrieval from HTTP headers in addition to environment variables.

* **Bug Fixes**
  * Enhanced reliability of session initialization by ensuring headers are safely handled even if missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->