### PR TITLE
fix(ui): improve async comp loader - AB-235

### DIFF
--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -202,6 +202,7 @@ import { defineAsyncComponentWithLoader } from "@/utils/defineAsyncComponentWith
 
 const BlueprintToolbar = defineAsyncComponentWithLoader({
 	loader: () => import("./base/BlueprintToolbar.vue"),
+	loadingComponentProps: { width: "250px", height: "40px" },
 });
 
 const wf = inject(injectionKeys.core);

--- a/src/ui/src/utils/defineAsyncComponentWithLoader.ts
+++ b/src/ui/src/utils/defineAsyncComponentWithLoader.ts
@@ -1,7 +1,9 @@
 import { useLogger } from "@/composables/useLogger";
 import WdsSkeletonLoader from "@/wds/WdsSkeletonLoader.vue";
-import { h } from "vue";
+import { CSSProperties, h } from "vue";
 import { AsyncComponentOptions, defineAsyncComponent } from "vue";
+
+type LoadingComponentProps = Pick<CSSProperties, "height" | "width">;
 
 function errorComponent() {
 	return h(
@@ -27,7 +29,7 @@ function errorComponent() {
 	);
 }
 
-function loadingComponent() {
+function loadingComponent(props: LoadingComponentProps) {
 	return h(
 		"div",
 		{
@@ -35,8 +37,8 @@ function loadingComponent() {
 				display: "flex",
 				alignItems: "center",
 				justifyContent: "center",
-				height: "100%",
-				width: "100%",
+				height: props.height ?? "100%",
+				width: props.width ?? "100%",
 				padding: "8px",
 			},
 		},
@@ -46,9 +48,14 @@ function loadingComponent() {
 
 const ASYNC_COMP_MAX_RETRIES = 5;
 
-export function defineAsyncComponentWithLoader(options: AsyncComponentOptions) {
+export function defineAsyncComponentWithLoader(
+	options: AsyncComponentOptions & {
+		loadingComponentProps?: LoadingComponentProps;
+	},
+) {
 	return defineAsyncComponent({
-		loadingComponent,
+		loadingComponent: () =>
+			loadingComponent(options.loadingComponentProps ?? {}),
 		errorComponent,
 		delay: 300,
 		onError(error, retry, fail, attempts) {


### PR DESCRIPTION

Add a property to `defineAsyncComponentWithLoader` to define the size of the loader.


<img width="980" height="294" alt="Screenshot 2025-08-19 at 11 21 03" src="https://github.com/user-attachments/assets/4a3b0bf3-bbbf-47ff-8a2a-7e701ad3dc53" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loading placeholders for async components now support custom width and height.
  * Blueprint toolbar’s loading state updated to a compact 250×40 px placeholder for better layout consistency.
  * Enhances visual alignment and reduces layout shift while content loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->