### PR TITLE
feat(ui): retry failed loading of async components - AB-235

### DIFF
--- a/src/ui/src/utils/defineAsyncComponentWithLoader.ts
+++ b/src/ui/src/utils/defineAsyncComponentWithLoader.ts
@@ -1,3 +1,4 @@
+import { useLogger } from "@/composables/useLogger";
 import WdsSkeletonLoader from "@/wds/WdsSkeletonLoader.vue";
 import { h } from "vue";
 import { AsyncComponentOptions, defineAsyncComponent } from "vue";
@@ -43,11 +44,25 @@ function loadingComponent() {
 	);
 }
 
+const ASYNC_COMP_MAX_RETRIES = 5;
+
 export function defineAsyncComponentWithLoader(options: AsyncComponentOptions) {
 	return defineAsyncComponent({
 		loadingComponent,
 		errorComponent,
 		delay: 300,
+		onError(error, retry, fail, attempts) {
+			const logger = useLogger();
+			if (attempts <= ASYNC_COMP_MAX_RETRIES) {
+				const msg = `Failed to load async component (retry ${attempts}/${ASYNC_COMP_MAX_RETRIES})`;
+				logger.warn(msg, error);
+				setTimeout(retry, 1_000);
+			} else {
+				const msg = `Failed to load async component after ${ASYNC_COMP_MAX_RETRIES} attempts`;
+				logger.error(msg, error);
+				fail();
+			}
+		},
 		...options,
 	});
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Added automatic retry (up to 5 times) when loading async components fails, with a short delay between attempts to reduce transient errors.
  - Improved logging for load failures, providing clear warnings and a final error after maximum retries.
  - Existing loading and error placeholders remain unchanged; the loading delay is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->