### PR TITLE
fix: prevent fallback value from overwriting cleared input by tracking dirty state - AB-220

### DIFF
--- a/src/ui/src/builder/useComponentFieldViewModel.spec.ts
+++ b/src/ui/src/builder/useComponentFieldViewModel.spec.ts
@@ -100,7 +100,15 @@ describe(useComponentFieldViewModel.name, () => {
 		expect(
 			mockCore.core.getComponentById(componentId).content[fieldKey],
 		).toBe("new value");
-
 		expect(vm.value).toBe("new value");
+
+		vm.value = "";
+
+		await nextTick();
+
+		expect(
+			mockCore.core.getComponentById(componentId).content[fieldKey],
+		).toBe("");
+		expect(vm.value).toBe("");
 	});
 });

--- a/src/ui/src/builder/useComponentFieldViewModel.spec.ts
+++ b/src/ui/src/builder/useComponentFieldViewModel.spec.ts
@@ -1,51 +1,55 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect } from "vitest";
+import { ref, nextTick } from "vue";
+import { buildMockComponent, buildMockCore } from "@/tests/mocks";
+import { generateBuilderManager } from "./builderManager";
+import {
+	useComponentFieldViewModel,
+	Dependencies,
+} from "./useComponentFieldViewModel";
+import { FieldType, WriterComponentDefinition } from "@/writerTypes";
 
