### PR TITLE
fix(ui): Enable Shift+Return for new line in chatbot UI - AB-255

### DIFF
--- a/src/ui/src/components/core/content/CoreChatbot.vue
+++ b/src/ui/src/components/core/content/CoreChatbot.vue
@@ -71,7 +71,7 @@ See the stubs for more details.
 			<WdsTextareaInput
 				v-model="outgoingMessage"
 				:placeholder="fields.placeholder.value"
-				@keydown.prevent.enter="handleMessageSent"
+				@keydown.enter="handleMessageSent"
 			>
 			</WdsTextareaInput>
 		</div>
@@ -329,7 +329,10 @@ const displayExtraLoader = computed(() => {
 	return messageIndexLoading.value >= messages.value.length;
 });
 
-function handleMessageSent() {
+function handleMessageSent(e: KeyboardEvent) {
+	if (e.shiftKey) return;
+
+	e.preventDefault();
 	if (messageIndexLoading.value) return;
 	messageIndexLoading.value = messages.value.length + 1;
 	const event = new CustomEvent("wf-chatbot-message", {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Shift+Enter now inserts a newline in the chat input, enabling multi-line messages.
  * Enter sends the message as before, with improved handling to prevent accidental duplicate sends.
  * Sending maintains existing loading feedback and clears the input upon completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->