### PR TITLE
fix: correct template evaluation for JSON vs string contexts

### DIFF
--- a/src/writer/evaluator.py
+++ b/src/writer/evaluator.py
@@ -40,8 +40,30 @@ class Evaluator:
         if base_context is None:
             base_context = {}
 
-        def decode_json(text):
-            if not isinstance(text, str):
+        def decode_json(text: str):
+            def _looks_like_json_literal(t: str) -> bool:
+                t = t.strip()
+                if not t:
+                    # Empty string - json.loads would fail, invalid case
+                    return False
+                if (
+                    (t[0] == '{' and t[-1] == '}')
+                    or
+                    (t[0] == '[' and t[-1] == ']')
+                ):
+                    # JSON container - object ({...}) or array ([...])
+                    # - valid case
+                    return True
+                if t[0] == '"' and t[-1] == '"':
+                    # Quoted JSON string ("...") - valid case
+                    return True
+                if t in ("true", "false", "null"):
+                    # JSON literals (true, false, null) - valid case
+                    return True
+                return False
+
+            if not _looks_like_json_literal(text):
+                # Avoid processing strings w/o JSON structure
                 return text
             try:
                 clean_text = Evaluator.CONTROL_CHARS.sub("", text)

--- a/src/writer/evaluator.py
+++ b/src/writer/evaluator.py
@@ -33,21 +33,37 @@ class Evaluator:
         self,
         instance_path: InstancePath,
         field_key: str,
-        as_json=False,
-        default_field_value="",
-        base_context={},
+        as_json: bool = False,
+        default_field_value: str = "",
+        base_context: Optional[Dict[str, Any]] = None,
     ) -> Any:
+        if base_context is None:
+            base_context = {}
+
         def decode_json(text):
             if not isinstance(text, str):
                 return text
             try:
-                # Remove control chars
                 clean_text = Evaluator.CONTROL_CHARS.sub("", text)
                 return json.loads(clean_text, strict=False)
             except json.JSONDecodeError as exception:
-                raise WriterConfigurationError(
-                    "Error decoding JSON. " + str(exception)
-                ) from exception
+                raise WriterConfigurationError("Error decoding JSON. " + str(exception)) from exception
+
+        def inside_json_string(src: str, pos: int) -> bool:
+            in_str = False
+            escaped = False
+            i = 0
+            while i < pos:
+                c = src[i]
+                if escaped:
+                    escaped = False
+                else:
+                    if c == '\\':
+                        escaped = True
+                    elif c == '"':
+                        in_str = not in_str
+                i += 1
+            return in_str
 
         component_id = instance_path[-1]["componentId"]
         component = self.component_tree.get_component(component_id)
@@ -60,17 +76,39 @@ class Evaluator:
         def replacer(matched: re.Match):
             if matched.group(0)[0] == "\\":  # Escaped @, don't evaluate
                 return matched.group(0)
+
             expr = matched.group(1).strip()
-            expr_value = self.evaluate_expression(expr, instance_path, base_context)
+            expr_value = self.evaluate_expression(
+                expr,
+                instance_path,
+                base_context
+            )
+
+            # FULL MATCH: return raw, with a special-case
+            # for None in non-JSON mode
             if full_match is not None:
+                if not as_json and expr_value is None:
+                    return None
+                # raw; decode_json() will handle strings if needed
                 return expr_value
+
+            # EMBEDDED
             if as_json:
-                dumped = expr_value
-                if not isinstance(dumped, str):
-                    dumped = json.dumps(dumped)
+                # Decide context by scanning quotes up to the match
+                inside_str = inside_json_string(field_value, matched.start())
+                if inside_str:
+                    # Insert as escaped string fragment
+                    text = (
+                        expr_value
+                        if isinstance(expr_value, str)
+                        else json.dumps(expr_value)
+                        )
+                    return json.dumps(text)[1:-1]
                 else:
-                    dumped = json.dumps(dumped)[1:-1]
-                return re.sub(r'(?<!\\)"', r'\"', dumped)
+                    # Insert as JSON literal
+                    return json.dumps(expr_value)
+
+            # Non-JSON embedded: stringify non-strings
             if not isinstance(expr_value, str):
                 return json.dumps(expr_value)
             return expr_value
