### PR TITLE
feat: renew publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,7 @@ name: publish
 on:
     push:
         tags:
-            - 'v[0-9]+.[0-9]+.[0-9]+'
-            - 'v[0-9]+.[0-9]+.[0-9]+[a-z0-9]*'
+            - 'agent-builder-[0-9]+.[0-9]+.[0-9]+-image-[0-9]+.[0-9]+.[0-9]+-main'
 
 jobs:
     build:
@@ -13,6 +12,20 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+
+            - name: Extract version from tag
+              id: extract_version
+              run: |
+                REF="${{ github.ref_name }}"
+                if [[ "$REF" =~ ^agent-builder-([0-9]+\.[0-9]+\.[0-9]+)-image-([0-9]+\.[0-9]+\.[0-9]+)-main$ ]]; then
+                  echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+                else
+                  echo "Unable to parse version from tag: $REF" >&2
+                  exit 1
+                fi
+
+            - name: Show extracted version
+              run: echo "Version is ${{ steps.extract_version.outputs.version }}"
 
             - name: Install poetry
               run: pipx install poetry
@@ -27,6 +40,9 @@ jobs:
               with:
                 node-version: "22.x"
                 cache: npm
+
+            - name: Update version before publishing
+              run: poetry version ${{ steps.extract_version.outputs.version }}
 
             - name: install python3 environment
               run: poetry install --with build


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Publish workflow now triggers on a single agent-builder image tag pattern for releases.
  - CI extracts the release version from the tag during publish runs and fails early if parsing fails.
  - The publishing process updates the project version from the extracted value before publishing, ensuring published artifacts match the tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->