### PR TITLE
fix(ui): prevent loading message to stay on the page - AB-224

### DIFF
--- a/src/ui/src/main.ts
+++ b/src/ui/src/main.ts
@@ -96,14 +96,18 @@ async function initialise() {
 					reason,
 				);
 				const loaderEl = document.getElementById("loading_L1");
-				if (loaderEl && !document.getElementById("loading_message") && attempt >= 2) {
+				if (
+					loaderEl &&
+					!document.getElementById("loading_message") &&
+					attempt >= 2
+				) {
 					const message = document.createElement("div");
 					message.id = "loading_message";
 					message.textContent =
 						"We're getting things ready.\nHang tight while we connect...";
 					message.style.cssText =
 						"position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);margin-top:120px;text-align:center;font-family: 'Poppins','Helvetica Neue','Lucida Grande',sans-serif;color:#666;font-size:14px;line-height:1.4;max-width:400px;padding:0 20px;z-index:1000;white-space:pre-line;opacity:0;transition:opacity 0.5s ease-in;";
-					document.body.appendChild(message);
+					document.getElementById("loading_L1")?.appendChild(message);
 					// Trigger fade-in animation
 					setTimeout(() => {
 						message.style.opacity = "1";
@@ -126,7 +130,7 @@ initialise()
 	})
 	.catch((reason) => {
 		logger.error("Core initialisation failed.", reason);
-		
+
 		const errorDiv = document.createElement("div");
 		errorDiv.className = "error-message";
 		errorDiv.setAttribute("role", "alert");


### PR DESCRIPTION
The loading message was inserted outside the `#app` div, which caused an issue because the element was not removed after the application was loaded (because Vue.js only mounts on `#app`)

<img width="1024" height="620" alt="image" src="https://github.com/user-attachments/assets/ae34c241-07fa-431d-a47a-213e686d3e30" />
<img width="1024" height="689" alt="image" src="https://github.com/user-attachments/assets/438029b0-cd7c-4e50-b22e-309193590c6a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retry loading message now appears within the intended loading area rather than across the page, preventing overlap with other content and improving readability.
  * Improved resilience when the loading container isn’t available, reducing the chance of missing or misplaced retry messages and minimizing visual glitches.
  * Enhanced consistency of loading feedback during multiple retries, ensuring clearer user guidance without duplicate or errant messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->