### PR TITLE
fix: properly write created_by block ID in traces

### DIFF
--- a/src/writer/blocks/base_block.py
+++ b/src/writer/blocks/base_block.py
@@ -264,6 +264,17 @@ class BlueprintBlock:
                 import datetime as dt
                 request_id = str(uuid.uuid4())
                 
+                # Get the current block's ID for accurate logging
+                current_block_id = self.instance_path  # fallback (should be componentId)
+                try:
+                    from writer.blueprints import get_current_block
+                    current_block = get_current_block()
+                    if current_block and hasattr(current_block, 'instance_path'):
+                        # Extract componentId from the current block's instance path
+                        current_block_id = current_block.instance_path[0].get('componentId', None)
+                except Exception:
+                    pass
+                
                 # Capture request content
                 content = None
                 if request.content:
@@ -281,7 +292,7 @@ class BlueprintBlock:
                 log_entry = {
                     'id': request_id,
                     'created_at': dt.datetime.now(dt.timezone.utc).isoformat(),
-                    'created_by': self.instance_path,
+                    'created_by': current_block_id,
                     'request': {
                         'method': request.method,
                         'url': str(request.url),


### PR DESCRIPTION
Previously, API calls traces reported the first block to ever make an API call as an initiator for each API call; this PR fixes it by providing a proper mechanism to retrieve the current block ID to use in logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Request logs now correctly attribute actions to the active block/component, improving traceability across HTTP hooks, streaming, and content-capture scenarios.
  - Eliminates instances where logs showed a generic or incorrect source for created_by.

- Chores
  - Internal logging logic made more resilient without changing public APIs or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->