### PR TITLE
chore: ability to set worker count

### DIFF
--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -615,8 +615,9 @@ class AppProcess(multiprocessing.Process):
         thread_pool_future.add_done_callback(self._send_packet)
 
     def run(self) -> None:
+        max_workers = int(os.getenv("WRITER_MAX_WORKERS", (os.cpu_count() or 4) * 10))
         self.executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=(os.cpu_count() or 4) * 10
+            max_workers=max_workers,
         )
         self.server_conn_lock = threading.Lock()
         self.client_conn.close()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an environment variable to configure the app’s maximum parallel workers, enabling performance tuning without code changes.
  * Default behavior remains unchanged if the variable is not set.
  * Requires an integer value; invalid values will prevent startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->