@@ -79,7 +117,9 @@ class Evaluator:
             replaced = self.TEMPLATE_REGEX.sub(replacer, field_value)
         else:
             replaced = replacer(full_match)
-        if as_json:
+
+        # Only parse if we ended with a string and caller asked for JSON
+        if as_json and isinstance(replaced, str):
             replaced = decode_json(replaced)
 
         return replaced

--- a/tests/backend/blocks/test_writervision.py
+++ b/tests/backend/blocks/test_writervision.py
@@ -95,7 +95,7 @@ def test_invalid_images_type(monkeypatch, session, runner, fake_client):
         "images": 'not_a_list'
     })
     block = WriterVision(component, runner, {})
-    with pytest.raises(WriterConfigurationError, match="Error decoding JSON.*"):
+    with pytest.raises(ValueError, match="Images must be a list*"):
         block.run()
     assert block.outcome == "error"
 

--- a/tests/backend/test_evaluator.py
+++ b/tests/backend/test_evaluator.py
@@ -108,7 +108,7 @@ class TestEvaluator:
                 "boolean": True,
                 "none": None,
                 "escaped": "\\",
-                "invalid_chars": "\ \" \f \n \t \b \r \u1234"
+                "invalid_chars": r"\ \" \f \n \t \b \r \u1234"
             }
         )
         e = evaluator.Evaluator(session.session_state, session.session_component_tree)
@@ -132,8 +132,8 @@ class TestEvaluator:
             "none_with_text": "TEXT null TEXT",
             "escaped": "\\@{escaped}",
             "escaped_with_text": "TEXT \\@{escaped} TEXT",
-            "invalid_chars": "\ \" \f \n \t \b \r \u1234",
-            "invalid_chars_with_text": "TEXT \ \" \f \n \t \b \r \u1234 TEXT"
+            "invalid_chars": r"\ \" \f \n \t \b \r \u1234",
+            "invalid_chars_with_text": r"TEXT \ \" \f \n \t \b \r \u1234 TEXT"
         }
 
     def test_evaluate_field_full_match(self) -> None:
@@ -179,7 +179,7 @@ class TestEvaluator:
         assert e.evaluate_expression("features.eyes", instance_path) == "green"
         assert e.evaluate_expression("best_feature", instance_path) == "eyes"
         assert e.evaluate_expression("features[best_feature]", instance_path) == "green"
-        assert e.evaluate_expression("a\.b", instance_path) == 3
+        assert e.evaluate_expression(r"a\.b", instance_path) == 3
 
         assert e.evaluate_expression("features.nose", instance_path) is None
         assert e.evaluate_expression("features.eyes.eyelashes", instance_path) is None
@@ -252,3 +252,452 @@ class TestEvaluator:
         assert context.get("target") == "button1"
         assert context.get("item") == "b"
         assert context.get("value") == "B"
