### PR TITLE
fix: include API trigger results in blueprint results dictionary

### DIFF
--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -479,7 +479,7 @@ class Graph:
     def get_results(self) -> Dict[str, Any]:
         results = {}
         for node in self.nodes:
-            if node.tool and node.tool.outcome == "success":
+            if node.tool and node.tool.outcome in ["success", "trigger"]:
                 results[node.id] = node.result
         return results
 


### PR DESCRIPTION
  - API trigger results were returning null when referenced via @{results.<trigger_id>} syntax
  - Fixed by including "trigger" outcomes in the blueprint results dictionary (previously only
  "success" outcomes were included)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Run results now include outputs from triggered steps in addition to successful ones, providing a more complete results view and easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->