### PR TITLE
fix(ui): prevent resource dropdown overflow - AB-221

### DIFF
--- a/src/ui/src/builder/settings/BuilderFieldsWriterResourceId.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsWriterResourceId.vue
@@ -187,7 +187,7 @@ function onSelectedData(appData: WriterApplication | undefined) {
 }
 
 .BuilderFieldsWriterResourceId:has(.BuilderFieldsWriterResourceId__link) {
-	grid-template-columns: 1fr auto;
+	grid-template-columns: minmax(0, 1fr) auto;
 }
 
 .BuilderFieldsWriterResourceId__link {


### PR DESCRIPTION
<img width="259" height="266" alt="image" src="https://github.com/user-attachments/assets/0b8d598b-1704-4628-85d2-5e22ae23e8b4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Adjusted layout in builder settings for the Writer Resource ID field to use more flexible column sizing when a link is present, improving responsiveness and preventing content overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->