### PR TITLE
feat(ui): display output count tag on node + scroll to selected log in the panel - AB-116

### DIFF
--- a/src/ui/src/builder/panels/BuilderLogPanel.vue
+++ b/src/ui/src/builder/panels/BuilderLogPanel.vue
@@ -1,5 +1,6 @@
 <template>
 	<BuilderPanel
+		ref="panel"
 		panel-id="log"
 		name="Log"
 		:contents-teleport-el="contentsTeleportEl"
@@ -60,7 +61,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject } from "vue";
+import { computed, inject, nextTick, useTemplateRef, watch } from "vue";
 import BuilderPanel, { type BuilderPanelAction } from "./BuilderPanel.vue";
 import BuilderLogBlueprintExecution from "./BuilderLogBlueprintExecution.vue";
 import injectionKeys from "@/injectionKeys";
@@ -75,10 +76,15 @@ defineProps<{
 const wf = inject(injectionKeys.core);
 const wfbm = inject(injectionKeys.builderManager);
 
+const panel = useTemplateRef("panel");
+
 const tracking = useWriterTracking(wf);
 
-function onOpenPanel(open: boolean) {
-	if (open) tracking.track("nav_logs_opened");
+async function onOpenPanel(open: boolean) {
+	if (!open) return;
+	tracking.track("nav_logs_opened");
+	await nextTick();
+	await scrollToSelectedLog();
 }
 
 const actions: BuilderPanelAction[] = [
@@ -97,6 +103,30 @@ const actions: BuilderPanelAction[] = [
 
 const logEntries = computed(() => {
 	return wfbm.getLogEntries();
+});
+
+async function scrollToSelectedLog() {
+	const mainEl = panel.value?.mainContents;
+	if (!mainEl) return;
+
+	const selectedEl = mainEl.querySelector(".item.selected");
+	if (!selectedEl) return;
+
+	const mainRect = mainEl.getBoundingClientRect();
+	const selectedRect = selectedEl.getBoundingClientRect();
+
+	// Current scroll position + offset needed to center
+	const top =
+		mainEl.scrollTop +
+		(selectedRect.top - mainRect.top) -
+		(mainRect.height / 2 - selectedRect.height / 2);
+
+	mainEl.scrollTo({ top, behavior: "smooth" });
+}
+
+watch(wfbm.selection, async () => {
+	await nextTick();
+	await scrollToSelectedLog();
 });
 </script>
 

--- a/src/ui/src/builder/panels/BuilderPanel.vue
+++ b/src/ui/src/builder/panels/BuilderPanel.vue
@@ -63,7 +63,10 @@
 								<WdsIcon :name="action.icon" />
 							</WdsButton>
 						</div>
-						<div class="BuilderPanel__mainContents">
+						<div
+							ref="mainContents"
+							class="BuilderPanel__mainContents"
+						>
 							<slot></slot>
 						</div>
 					</template>
@@ -91,7 +94,14 @@ import { getModifierKeyName, isModifierKeyActive } from "@/core/detectPlatform";
 import injectionKeys from "@/injectionKeys";
 import WdsButton from "@/wds/WdsButton.vue";
 import WdsIcon from "@/wds/WdsIcon.vue";
-import { computed, inject, onMounted, onUnmounted, ref } from "vue";
+import {
+	computed,
+	inject,
+	onMounted,
+	onUnmounted,
+	ref,
+	useTemplateRef,
+} from "vue";
 import BuilderDropFileZone from "../BuilderDropFileZone.vue";
 
 const wfbm = inject(injectionKeys.builderManager);
@@ -113,6 +123,10 @@ const emits = defineEmits({
 	openned: (open: boolean) => typeof open === "boolean",
 	filesDrop: (files: File[]) => Array.isArray(files) && files.length > 0,
 });
+
+const mainContents = useTemplateRef("mainContents");
+
+defineExpose({ mainContents });
 
 const showDropingFilesZone = computed(
 	() => props.enableDropFile && isDropingFiles.value,

--- a/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
+++ b/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
@@ -94,12 +94,18 @@
 					@click="$emit('outMousedown', outId)"
 				/>
 			</div>
-			<BlueprintsNodeActions
-				v-if="!isTrigger"
-				class="BlueprintsNode__main__footer"
-				:show-display-error-option="canDisplayErrorOut"
-				@show-error="forceDisplayErrorOut = true"
-			/>
+			<div v-if="!isTrigger" class="BlueprintsNode__main__footer">
+				<BlueprintsNodeLogs
+					v-if="latestKnownOutcomes.length > 0"
+					:completion-style
+					:count="latestKnownOutcomes.length"
+					@click="openLogs"
+				/>
+				<BlueprintsNodeActions
+					:show-display-error-option="canDisplayErrorOut"
+					@show-error="forceDisplayErrorOut = true"
+				/>
+			</div>
 		</div>
 	</div>
 </template>
@@ -134,6 +140,7 @@ import { convertAbsolutePathtoFullURL } from "@/utils/url";
 import { useComponentInformation } from "@/composables/useComponentInformation";
 import BlueprintsNodeActions from "./BlueprintsNodeActions.vue";
 import BlueprintsNodeOutput from "./BlueprintsNodeOutput.vue";
+import BlueprintsNodeLogs from "./BlueprintsNodeLogs.vue";
 
 const emit = defineEmits(["outMousedown", "engaged"]);
 const wf = inject(injectionKeys.core);
@@ -190,25 +197,30 @@ const outcomeSeverity = {
 	none: 0,
 };
 
-const latestKnownOutcome = computed(() => {
+const latestKnownOutcomes = computed(() => {
 	const executionLogs = latestRun.value
 		.map((entry) => {
 			return entry.blueprintExecution;
 		})
 		.filter(Boolean);
-	let outcome = "none";
-	executionLogs.forEach((log) => {
-		log.summary
+	return executionLogs.flatMap((log) => {
+		return log.summary
 			.filter((item) => item.componentId === component.value.id)
-			.filter((item) => Boolean(item.outcome))
-			.forEach((item) => {
-				const severity =
-					outcomeSeverity[item.outcome] ?? outcomeSeverity.success;
-				if (severity > outcomeSeverity[outcome]) {
-					outcome = item.outcome;
-				}
-			});
+			.filter((item) => Boolean(item.outcome));
 	});
+});
+
+const latestKnownOutcome = computed(() => {
+	let outcome = "none";
+
+	for (const item of latestKnownOutcomes.value) {
+		const severity =
+			outcomeSeverity[item.outcome] ?? outcomeSeverity.success;
+		if (severity > outcomeSeverity[outcome]) {
+			outcome = item.outcome;
+		}
+	}
+
 	return outcome === "none" ? null : outcome;
 });
 
@@ -356,6 +368,13 @@ const possibleImageUrls = computed(() => {
 
 	return paths.map((p) => convertAbsolutePathtoFullURL(p));
 });
+
+function openLogs() {
+	const item = latestKnownOutcomes.value.at(-1);
+	if (!item) return;
+	wfbm.openPanels.value.add("log");
+	wfbm.setSelection(componentId, undefined, "click");
+}
 
 watch(isEngaged, () => {
 	emit("engaged");
@@ -572,6 +591,8 @@ watch(isEngaged, () => {
 
 .BlueprintsNode__main__footer {
 	border-top: 1px solid var(--builderSeparatorColor);
+	display: grid;
+	grid-template-columns: 1fr auto;
 }
 .BlueprintsNode:has(.BlueprintsNode__main__outputs--float)
 	.BlueprintsNode__main__footer {

--- a/src/ui/src/components/blueprints/abstract/BlueprintsNodeLogs.vue
+++ b/src/ui/src/components/blueprints/abstract/BlueprintsNodeLogs.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps({
+	status: { type: Boolean },
+	count: { type: Number, required: true },
+	completionStyle: { type: String, required: false, default: undefined },
+});
+
+defineEmits({
+	click: () => true,
+});
+
+const content = computed(() => {
+	if (props.count === 1) return "1 output";
+	return `${props.count} outputs`;
+});
+</script>
+
+<template>
+	<div class="BlueprintsNodeLogs">
+		<button
+			class="BlueprintsNodeLogs__btn"
+			:class="{
+				'BlueprintsNodeLogs__btn--success':
+					completionStyle == 'success',
+				'BlueprintsNodeLogs__btn--skipped':
+					completionStyle == 'skipped',
+				'BlueprintsNodeLogs__btn--stopped':
+					completionStyle == 'stopped',
+				'BlueprintsNodeLogs__btn--error': completionStyle == 'error',
+			}"
+			:data-writer-unselectable="true"
+			type="button"
+			@click="$emit('click')"
+		>
+			{{ content }}
+		</button>
+	</div>
+</template>
+
+<style scoped>
+.BlueprintsNodeLogs {
+	display: flex;
+}
+.BlueprintsNodeLogs__btn {
+	border-radius: 4px;
+	border: none;
+	padding: 4px 8px;
+	cursor: pointer;
+}
+.BlueprintsNodeLogs__btn--success {
+	background: var(--wdsColorGreen3) !important;
+}
+
+.BlueprintsNodeLogs__btn--skipped {
+	background: var(--wdsColorGray3) !important;
+}
+
+.BlueprintsNodeLogs__btn--stopped {
+	background: var(--wdsColorGray3) !important;
+}
+
+.BlueprintsNodeLogs__btn--error {
+	background: var(--wdsColorOrange2) !important;
+}
+</style>

--- a/src/ui/src/components/blueprints/abstract/BlueprintsNodeLogs.vue
+++ b/src/ui/src/components/blueprints/abstract/BlueprintsNodeLogs.vue
@@ -2,7 +2,6 @@
 import { computed } from "vue";
 
 const props = defineProps({
-	status: { type: Boolean },
 	count: { type: Number, required: true },
 	completionStyle: { type: String, required: false, default: undefined },
 });


### PR DESCRIPTION

https://github.com/user-attachments/assets/3b5e0d2d-f118-4724-8f8c-87daeafacdb2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Logs button in blueprint nodes showing output count; clicking opens the logs for that node.
  * Logs indicator uses completion styling (success, skipped, stopped, error).

* **Refactor**
  * Logs panel now auto-scrolls to the selected log when opened and when selection changes for quicker navigation.

* **Style**
  * Node footer layout updated to show logs and actions side-by-side for clearer controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->