+
+    def test_inside_json_string_detection(self) -> None:
+        """Test the inside_json_string function for JSON string context detection"""
+        # Test cases for inside_json_string function
+        test_cases = [
+            # (json_string, position, expected_inside_string)
+            ('{"key": "value"}', 9, True),   # Inside string value - pos 9 is 'v'
+            ('{"key": "value"}', 2, True),   # Inside string key - pos 2 is 'k'
+            ('{"key": "value"}', 6, False),  # Between key and value - pos 6 is ':'
+            ('{"key": "value"}', 0, False),  # At start - pos 0 is '{'
+            ('{"key": "value"}', 8, False),  # At quote start - pos 8 is '"'
+            ('{"text": "hello \\"world\\""}', 15, True),  # Inside escaped quotes  
+            ('{"text": "hello \\"world\\""}', 26, False), # Outside string (closing brace)
+            ('{"a": 1, "b": "text"}', 10, True), # Inside key "b"
+            ('{"a": 1, "b": "text"}', 15, True),  # Inside second string - pos 15 is 't'
+            ('{"a": 1, "b": "text"}', 7, False),  # Between values (comma)
+            ('["item1", "item2"]', 2, True),     # Inside array string
+            ('["item1", "item2"]', 8, False),    # Between array items
+            ('', 0, False),                      # Empty string
+            ('"simple string"', 5, True),        # Inside simple string
+            ('123', 1, False),                   # In number
+            ('true', 2, False),                  # In boolean
+        ]
+        
+        def mock_inside_json_string(src: str, pos: int) -> bool:
+            """Replicate the inside_json_string logic for testing"""
+            in_str = False
+            escaped = False
+            i = 0
+            while i < pos:
+                c = src[i]
+                if escaped:
+                    escaped = False
+                else:
+                    if c == '\\':
+                        escaped = True
+                    elif c == '"':
+                        in_str = not in_str
+                i += 1
+            return in_str
+        
+        # Test the mock function against our test cases
+        for json_str, pos, expected in test_cases:
+            if pos < len(json_str):
+                result = mock_inside_json_string(json_str, pos)
+                assert result == expected, f"Failed for '{json_str}' at pos {pos}: expected {expected}, got {result}"
+
+    def test_json_literal_detection(self) -> None:
+        """Test the _looks_like_json_literal function for JSON structure detection"""
+        
+        # Test cases that should be parsed as JSON
+        json_cases = [
+            ('{"key": "value"}', {"key": "value"}),
+            ('[1, 2, 3]', [1, 2, 3]),
+            ('"hello"', "hello"),
+            ('null', None),
+            ('true', True),
+            ('false', False),
+            # Note: Numbers without quotes are NOT detected as JSON literals by _looks_like_json_literal
+            # They would be returned as strings, then parsed if they're valid JSON
+        ]
+        
+        # Test cases that should NOT be parsed as JSON (returned as-is)
+        non_json_cases = [
+            ('', ''),  # Empty string
+            ('hello world', 'hello world'),
+            ('not json', 'not json'),
+            ('{invalid}', '{invalid}'),
+            ('[invalid', '[invalid'),
+            ('just text', 'just text'),
+            ('42', '42'),  # Plain numbers are not detected as JSON literals
+            ('42.5', '42.5'),  # Plain numbers are not detected as JSON literals
+        ]
+        
+        # Create a mock decode_json function to test _looks_like_json_literal logic
+        def mock_looks_like_json_literal(t: str) -> bool:
+            """Replicate the _looks_like_json_literal logic for testing"""
+            t = t.strip()
+            if not t:
+                return False
+            if ((t[0] == '{' and t[-1] == '}') or (t[0] == '[' and t[-1] == ']')):
+                return True
+            if t[0] == '"' and t[-1] == '"':
+                return True
+            if t in ("true", "false", "null"):
+                return True
+            return False
+        
+        def mock_decode_json(text: str):
+            """Mock decode_json that uses _looks_like_json_literal logic"""
+            if not mock_looks_like_json_literal(text):
+                return text
+            try:
+                return json.loads(text, strict=False)
+            except json.JSONDecodeError:
+                return text
+        
+        # Test valid JSON cases
+        for input_text, expected in json_cases:
+            result = mock_decode_json(input_text)
+            assert result == expected, f"Failed for '{input_text}': expected {expected}, got {result}"
+        
+        # Test non-JSON cases (should return as-is)
+        for input_text, expected in non_json_cases:
+            result = mock_decode_json(input_text)
+            assert result == expected, f"Failed for '{input_text}': expected {expected}, got {result}"
+
+    def test_none_handling_in_full_match(self) -> None:
+        """Test None value handling in full match non-JSON mode"""
+        from writer.core_ui import Component
+        
+        session.session_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id="test_comp", parentId="root", type="text", 
+                     content={"text": "@{none_value}"})
+        ], init_root=True)
+        
+        session.session_state = WriterState({
+            "none_value": None,
+            "string_value": "hello",
+            "number_value": 42
+        })
+        
+        e = evaluator.Evaluator(session.session_state, session.session_component_tree)
+        
+        # Test None in non-JSON mode (should return None)
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "text", as_json=False
+        )
+        assert result is None, f"Expected None, got {result}"
+        
+        # Test None in JSON mode (should return None for parsing)
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "text", as_json=True
+        )
+        assert result is None, f"Expected None, got {result}"
+        
+        # Test other values work normally
+        session.session_component_tree.get_component("test_comp").content["text"] = "@{string_value}"
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "text", as_json=False
+        )
+        assert result == "hello"
+
+    def test_control_character_removal(self) -> None:
+        """Test control character removal in JSON decoding"""
+        session.session_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id="test_comp", parentId="root", type="text", 
+                     content={"text": "@{dirty_json}"})
+        ], init_root=True)
+        
+        # Test various control characters
+        session.session_state = WriterState({
+            "dirty_json": '{"text": "hello\x00\x01\x1f\x7fworld"}',  # Contains control chars
+            "clean_json": '{"text": "helloworld"}',  # Expected result after cleaning
+        })
+        
+        e = evaluator.Evaluator(session.session_state, session.session_component_tree)
+        
+        # Test that control characters are removed during JSON parsing
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "text", as_json=True
+        )
+        
+        expected = {"text": "helloworld"}
+        assert result == expected, f"Expected {expected}, got {result}"
+
+    def test_embedded_expressions_json_context(self) -> None:
+        """Test embedded expressions in JSON strings vs JSON literals"""
+        session.session_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id="test_comp", parentId="root", type="text", 
+                     content={"jsonField": '{"message": "@{greeting}", "count": @{count}, "nested": {"text": "@{name}"}}'}),
+        ], init_root=True)
+        
+        session.session_state = WriterState({
+            "greeting": "Hello World",
+            "name": "Alice", 
+            "count": 42
+        })
+        
+        e = evaluator.Evaluator(session.session_state, session.session_component_tree)
+        
+        # Test JSON field evaluation with embedded expressions
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "jsonField", as_json=True
+        )
+        
+        expected = {
+            "message": "Hello World",
+            "count": 42,
+            "nested": {"text": "Alice"}
+        }
+        assert result == expected, f"Expected {expected}, got {result}"
+
+    def test_escaped_expressions(self) -> None:
+        """Test escaped @ expressions are not evaluated"""
+        session.session_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id="test_comp", parentId="root", type="text", 
+                     content={"text": "Normal @{value} and escaped \\@{value}"})
+        ], init_root=True)
+        
+        session.session_state = WriterState({
+            "value": "replaced"
+        })
+        
+        e = evaluator.Evaluator(session.session_state, session.session_component_tree)
+        
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "text", as_json=False
+        )
+        
+        # The escaped expression should remain as literal text
+        assert result == "Normal replaced and escaped \\@{value}", f"Got: {result}"
+
+    def test_json_edge_cases(self) -> None:
+        """Test various edge cases for JSON processing"""
+        session.session_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id="test_comp", parentId="root", type="text", content={})
+        ], init_root=True)
+        
+        session.session_state = WriterState({
+            "empty_string": "",
+            "whitespace": "   ",
+            "special_chars": "hello\n\t\"world",
+            "unicode": "café ☕ 🔥",
+            "number": 3.14159,
+            "boolean": True,
+            "array": [1, "two", 3.0],
+            "nested": {"a": {"b": {"c": "deep"}}}
+        })
+        
+        e = evaluator.Evaluator(session.session_state, session.session_component_tree)
+        
+        # Test various edge cases
+        test_cases = [
+            # (field_content, expected_result, as_json)
+            ('{"empty": "@{empty_string}"}', {"empty": ""}, True),
+            ('{"whitespace": "@{whitespace}"}', {"whitespace": "   "}, True),
+            ('{"special": "@{special_chars}"}', {"special": "hello\n\t\"world"}, True),
+            ('{"unicode": "@{unicode}"}', {"unicode": "café ☕ 🔥"}, True),
+            ('{"number": @{number}}', {"number": 3.14159}, True),
+            ('{"boolean": @{boolean}}', {"boolean": True}, True),
+            ('{"array": @{array}}', {"array": [1, "two", 3.0]}, True),
+            ('{"nested": @{nested}}', {"nested": {"a": {"b": {"c": "deep"}}}}, True),
+        ]
+        
+        for field_content, expected, as_json_mode in test_cases:
+            # Update component content
+            session.session_component_tree.get_component("test_comp").content["testField"] = field_content
+            
+            result = e.evaluate_field(
+                [{"componentId": "root", "instanceNumber": 0}, 
+                 {"componentId": "test_comp", "instanceNumber": 0}], 
+                "testField", as_json=as_json_mode
+            )
+            
+            assert result == expected, f"Failed for '{field_content}': expected {expected}, got {result}"
+
+    def test_double_escaping_bug_fix(self) -> None:
+        """Test that double-escaping bug is fixed - arrays should not become [\"a\"]"""
+        session.session_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id="test_comp", parentId="root", type="text", content={})
+        ], init_root=True)
+        
+        session.session_state = WriterState({
+            "my_array": ["apple", "banana", "cherry"],
+            "nested_object": {"items": ["x", "y", "z"]}
+        })
+        
+        e = evaluator.Evaluator(session.session_state, session.session_component_tree)
+        
+        # Test array in JSON context - should NOT be double-escaped
+        session.session_component_tree.get_component("test_comp").content["jsonField"] = '{"data": @{my_array}}'
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "jsonField", as_json=True
+        )
+        
+        expected = {"data": ["apple", "banana", "cherry"]}
+        assert result == expected, f"Double-escaping bug: expected {expected}, got {result}"
+        
+        # Test nested object should also work correctly
+        session.session_component_tree.get_component("test_comp").content["jsonField"] = '{"result": @{nested_object}}'
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "jsonField", as_json=True
+        )
+        
+        expected = {"result": {"items": ["x", "y", "z"]}}
+        assert result == expected, f"Nested object failed: expected {expected}, got {result}"
+
+    def test_context_confusion_fix(self) -> None:
+        """Test that context confusion is fixed - JSON string vs JSON literal handling"""
+        session.session_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id="test_comp", parentId="root", type="text", content={})
+        ], init_root=True)
+        
+        session.session_state = WriterState({
+            "user_name": "Alice",
+            "special_chars": 'hello "world"',
+            "user_data": {"name": "Bob", "age": 25}
+        })
+        
+        e = evaluator.Evaluator(session.session_state, session.session_component_tree)
+        
+        # Case 1: Inside JSON string - should inject escaped string fragment
+        session.session_component_tree.get_component("test_comp").content["jsonField"] = '{"message": "Hello @{user_name}!"}'
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "jsonField", as_json=True
+        )
+        expected = {"message": "Hello Alice!"}
+        assert result == expected, f"JSON string context failed: expected {expected}, got {result}"
+        
+        # Case 2: Inside JSON string with special characters - should be properly escaped
+        session.session_component_tree.get_component("test_comp").content["jsonField"] = '{"text": "User said: @{special_chars}"}'
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "jsonField", as_json=True
+        )
+        expected = {"text": 'User said: hello "world"'}
+        assert result == expected, f"Special chars in string failed: expected {expected}, got {result}"
+        
+        # Case 3: As JSON literal - should inject raw JSON
+        session.session_component_tree.get_component("test_comp").content["jsonField"] = '{"data": @{user_data}}'
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "jsonField", as_json=True
+        )
+        expected = {"data": {"name": "Bob", "age": 25}}
+        assert result == expected, f"JSON literal context failed: expected {expected}, got {result}"
+
+    def test_full_match_handling_fix(self) -> None:
+        """Test full-match handling returns raw values correctly"""
+        session.session_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id="test_comp", parentId="root", type="text", content={})
+        ], init_root=True)
+        
+        session.session_state = WriterState({
+            "raw_dict": {"key": "value", "nested": {"deep": "data"}},
+            "raw_list": [1, 2, {"item": "test"}],
+            "raw_none": None,
+            "raw_string": "plain text",
+            "json_string": '{"parsed": "json"}',
+            "raw_number": 42,
+            "raw_boolean": True
+        })
+        
+        e = evaluator.Evaluator(session.session_state, session.session_component_tree)
+        
+        test_cases = [
+            # (state_key, expected_result, as_json, description)
+            ("raw_dict", {"key": "value", "nested": {"deep": "data"}}, True, "dict should pass through"),
+            ("raw_list", [1, 2, {"item": "test"}], True, "list should pass through"),
+            ("raw_none", None, True, "None should pass through in JSON mode"),
+            ("raw_none", None, False, "None should pass through in non-JSON mode"),
+            ("raw_string", "plain text", False, "string should pass through in non-JSON"),
+            ("json_string", {"parsed": "json"}, True, "JSON string should be parsed in JSON mode"),
+            ("json_string", '{"parsed": "json"}', False, "JSON string should NOT be parsed in non-JSON mode"),
+            ("raw_number", 42, True, "number should pass through"),
+            ("raw_boolean", True, False, "boolean should pass through"),
+        ]
+        
+        for state_key, expected, as_json_mode, description in test_cases:
+            # Set field to exactly @{state_key} for full match
+            session.session_component_tree.get_component("test_comp").content["testField"] = f"@{{{state_key}}}"
+            
+            result = e.evaluate_field(
+                [{"componentId": "root", "instanceNumber": 0}, 
+                 {"componentId": "test_comp", "instanceNumber": 0}], 
+                "testField", as_json=as_json_mode
+            )
+            
+            assert result == expected, f"Full match failed - {description}: expected {expected}, got {result}"
+
+    def test_simplified_decode_step(self) -> None:
+        """Test that decode_json is only called when final result is string and as_json=True"""
+        session.session_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id="test_comp", parentId="root", type="text", content={})
+        ], init_root=True)
+        
+        session.session_state = WriterState({
+            "already_dict": {"key": "value"},
+            "json_string": '{"will": "be_parsed"}',
+            "plain_string": "not json",
+            "number_val": 123
+        })
+        
+        e = evaluator.Evaluator(session.session_state, session.session_component_tree)
+        
+        # Case 1: Already a dict - should NOT be processed by decode_json
+        session.session_component_tree.get_component("test_comp").content["field"] = "@{already_dict}"
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "field", as_json=True
+        )
+        assert result == {"key": "value"}, f"Dict should pass through: {result}"
+        
+        # Case 2: JSON string with as_json=True - should be decoded
+        session.session_component_tree.get_component("test_comp").content["field"] = "@{json_string}"
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "field", as_json=True
+        )
+        assert result == {"will": "be_parsed"}, f"JSON string should be parsed: {result}"
+        
+        # Case 3: JSON string with as_json=False - should NOT be decoded
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "field", as_json=False
+        )
+        assert result == '{"will": "be_parsed"}', f"JSON string should remain string: {result}"
+        
+        # Case 4: Plain string with as_json=True - should remain string (not parseable)
+        session.session_component_tree.get_component("test_comp").content["field"] = "@{plain_string}"
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "field", as_json=True
+        )
+        assert result == "not json", f"Plain string should remain unchanged: {result}"
+        
+        # Case 5: Number - should pass through without decode attempt
+        session.session_component_tree.get_component("test_comp").content["field"] = "@{number_val}"
+        result = e.evaluate_field(
+            [{"componentId": "root", "instanceNumber": 0}, 
+             {"componentId": "test_comp", "instanceNumber": 0}], 
+            "field", as_json=True
+        )
+        assert result == 123, f"Number should pass through: {result}"