-import { describe, it, expect, vi } from "vitest";
-import { ref, reactive, nextTick } from "vue";
-import { useComponentFieldViewModel } from "./useComponentFieldViewModel";
-
-type Component = { id: string; type: string; content: Record<string, string> };
-type Defs = Record<string, { fields?: Record<string, { default?: string }> }>;
-
-function mockDependencies(
-	initial: Record<string, Component>,
-	defs: Defs = {},
-): { components: Record<string, Component>; wf: any; ssbm: any } {
-	const components = reactive(initial);
-
-	function getComponentById(id: string) {
-		return components[id];
-	}
-
-	function getComponentDefinition(type?: string) {
-		return type ? defs[type] : undefined;
-	}
-
-	return {
-		components,
-		wf: {
-			getComponentById,
-			getComponentDefinition,
-			sendComponentUpdate: vi.fn(),
-		},
-		ssbm: {
-			openMutationTransaction: vi.fn(),
-			registerPreMutation: vi.fn(),
-			registerPostMutation: vi.fn(),
-			closeMutationTransaction: vi.fn(),
-		},
-	};
-}
-
-describe("useComponentFieldViewModel", () => {
+describe(useComponentFieldViewModel.name, () => {
 	const componentId = "TestComponent";
 	const fieldKey = "TestField";
 
-	function setupMockDependencies(componentId: string, fieldKey: string) {
-		return mockDependencies(
-			{ [componentId]: { id: componentId, type: "Text", content: {} } },
-			{ Text: { fields: { [fieldKey]: { default: "default test" } } } },
+	let mockCore: ReturnType<typeof buildMockCore>;
+
+	function setupMockDependencies(
+		componentId: string,
+		fieldKey: string,
+	): Dependencies {
+		mockCore = buildMockCore();
+		mockCore.core.addComponent(
+			buildMockComponent({
+				id: componentId,
+				type: FieldType.Text,
+				content: {
+					[fieldKey]: undefined,
+				},
+			}),
 		);
+
+		function getComponentDefinition(): WriterComponentDefinition {
+			return {
+				name: "",
+				description: "",
+				fields: {
+					[fieldKey]: {
+						name: "",
+						type: FieldType.Text,
+						default: "default test",
+					},
+				},
+			};
+		}
+
+		return {
+			wf: {
+				...mockCore.core,
+				getComponentDefinition,
+			},
+			ssbm: generateBuilderManager(),
+		};
 	}
 
 	it("Default: uses field default from component definition when content is unset", async () => {
@@ -98,9 +102,9 @@ describe("useComponentFieldViewModel", () => {
 
 		await nextTick();
 
-		expect(dependencies.components[componentId].content[fieldKey]).toBe(
-			"new value",
-		);
+		expect(
+			mockCore.core.getComponentById(componentId).content[fieldKey],
+		).toBe("new value");
 
 		expect(vm.value).toBe("new value");
 	});

--- a/src/ui/src/builder/useComponentFieldViewModel.spec.ts
+++ b/src/ui/src/builder/useComponentFieldViewModel.spec.ts
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, vi } from "vitest";
+import { ref, reactive, nextTick } from "vue";
+import { useComponentFieldViewModel } from "./useComponentFieldViewModel";
+
+type Component = { id: string; type: string; content: Record<string, string> };
+type Defs = Record<string, { fields?: Record<string, { default?: string }> }>;
+
+function mockDependencies(
+	initial: Record<string, Component>,
+	defs: Defs = {},
+): { components: Record<string, Component>; wf: any; ssbm: any } {
+	const components = reactive(initial);
+
+	function getComponentById(id: string) {
+		return components[id];
+	}
+
+	function getComponentDefinition(type?: string) {
+		return type ? defs[type] : undefined;
+	}
+
+	return {
+		components,
+		wf: {
+			getComponentById,
+			getComponentDefinition,
+			sendComponentUpdate: vi.fn(),
+		},
+		ssbm: {
+			openMutationTransaction: vi.fn(),
+			registerPreMutation: vi.fn(),
+			registerPostMutation: vi.fn(),
+			closeMutationTransaction: vi.fn(),
+		},
+	};
+}
+
+describe("useComponentFieldViewModel", () => {
+	const componentId = "TestComponent";
+	const fieldKey = "TestField";
+
+	function setupMockDependencies(componentId: string, fieldKey: string) {
+		return mockDependencies(
+			{ [componentId]: { id: componentId, type: "Text", content: {} } },
+			{ Text: { fields: { [fieldKey]: { default: "default test" } } } },
+		);
+	}
+
+	it("Default: uses field default from component definition when content is unset", async () => {
+		const dependencies = setupMockDependencies(componentId, fieldKey);
+
+		const vm = useComponentFieldViewModel(
+			{ componentId, fieldKey },
+			dependencies,
+		);
+
+		await nextTick();
+
+		expect(vm.value).toBe("default test");
+	});
+
+	it("Default update: reactive defaultValue overrides definition and updates value when changed", async () => {
+		const dependencies = setupMockDependencies(componentId, fieldKey);
+
+		const defaultValue = ref("ref default test");
+
+		const vm = useComponentFieldViewModel(
+			{ componentId, fieldKey, defaultValue },
+			dependencies,
+		);
+
+		await nextTick();
+
+		expect(vm.value).toBe("ref default test");
+
+		defaultValue.value = "ref test";
+
+		await nextTick();
+
+		expect(vm.value).toBe("ref test");
+	});
+
+	it("viewModel update: setting vm.value persists to component content and reflects in getter", async () => {
+		const dependencies = setupMockDependencies(componentId, fieldKey);
+
+		const vm = useComponentFieldViewModel(
+			{ componentId, fieldKey },
+			dependencies,
+		);
+
+		await nextTick();
+
+		expect(vm.value).toBe("default test");
+
+		vm.value = "new value";
+
+		await nextTick();
+
+		expect(dependencies.components[componentId].content[fieldKey]).toBe(
+			"new value",
+		);
+
+		expect(vm.value).toBe("new value");
+	});
+});

--- a/src/ui/src/builder/useComponentFieldViewModel.spec.ts
+++ b/src/ui/src/builder/useComponentFieldViewModel.spec.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { ref, nextTick } from "vue";
 import { buildMockComponent, buildMockCore } from "@/tests/mocks";
+import { FieldType } from "@/writerTypes";
 import { generateBuilderManager } from "./builderManager";
 import {
 	useComponentFieldViewModel,
 	Dependencies,
 } from "./useComponentFieldViewModel";
-import { FieldType, WriterComponentDefinition } from "@/writerTypes";
 
 describe(useComponentFieldViewModel.name, () => {
 	const componentId = "TestComponent";
@@ -29,25 +29,20 @@ describe(useComponentFieldViewModel.name, () => {
 			}),
 		);
 
-		function getComponentDefinition(): WriterComponentDefinition {
-			return {
-				name: "",
-				description: "",
-				fields: {
-					[fieldKey]: {
-						name: "",
-						type: FieldType.Text,
-						default: "default test",
-					},
+		vi.spyOn(mockCore.core, "getComponentDefinition").mockReturnValue({
+			name: "",
+			description: "",
+			fields: {
+				[fieldKey]: {
+					name: "",
+					type: FieldType.Text,
+					default: "default test",
 				},
-			};
-		}
+			},
+		});
 
 		return {
-			wf: {
-				...mockCore.core,
-				getComponentDefinition,
-			},
+			wf: mockCore.core,
 			ssbm: generateBuilderManager(),
 		};
 	}

--- a/src/ui/src/builder/useComponentFieldViewModel.ts
+++ b/src/ui/src/builder/useComponentFieldViewModel.ts
@@ -74,6 +74,13 @@ export function useComponentFieldViewModel(
 
 	const isDirty = ref(false);
 
+	watch(
+		[() => toValue(params.componentId), () => toValue(params.fieldKey)],
+		() => {
+			isDirty.value = false;
+		},
+	);
+
 	const fieldValue = computed<string>(() => {
 		const val = component.value?.content?.[toValue(params.fieldKey)];
 

--- a/src/ui/src/builder/useComponentFieldViewModel.ts
+++ b/src/ui/src/builder/useComponentFieldViewModel.ts
@@ -1,4 +1,4 @@
-import { computed, inject, MaybeRef, toValue, watch } from "vue";
+import { computed, inject, MaybeRef, ref, toValue, watch } from "vue";
 import { BuilderManager, Core } from "@/writerTypes";
 import injectionKeys from "@/injectionKeys";
 import { useLogger } from "@/composables/useLogger";
@@ -72,16 +72,23 @@ export function useComponentFieldViewModel(
 		setContentValue(component.value.id, toValue(params.fieldKey), value);
 	}
 
+	const isDirty = ref(false);
+
 	const fieldValue = computed<string>(() => {
-		return (
-			component.value?.content?.[toValue(params.fieldKey)] ||
-			fallbackValue.value
-		);
+		const val = component.value?.content?.[toValue(params.fieldKey)];
+
+		if (isDirty.value && typeof val === "string") {
+			return val;
+		}
+
+		return val || fallbackValue.value;
 	});
 
 	const fieldViewModel = computed<string>({
 		get: () => fieldValue.value,
 		set: (value: string) => {
+			isDirty.value = true;
+
 			setFieldValue(value);
 		},
 	});

--- a/src/ui/src/builder/useComponentFieldViewModel.ts
+++ b/src/ui/src/builder/useComponentFieldViewModel.ts
@@ -4,13 +4,13 @@ import injectionKeys from "@/injectionKeys";
 import { useLogger } from "@/composables/useLogger";
 import { useComponentActions } from "./useComponentActions";
 
-type Params = {
+export type Params = {
 	componentId: MaybeRef<string>;
 	fieldKey: MaybeRef<string>;
 	defaultValue?: MaybeRef<string | undefined>;
 };
 
-type Dependencies = {
+export type Dependencies = {
 	wf?: Core;
 	ssbm?: BuilderManager;
 };

--- a/src/ui/src/composables/useLogger.ts
+++ b/src/ui/src/composables/useLogger.ts
@@ -1,12 +1,11 @@
 /* eslint-disable no-console */
 
+export type ILogger = Pick<typeof console, "log" | "warn" | "info" | "error">;
+
 /**
  * A simple abstraction to use logger in the application. For the moment, it's just a proxy to `console`, but it can be plugged to any library later.
  */
-export function useLogger(): Pick<
-	typeof console,
-	"log" | "warn" | "info" | "error"
-> {
+export function useLogger(): ILogger {
 	return {
 		log: console.log,
 		warn: console.warn,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Edited component fields no longer get overwritten by fallback values; user-entered text now reliably persists.
  - Prevents unexpected resets when switching fields or updating content, improving editing consistency.
  - Current input is prioritized over fallback content for string fields for a more predictable experience.

- Tests
  - Added unit tests for field view model initialization, reactive defaults, and persisting edits.

- Chores
  - Cleaned up public type exports and simplified logger return type for a clearer API surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->