### PR TITLE
fix(ui): prevent horizontal scrolling in JSON Viewer - AB-261

### DIFF
--- a/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewerValue.vue
+++ b/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewerValue.vue
@@ -35,5 +35,6 @@ const dataFormatted = computed(() => {
 .SharedJsonViewerValue {
 	font-family: monospace;
 	color: var(--secondaryTextColor);
+	word-break: break-all;
 }
 </style>


### PR DESCRIPTION
| before | after |
|---|---|
| <img width="958" height="473" alt="Screenshot 2025-08-27 at 10 27 09" src="https://github.com/user-attachments/assets/6a7a8a46-3d4f-495e-8161-5955a94860e7" />  |  <img width="958" height="473" alt="Screenshot 2025-08-27 at 10 27 02" src="https://github.com/user-attachments/assets/84c5ada0-7818-417a-ac66-19bd0695623a" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Improved readability of long JSON values by enabling automatic line breaks within the JSON viewer. Long strings now wrap instead of overflowing, reducing horizontal scrolling and preventing layout shifts on smaller screens.
  - Enhances visual consistency across browsers and improves accessibility for users viewing large payloads.
  - No changes to functionality or data formatting; this update strictly affects presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->