### PR TITLE
fix(ui): scrolling issue in settings dropdown menu options - AB-233

### DIFF
--- a/src/ui/src/builder/BuilderHeaderMoreDropdown.vue
+++ b/src/ui/src/builder/BuilderHeaderMoreDropdown.vue
@@ -146,7 +146,7 @@ async function onSelect(key: string) {
 </script>
 
 <style scoped>
-.BuilderHeaderMoreDropdown:deep(.BuilderMoreDropdown__dropdown) {
+.BuilderHeaderMoreDropdown:deep(.SharedMoreDropdown__dropdown) {
 	min-width: 200px;
 }
 </style>

--- a/src/ui/src/builder/settings/BuilderSettings.vue
+++ b/src/ui/src/builder/settings/BuilderSettings.vue
@@ -1,6 +1,7 @@
 <template>
 	<div
 		v-if="ssbm.selectionStatus.value !== SelectionStatus.None"
+		ref="root"
 		class="BuilderSettings"
 		:class="{
 			'BuilderSettings--collapsed': collapsed,
@@ -56,6 +57,7 @@
 					<WdsIcon name="at-sign" />
 				</WdsButton>
 				<SharedMoreDropdown
+					class="BuilderSettings__titleBar__actions__more"
 					data-automation-action="settings-actions-dropdown"
 					:options="dropdownOptions"
 					trigger-custom-size="32px"
@@ -89,7 +91,7 @@
 </template>
 
 <script setup lang="ts">
-import { inject, computed, watch, ref } from "vue";
+import { inject, computed, watch, ref, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 
 import BuilderSettingsMain from "./BuilderSettingsMain.vue";
@@ -107,9 +109,18 @@ import {
 import BuilderSettingsAddComponentModal from "./BuilderSettingsAddComponentModal.vue";
 import { useComponentInformation } from "@/composables/useComponentInformation";
 import { useBlueprintComponentResultId } from "@/composables/useBlueprintComponentResultId";
+import { useElementClientHeight } from "@/composables/useComponentClientHeight";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
+
+const root = useTemplateRef("root");
+const rootHeight = useElementClientHeight(root, 1_000);
+const dropdownMaxHeight = computed(() => {
+	if (!rootHeight.value) return "unset";
+	const maxHeight = rootHeight.value - 42;
+	return maxHeight > 0 ? `${maxHeight}px` : "unset";
+});
 
 const { component, definition: componentDefinition } = useComponentInformation(
 	wf,
@@ -263,5 +274,9 @@ watch(component, (newComponent) => {
 	max-height: 400px;
 	margin-top: -400px;
 	grid-column: 2;
+}
+
+.BuilderSettings__titleBar__actions__more:deep(.SharedMoreDropdown__dropdown) {
+	max-height: v-bind(dropdownMaxHeight);
 }
 </style>

--- a/src/ui/src/components/shared/SharedMoreDropdown.vue
+++ b/src/ui/src/components/shared/SharedMoreDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-	<div ref="trigger" class="BuilderMoreDropdown">
+	<div ref="trigger" class="SharedMoreDropdown">
 		<WdsButton
 			:variant="triggerVariant"
 			:size="triggerSize"
@@ -12,7 +12,7 @@
 		<WdsDropdownMenu
 			v-if="isOpen"
 			ref="dropdown"
-			class="BuilderMoreDropdown__dropdown"
+			class="SharedMoreDropdown__dropdown"
 			:options="options"
 			:style="floatingStyles"
 			:hide-icons="hideIcons"
@@ -112,10 +112,10 @@ function onSelect(value: string) {
 </script>
 
 <style scoped>
-.BuilderMoreDropdown {
+.SharedMoreDropdown {
 	position: relative;
 }
-.BuilderMoreDropdown__dropdown {
+.SharedMoreDropdown__dropdown {
 	min-width: 180px;
 }
 </style>

--- a/src/ui/src/composables/useComponentClientHeight.ts
+++ b/src/ui/src/composables/useComponentClientHeight.ts
@@ -1,0 +1,30 @@
+import { ref, onMounted, onUnmounted, ShallowRef } from "vue";
+
+/**
+ * Composable function to calculate the height of a DOM element and update it regularly
+ */
+export function useElementClientHeight(
+	elementRef: ShallowRef<HTMLDivElement>,
+	intervalMs = 500,
+) {
+	const height = ref(0);
+	let intervalId = null;
+
+	function updateHeight() {
+		if (elementRef.value) {
+			height.value = elementRef.value.clientHeight;
+		}
+	}
+
+	onMounted(() => {
+		updateHeight();
+		intervalId = setInterval(updateHeight, intervalMs);
+	});
+
+	onUnmounted(() => {
+		if (!intervalId) return;
+		clearInterval(intervalId);
+	});
+
+	return height;
+}


### PR DESCRIPTION
<img width="472" height="386" alt="image" src="https://github.com/user-attachments/assets/707502f1-f73c-4c5e-96bc-670445d753e5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings “More” menu now auto-adjusts its maximum height to fit available space, preventing overflow and improving usability on smaller viewports.

* **Refactor**
  * Unified naming and styling for the shared “More” dropdown to ensure consistent behavior across header and settings.

* **Style**
  * Minor visual consistency tweaks to dropdown menus; no functional changes beyond adaptive height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->