### PR TITLE
fix(ui): prevent empty entries in Key-Value editor - AB-259

### DIFF
--- a/src/ui/src/builder/settings/composables/useKeyValueEditor.spec.ts
+++ b/src/ui/src/builder/settings/composables/useKeyValueEditor.spec.ts
@@ -31,6 +31,16 @@ describe(useKeyValueEditor.name, () => {
 			);
 		});
 
+		it("should filter empty entries", () => {
+			const initial = { foo: "bar" };
+			const { currentValue, addAssistedEntry } =
+				useKeyValueEditor(initial);
+
+			addAssistedEntry();
+
+			expect(currentValue.value).toBe(JSON.stringify(initial));
+		});
+
 		it("should update an entry", () => {
 			const {
 				assistedEntries,

--- a/src/ui/src/builder/settings/composables/useKeyValueEditor.ts
+++ b/src/ui/src/builder/settings/composables/useKeyValueEditor.ts
@@ -160,13 +160,12 @@ export function useKeyValueEditor(originalValue: string | JSONValue) {
 	const currentValue = computed<string>(() => {
 		switch (mode.value) {
 			case "assisted": {
-				const obj = Object.values(assistedEntries.value).reduce(
-					(acc, v) => {
+				const obj = Object.values(assistedEntries.value)
+					.filter((v) => !(v.key === "" && v.value === ""))
+					.reduce((acc, v) => {
 						acc[v.key] = v.value;
 						return acc;
-					},
-					{},
-				);
+					}, {});
 				return JSON.stringify(obj);
 			}
 			case "freehand":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assisted key-value editor now ignores empty placeholder entries (empty key and value), preventing them from appearing in the serialized output and avoiding unintended empty pairs.
  * Adding an empty assisted entry no longer changes the current value.

* **Tests**
  * Added a unit test to verify that empty assisted entries are filtered and do not affect the serialized representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->