--- a/tests/backend/test_evaluator.py
+++ b/tests/backend/test_evaluator.py
@@ -1,12 +1,14 @@
 import json
 
 import numpy as np
+import pytest
 import writer as wf
 from writer import audit_and_fix, evaluator, wf_project
 from writer.core import (
     WriterState,
 )
 from writer.core_ui import Component
+from writer.ss_types import WriterConfigurationError
 
 from tests.backend import test_app_dir
 from tests.backend.fixtures import (
@@ -263,6 +265,8 @@ class TestEvaluator:
             ('{"key": "value"}', 6, False),  # Between key and value - pos 6 is ':'
             ('{"key": "value"}', 0, False),  # At start - pos 0 is '{'
             ('{"key": "value"}', 8, False),  # At quote start - pos 8 is '"'
+            ('{"key": "value"}', 14, True),  # At closing quote - still inside before processing
+            ('{"key": "value"}', 15, False), # Right after closing quote (closing brace)
             ('{"text": "hello \\"world\\""}', 15, True),  # Inside escaped quotes  
             ('{"text": "hello \\"world\\""}', 26, False), # Outside string (closing brace)
             ('{"a": 1, "b": "text"}', 10, True), # Inside key "b"
@@ -310,6 +314,7 @@ class TestEvaluator:
             ('null', None),
             ('true', True),
             ('false', False),
+            ('  true  ', True),  # Whitespace-tolerant booleans should parse
             # Note: Numbers without quotes are NOT detected as JSON literals by _looks_like_json_literal
             # They would be returned as strings, then parsed if they're valid JSON
         ]
