### PR TITLE
fix(writer): fix validation for Ask KG / Graph Ids - AB-205

### DIFF
--- a/src/writer/blocks/writeraskkg.py
+++ b/src/writer/blocks/writeraskkg.py
@@ -39,13 +39,9 @@ class WriterAskGraphQuestion(WriterBlock):
                         "name": "Graph Ids",
                         "type": "Graph Ids",
                         "desc": "IDs of the graphs to query.",
-                        "default": "[]",
+                        "default": "",
                         "validator": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "format": "uuid"
-                            }
+                            "type": "string",
                         }
                     },
                     "subqueries": {


### PR DESCRIPTION
The graph Ids field is not an array but a string with ids separated with coma.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - The Graph ID input for graph-related questions now expects a single ID string (default empty) instead of an array. Validation and form guidance were updated to reflect the single-ID format. Runtime behavior remains compatible with single inputs, so existing executions are unaffected. This simplifies configuration and reduces input errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->