### PR TITLE
Revert "fix(writer): filter notes when running a blueprint - AB-234"

### DIFF
--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -226,8 +226,7 @@ class BlueprintRunner:
             if not node:
                 break
             if node.type == "blueprints_blueprint":
-                nodes = self.session.session_component_tree.get_descendents(current_node_id)
-                return [node for node in nodes if node.type != 'note']
+                return self.session.session_component_tree.get_descendents(current_node_id)
             current_node_id = node.parentId
         return []
 


### PR DESCRIPTION
Reverts writer/writer-framework#1082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Blueprint graphs now include all descendant nodes, ensuring more accurate and complete graph construction.
  - Surfaces clearer configuration errors if unsupported note elements are present within blueprints, aiding faster troubleshooting.
  - No change in behavior for blueprints without note elements; existing setups continue to work as before.
- Chores
  - No public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->