### PR TITLE
fix(writer): filter notes when running a blueprint - AB-234

### DIFF
--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -226,7 +226,8 @@ class BlueprintRunner:
             if not node:
                 break
             if node.type == "blueprints_blueprint":
-                return self.session.session_component_tree.get_descendents(current_node_id)
+                nodes = self.session.session_component_tree.get_descendents(current_node_id)
+                return [node for node in nodes if node.type != 'note']
             current_node_id = node.parentId
         return []
 


### PR DESCRIPTION
"Note" is a frontend component that raise an expecption during the execution of the blueprint. We just need to filter them when executing the blueprint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Note-type items are now excluded from blueprint execution graphs, preventing unintended connections and reducing noise in runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->