@@ -324,6 +329,9 @@ class TestEvaluator:
             ('just text', 'just text'),
             ('42', '42'),  # Plain numbers are not detected as JSON literals
             ('42.5', '42.5'),  # Plain numbers are not detected as JSON literals
+            ('True', 'True'),  # Uppercase variants are not JSON
+            ('False', 'False'),  # Uppercase variants are not JSON
+            ('NULL', 'NULL'),  # Uppercase variants are not JSON
         ]
         
         # Create a mock decode_json function to test _looks_like_json_literal logic
@@ -361,7 +369,6 @@ class TestEvaluator:
 
     def test_none_handling_in_full_match(self) -> None:
         """Test None value handling in full match non-JSON mode"""
-        from writer.core_ui import Component
         
         session.session_component_tree = core_ui_fixtures.build_fake_component_tree([
             Component(id="test_comp", parentId="root", type="text", 
@@ -425,6 +432,28 @@ class TestEvaluator:
         
         expected = {"text": "helloworld"}
         assert result == expected, f"Expected {expected}, got {result}"
+
+    def test_invalid_json_raises_error(self) -> None:
+        """Test that invalid JSON raises WriterConfigurationError"""
+        session.session_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id="test_comp", parentId="root", type="text", 
+                     content={"text": "@{invalid_json}"})
+        ], init_root=True)
+        
+        # Test invalid JSON that should raise an error
+        session.session_state = WriterState({
+            "invalid_json": '{"incomplete": }',  # Invalid JSON
+        })
+        
+        e = evaluator.Evaluator(session.session_state, session.session_component_tree)
+        
+        # Test that invalid JSON raises WriterConfigurationError when as_json=True
+        with pytest.raises(WriterConfigurationError, match="Error decoding JSON"):
+            e.evaluate_field(
+                [{"componentId": "root", "instanceNumber": 0}, 
+                 {"componentId": "test_comp", "instanceNumber": 0}], 
+                "text", as_json=True
+            )
 
     def test_embedded_expressions_json_context(self) -> None:
         """Test embedded expressions in JSON strings vs JSON literals"""


