### PR TITLE
fix(ui): handle default image size for SVG in `CoreImage` - AB-232

### DIFF
--- a/src/ui/src/components/core/content/CoreImage.vue
+++ b/src/ui/src/components/core/content/CoreImage.vue
@@ -89,7 +89,7 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { computed, inject, useTemplateRef } from "vue";
+import { computed, CSSProperties, inject, useTemplateRef } from "vue";
 import injectionKeys from "@/injectionKeys";
 
 const rootEl = useTemplateRef("rootEl");
@@ -107,12 +107,12 @@ const rootStyle = computed(() => {
 	};
 });
 
-const imgStyle = computed(() => {
+const imgStyle = computed<CSSProperties>(() => {
 	const maxWidth = fields.maxWidth.value;
 	const maxHeight = fields.maxHeight.value;
 	return {
-		"max-width": maxWidth !== -1 ? `${maxWidth}px` : undefined,
-		"max-height": maxHeight !== -1 ? `${maxHeight}px` : undefined,
+		maxWidth: maxWidth !== -1 ? `${maxWidth}px` : undefined,
+		maxHeight: maxHeight !== -1 ? `${maxHeight}px` : undefined,
 	};
 });
 
@@ -131,6 +131,7 @@ function handleClick(ev: MouseEvent) {
 
 img {
 	max-width: 100%;
+	width: 100%;
 }
 
 .CoreImage.selected img {


### PR DESCRIPTION
<img width="1290" height="574" alt="image" src="https://github.com/user-attachments/assets/dddd55c0-f704-42d0-a88c-2846ac2d4b84" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Style
  - Improved image responsiveness: images now expand to the container width while respecting max dimensions for a more consistent display across layouts and devices.
- Refactor
  - Internal typing and style handling refined for greater reliability; no changes to public APIs or behavior.
- Chores
  - Minor maintenance to align styling conventions; external props/events remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->