### PR DESCRIPTION
This PR fixes several issues in `Evaluator.evaluate_field`:
• **Double-escaping bug**: Previously, JSON values like `["a"]` were being turned into `[\"a\"]`, causing `json.loads` to fail.
• **Context confusion**: Embedded templates inside a JSON string (e.g. `"TEXT @{var} TEXT"`) need to inject an escaped string fragment, while those in structural JSON (e.g. `{"arr": @{array}}`) must inject a JSON literal. We now detect this properly by scanning whether the replacement is positioned inside quotes.
• **Full-match handling**: When a field is exactly `@{...}`, we now return the raw value. Strings containing JSON are parsed once at the end; dicts/lists/`None` pass through unchanged. This avoids accidental double-serialization and supports `None` detection in blocks like `LogMessage`/`ReturnValue`.
• **Decode step simplified**: `decode_json` is only called when the final replaced value is a string and `as_json=True`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context-aware JSON embedding for template substitutions, distinguishing inserts inside strings vs. JSON literals.
  * Automatic decoding of JSON outputs when requested for ready-to-use results.

* **Bug Fixes**
  * Safer default context handling to avoid mutable-state leaks.
  * Clearer errors for unresolved components and invalid image inputs; more reliable embedded substitution behavior.

* **Tests**
  * Expanded test coverage for JSON embedding, string-vs-literal behavior, edge cases, escaping, and decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->