### PR TITLE
fix(ui): improve JSON copy functionality in state explorer - AB-242

### DIFF
--- a/src/ui/src/builder/useComponentClipboard.ts
+++ b/src/ui/src/builder/useComponentClipboard.ts
@@ -1,3 +1,4 @@
+import { isPlainObject } from "@/utils/object";
 import { useLogger } from "@/composables/useLogger";
 import { Component } from "@/writerTypes";
 
@@ -8,8 +9,7 @@ type ClipboardData = {
 
 function isClipboardData(data: unknown): data is ClipboardData {
 	return (
-		typeof data === "object" &&
-		data !== null &&
+		isPlainObject(data) &&
 		"type" in data &&
 		data.type === "writer/clipboard" &&
 		"components" in data &&

--- a/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewer.utils.ts
+++ b/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewer.utils.ts
@@ -1,3 +1,4 @@
+import { isPlainObject } from "@/utils/object";
 import type {
 	JsonData,
 	JsonValue,
@@ -18,7 +19,7 @@ export function isJSONArray(data: JsonData): data is JsonData[] {
 export function isJSONObject(
 	data: JsonData,
 ): data is { [x: string]: JsonData } {
-	return !isJSONArray(data) && typeof data === "object" && data !== null;
+	return isPlainObject(data);
 }
 
 export function getJSONLength(data: JsonData): number {

--- a/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewer.vue
+++ b/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewer.vue
@@ -6,7 +6,7 @@
 				:open="isRootOpen"
 				:data="data"
 				@toggle="$emit('toggle', { path: [], open: $event })"
-				@copy.stop.prevent="onCopyToClipboard(data)"
+				@copy="onCopyToClipboard($event, data)"
 			>
 				<SharedJsonViewerObject
 					:data="data"
@@ -21,7 +21,7 @@
 				:path="path"
 				:initial-depth="initialDepth"
 				@toggle="$emit('toggle', $event)"
-				@copy.stop.prevent="onCopyToClipboard(data)"
+				@copy="onCopyToClipboard($event, data)"
 			/>
 		</template>
 		<SharedJsonViewerValue v-else-if="isJSONValue(data)" :data="data" />
@@ -53,6 +53,7 @@ export type JsonViewerTogglePayload = { path: JsonPath; open: boolean };
  */
 import { PropType, computed } from "vue";
 import { useClipboard } from "@vueuse/core";
+import { isPlainObject } from "@/utils/object";
 import {
 	isJSONArray,
 	isJSONObject,
@@ -120,16 +121,32 @@ const dataAsString = computed(() => prettyJson(props.data, 0));
 
 const { copy } = useClipboard();
 
+function isEmptySubset(subset: Record<string, unknown> | unknown[]): boolean {
+	if (Array.isArray(subset)) return subset.length === 0;
+	if (isPlainObject(subset)) return Object.keys(subset).length === 0;
+	return false;
+}
+
 function onCopyToClipboard(
+	event: ClipboardEvent,
 	arrayOrObject: Record<string, JsonData> | JsonData[],
 ) {
-	const selection = window.getSelection();
-	const selectionText = selection?.toString().trim() ?? "";
+	event.stopPropagation();
 
-	const json = selectionText
-		? selectionToJson(arrayOrObject, selectionText)
-		: arrayOrObject;
+	const selectionText = (window.getSelection()?.toString() ?? "").trim();
 
-	copy(prettyJson(json));
+	if (!selectionText) {
+		return; // no selection → do nothing
+	}
+
+	const subset = selectionToJson(arrayOrObject, selectionText);
+
+	if (isEmptySubset(subset)) {
+		return; // nothing meaningful recognized → allow native copy of raw text
+	}
+
+	event.preventDefault();
+
+	copy(prettyJson(subset)); // copy subset
 }
 </script>

--- a/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewer.vue
+++ b/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewer.vue
@@ -105,19 +105,19 @@ const isRootOpen = computed(
 	() => props.initialDepth === -1 || props.initialDepth > 0,
 );
 
-function prettyJson(input: unknown, space = 2) {
+function prettyJson(input: unknown) {
 	if (input === undefined) {
 		return JSON.stringify(null);
 	}
 
 	try {
-		return JSON.stringify(input, null, space);
+		return JSON.stringify(input, null, 2);
 	} catch {
 		return JSON.stringify(null);
 	}
 }
 
-const dataAsString = computed(() => prettyJson(props.data, 0));
+const dataAsString = computed(() => prettyJson(props.data));
 
 const { copy } = useClipboard();
 

--- a/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewer.vue
+++ b/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewer.vue
@@ -6,6 +6,7 @@
 				:open="isRootOpen"
 				:data="data"
 				@toggle="$emit('toggle', { path: [], open: $event })"
+				@copy.stop.prevent="onCopyToClipboard(data)"
 			>
 				<SharedJsonViewerObject
 					:data="data"
@@ -20,6 +21,7 @@
 				:path="path"
 				:initial-depth="initialDepth"
 				@toggle="$emit('toggle', $event)"
+				@copy.stop.prevent="onCopyToClipboard(data)"
 			/>
 		</template>
 		<SharedJsonViewerValue v-else-if="isJSONValue(data)" :data="data" />
@@ -50,6 +52,7 @@ export type JsonViewerTogglePayload = { path: JsonPath; open: boolean };
  * This component will detect the shape of the JSON and redirect the right dedicated component.
  */
 import { PropType, computed } from "vue";
+import { useClipboard } from "@vueuse/core";
 import {
 	isJSONArray,
 	isJSONObject,
@@ -62,6 +65,7 @@ import SharedJsonViewerValue from "./SharedJsonViewerValue.vue";
 import SharedJsonViewerChildrenCounter from "./SharedJsonViewerChildrenCounter.vue";
 import SharedControlBar from "../SharedControlBar.vue";
 import { defineAsyncComponentWithLoader } from "@/utils/defineAsyncComponentWithLoader";
+import { selectionToJson } from "./selectionToJson";
 
 const SharedCopyClipboardButton = defineAsyncComponentWithLoader({
 	loader: () => import("@/components/shared/SharedCopyClipboardButton.vue"),
@@ -99,8 +103,33 @@ const isRoot = computed(() => props.path.length === 0 && !props.hideRoot);
 const isRootOpen = computed(
 	() => props.initialDepth === -1 || props.initialDepth > 0,
 );
-const dataAsString = computed(() => {
-	if (props.data === undefined) return JSON.stringify(null);
-	return JSON.stringify(props.data);
-});
+
+function prettyJson(input: unknown, space = 2) {
+	if (input === undefined) {
+		return JSON.stringify(null);
+	}
+
+	try {
+		return JSON.stringify(input, null, space);
+	} catch {
+		return JSON.stringify(null);
+	}
+}
+
+const dataAsString = computed(() => prettyJson(props.data, 0));
+
+const { copy } = useClipboard();
+
+function onCopyToClipboard(
+	arrayOrObject: Record<string, JsonData> | JsonData[],
+) {
+	const selection = window.getSelection();
+	const selectionText = selection?.toString().trim() ?? "";
+
+	const json = selectionText
+		? selectionToJson(arrayOrObject, selectionText)
+		: arrayOrObject;
+
+	copy(prettyJson(json));
+}
 </script>

--- a/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewerObject.vue
+++ b/src/ui/src/components/shared/SharedJsonViewer/SharedJsonViewerObject.vue
@@ -47,7 +47,9 @@ import SharedJsonViewerValue from "./SharedJsonViewerValue.vue";
 
 const props = defineProps({
 	data: {
-		type: [Object, Array] as PropType<JsonData>,
+		type: [Object, Array] as PropType<
+			Record<string, JsonData> | JsonData[]
+		>,
 		required: true,
 	},
 	path: {

--- a/src/ui/src/components/shared/SharedJsonViewer/__snapshots__/selectionToJson.spec.ts
+++ b/src/ui/src/components/shared/SharedJsonViewer/__snapshots__/selectionToJson.spec.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect } from "vitest";
+import { selectionToJson } from "../selectionToJson";
+
+describe("selectionToJson", () => {
+	describe("root object", () => {
+		const DATA = {
+			name: "JSON Viewer",
+			description: "A JSON tree viewer where you can expand the keys.",
+			sample: {
+				description: "This sample is opened by default",
+				bool: true,
+				null: null,
+				list: [1, "two", { key: 3 }],
+			},
+			sampleClosed: {
+				description: "This sample is not opened by default",
+			},
+			createdAt: "2025-08-07T12:40:38.362Z",
+		} as const;
+
+		const DATA_WITH_EDGE_KEYS = {
+			"weird.key[0]?": 123,
+			"a+b*c|d^e$": "ops",
+			name: "base",
+			nameLong: "should not match when only 'name' is selected",
+		} as const;
+
+		const EMPTY_SHAPES = {
+			emptyObj: {},
+			emptyArr: [],
+		} as const;
+
+		it("returns empty object when selection has no recognizable tokens", () => {
+			const sel = "random text only";
+			expect(selectionToJson(DATA, sel)).toEqual({});
+		});
+
+		it("returns empty object for blank/whitespace selection", () => {
+			const sel = "   \n\r  \n";
+			expect(selectionToJson(DATA, sel)).toEqual({});
+		});
+
+		it("recognizes CRLF-newline formatting (colon on next line)", () => {
+			const sel = `name\r\n:\r\n"JSON Viewer"`;
+			expect(selectionToJson(DATA, sel)).toEqual({
+				name: DATA.name,
+			});
+		});
+
+		it("picks a single KV when the line is whole", () => {
+			const sel = `"createdAt": "2025-08-07T12:40:38.362Z"`;
+			expect(selectionToJson(DATA, sel)).toEqual({
+				createdAt: DATA.createdAt,
+			});
+		});
+
+		it("picks 'name' only when 'description' key is partial", () => {
+			const sel = `"name": "JSON Viewer",\n  "desc`;
+			expect(selectionToJson(DATA, sel)).toEqual({
+				name: DATA.name,
+			});
+		});
+
+		it("picks full description when its value is partial", () => {
+			const sel = `"name": "JSON Viewer",\n  "description": "A JSON tr`;
+			expect(selectionToJson(DATA, sel)).toEqual({
+				name: DATA.name,
+				description: DATA.description,
+			});
+		});
+
+		it("collapsed parent only -> include full object", () => {
+			const sel = `sample\nObject{4}`;
+			expect(selectionToJson(DATA, sel)).toEqual({
+				sample: DATA.sample,
+			});
+		});
+
+		it("collapsed window -> include only picked children", () => {
+			const sel = `sample
+Object{4}
+description
+:
+"This sample is opened by default"
+bool
+:
+true`;
+			expect(selectionToJson(DATA, sel)).toEqual({
+				sample: {
+					description: DATA.sample.description,
+					bool: DATA.sample.bool,
+				},
+			});
+		});
+
+		it("collapsed window includes all children (Array[n] counts)", () => {
+			const sel = `sample
+Object{4}
+description
+:
+"This sample is opened by default"
+bool
+:
+true
+null
+:
+null
+list
+Array[3]`;
+			expect(selectionToJson(DATA, sel)).toEqual({
+				sample: DATA.sample,
+			});
+		});
+
+		it("does not leak root keys that appear inside a collapsed window", () => {
+			const sel = `sample
+Object{4}
+description
+:
+"This sample is opened by default"
+bool
+:
+true
+null
+:
+null
+list
+Array[3]`;
+			expect(Object.keys(selectionToJson(DATA, sel))).toEqual(["sample"]);
+		});
+
+		it("mix of root KVs and a collapsed parent with children", () => {
+			const sel = `name
+:
+"JSON Viewer"
+description
+:
+"A JSON tree viewer where you can expand the keys."
+sample
+Object{4}
+description
+:
+"This sample is opened by default"
+bool
+:
+true`;
+			expect(selectionToJson(DATA, sel)).toEqual({
+				name: DATA.name,
+				description: DATA.description,
+				sample: { description: DATA.sample.description, bool: true },
+			});
+		});
+
+		it("multiple collapsed + KV after them", () => {
+			const sel = `sample
+Object{4}
+sampleClosed
+Object{1}
+createdAt
+:
+"2025-08-07T12:40:38.362Z"`;
+			expect(selectionToJson(DATA, sel)).toEqual({
+				sample: DATA.sample,
+				sampleClosed: DATA.sampleClosed,
+				createdAt: DATA.createdAt,
+			});
+		});
+
+		it("copy whole object when selection effectively covers entire root", () => {
+			const sel = `Object{5}
+name
+:
+"JSON Viewer"
+description
+:
+"A JSON tree viewer where you can expand the keys."
+sample
+Object{4}
+description
+:
+"This sample is opened by default"
+bool
+:
+true
+null
+:
+null
+list
+Array[3]
+sampleClosed
+Object{1}
+description
+:
+"This sample is not opened by default"
+createdAt
+:
+"2025-08-07T12:40:38.362Z"`;
+			expect(selectionToJson(DATA, sel)).toEqual(DATA);
+		});
+
+		it("keys with regex-special characters are matched literally", () => {
+			const sel = `"weird.key[0]?"
+:
+123
+"a+b*c|d^e$"
+:
+"ops"`;
+			expect(selectionToJson(DATA_WITH_EDGE_KEYS, sel)).toEqual({
+				"weird.key[0]?": DATA_WITH_EDGE_KEYS["weird.key[0]?"],
+				"a+b*c|d^e$": DATA_WITH_EDGE_KEYS["a+b*c|d^e$"],
+			});
+		});
+
+		it("key substring does not match a longer key (exact match only)", () => {
+			const sel = `"name": "base"`;
+			expect(selectionToJson(DATA_WITH_EDGE_KEYS, sel)).toEqual({
+				name: DATA_WITH_EDGE_KEYS.name,
+			});
+		});
+
+		it("longer key does not accidentally match the shorter one", () => {
+			const sel = `"nameLong": "should not match when only 'name' is selected"`;
+			expect(selectionToJson(DATA_WITH_EDGE_KEYS, sel)).toEqual({
+				nameLong: DATA_WITH_EDGE_KEYS.nameLong,
+			});
+		});
+
+		it("collapsed empty object/array are included fully", () => {
+			const sel1 = `emptyObj\nObject{0}`;
+			expect(selectionToJson(EMPTY_SHAPES, sel1)).toEqual({
+				emptyObj: {},
+			});
+
+			const sel2 = `emptyArr\nArray[0]`;
+			expect(selectionToJson(EMPTY_SHAPES, sel2)).toEqual({
+				emptyArr: [],
+			});
+		});
+
+		it("unknown root key in selection is ignored", () => {
+			const sel = `ghost\nObject{1}\nname\n:\n"JSON Viewer"`;
+			expect(selectionToJson(DATA, sel)).toEqual({
+				name: DATA.name,
+			});
+		});
+	});
+
+	describe("root array", () => {
+		const DATA = [
+			{
+				only: "first",
+			},
+			{
+				name: "JSON Viewer",
+				description:
+					"A JSON tree viewer where you can expand the keys.",
+				sample: {
+					description: "This sample is opened by default",
+					bool: true,
+					null: null,
+					list: [1, "two", { key: 3 }],
+				},
+				sampleClosed: {
+					description: "This sample is not opened by default",
+				},
+				createdAt: "2025-08-27T11:29:31.963Z",
+			},
+		];
+
+		it("Array[n] mention only -> returns full array (copy-all)", () => {
+			const sel = `Array[2]`;
+			expect(selectionToJson(DATA, sel)).toEqual(DATA);
+		});
+
+		it("collapsed index 0 only -> includes element 0 fully", () => {
+			const sel = `0\nObject{1}`;
+			expect(selectionToJson(DATA, sel)).toEqual([DATA[0]]);
+		});
+
+		it("collapsed index 1 with picked children -> includes partial object", () => {
+			const sel = `1
+Object{5}
+description
+:
+"A JSON tree viewer where you can expand the keys."
+sample
+Object{4}
+description
+:
+"This sample is opened by default"
+bool
+:
+true`;
+			expect(selectionToJson(DATA, sel)).toEqual([
+				{
+					description:
+						"A JSON tree viewer where you can expand the keys.",
+					sample: {
+						description: "This sample is opened by default",
+						bool: true,
+					},
+				},
+			]);
+		});
+
+		it("textual order of indices is preserved in the output array", () => {
+			const three = [{ i: 0 }, { i: 1 }, { i: 2 }];
+			const sel = `2
+Object{1}
+0
+Object{1}`;
+			expect(selectionToJson(three, sel)).toEqual([three[2], three[0]]);
+		});
+
+		it("negative index is ignored", () => {
+			const sel = `-1\nObject{1}`;
+			expect(selectionToJson(DATA, sel)).toEqual([]);
+		});
+
+		it("index out of bounds is ignored", () => {
+			const sel = `2\nObject{1}`;
+			expect(selectionToJson(DATA, sel)).toEqual([]);
+		});
+
+		it("child key mention without index context does not include anything", () => {
+			const sel = `name\n:\n"JSON Viewer"`;
+			expect(selectionToJson(DATA, sel)).toEqual([]);
+		});
+
+		it("blank selection for root array returns empty array", () => {
+			expect(selectionToJson(DATA, "   \n")).toEqual([]);
+		});
+
+		it("Array[n] with extra noise still triggers copy-all", () => {
+			const sel = `Array[2]\n(not real tokens)`;
+			expect(selectionToJson(DATA, sel)).toEqual(DATA);
+		});
+	});
+});

--- a/src/ui/src/components/shared/SharedJsonViewer/selectionToJson.ts
+++ b/src/ui/src/components/shared/SharedJsonViewer/selectionToJson.ts
@@ -1,0 +1,337 @@
+import { isPlainObject } from "@/utils/object";
+
+type ArrayOrObject = unknown[] | Record<string, unknown>;
+
+type TokenType = "key-value" | "collapsed";
+type Token = {
+	type: TokenType;
+	key: string;
+	/** index in the selection text */
+	index: number;
+};
+
+function escapeRegex(text: string) {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Finds the first occurrence of a root key used as a Key:Value entry in the selection text.
+ * Accepts either `"key":` or `key` with the colon on the next line.
+ *
+ * Example matches:
+ *   - `"name":`
+ *   - `name` (newline) `:` (newline/space) …
+ */
+function findKeyValueIndex(key: string, selectionText: string): number {
+	return selectionText.search(
+		new RegExp(`(^|\\n)\\s*"?${escapeRegex(key)}"?\\s*:\\s*`),
+	);
+}
+
+/**
+ * Finds the first occurrence of a root key used as a collapsed header in the selection text.
+ * Accepts either the marker on the same line or the next line:
+ *
+ * Example matches:
+ *   - `key Object{N}`
+ *   - `key` (newline) `Object{N}`
+ *   - `key Array[N]`
+ *   - `key` (newline) `Array[N]`
+ */
+function findCollapsedIndex(key: string, selectionText: string): number {
+	return selectionText.search(
+		new RegExp(
+			`(^|\\n)\\s*"?${escapeRegex(key)}"?\\s*(\\n\\s*)?(Object\\{\\d+\\}|Array\\[\\d+\\])`,
+		),
+	);
+}
+
+/**
+ * Returns root-level tokens (first occurrences) found in the selection text.
+ * Each root key can contribute two tokens at most: "key-value" and/or "collapsed".
+ */
+function getRootTokens(
+	root: Record<string, unknown>,
+	selectionText: string,
+): Token[] {
+	const result: Token[] = [];
+
+	Object.keys(root).forEach((key) => {
+		const keyValueIndex = findKeyValueIndex(key, selectionText);
+
+		if (keyValueIndex !== -1) {
+			result.push({ type: "key-value", key, index: keyValueIndex });
+		}
+
+		const collapsedIndex = findCollapsedIndex(key, selectionText);
+
+		if (collapsedIndex !== -1) {
+			result.push({ type: "collapsed", key, index: collapsedIndex });
+		}
+	});
+
+	result.sort((a, b) => a.index - b.index);
+
+	return result;
+}
+
+type CollapsedSegment = {
+	key: string;
+	startIndex: number;
+	endIndex: number;
+};
+
+/**
+ * Returns "windows" for collapsed parents.
+ * A window spans from the collapsed token to the next token that either:
+ *  - is another collapsed root key, OR
+ *  - is a root key-value that does NOT belong to this parent
+ * If none is found, the window ends at the end of the selection text.
+ */
+function getCollapsedSegments(
+	root: Record<string, unknown>,
+	selectionText: string,
+	tokens: Token[],
+): CollapsedSegment[] {
+	const childMap = new Map<string, Set<string>>();
+
+	Object.entries(root).forEach(([key, value]) => {
+		childMap.set(
+			key,
+			isPlainObject(value) ? new Set(Object.keys(value)) : new Set(),
+		);
+	});
+
+	const result: CollapsedSegment[] = [];
+
+	tokens.forEach((token, tokenIndex) => {
+		if (token.type !== "collapsed") {
+			return;
+		}
+
+		const children = childMap.get(token.key) ?? new Set();
+		let endIndex = selectionText.length;
+
+		for (let i = tokenIndex + 1; i < tokens.length; i++) {
+			const nextToken = tokens[i];
+
+			if (nextToken.index <= token.index) {
+				continue;
+			}
+
+			if (nextToken.type === "collapsed") {
+				endIndex = nextToken.index;
+
+				break;
+			}
+
+			if (
+				nextToken.type === "key-value" &&
+				!children.has(nextToken.key)
+			) {
+				endIndex = nextToken.index;
+
+				break;
+			}
+		}
+
+		result.push({
+			key: token.key,
+			startIndex: token.index,
+			endIndex,
+		});
+	});
+
+	return result;
+}
+
+/**
+ * Returns the set of root key-value tokens that are NOT inside any collapsed window.
+ * These should be included at the root level.
+ */
+function getRootKeysOutsideSegments(
+	tokens: Token[],
+	segments: CollapsedSegment[],
+): Set<string> {
+	const result = new Set<string>();
+
+	tokens.forEach((token) => {
+		if (token.type !== "key-value") {
+			return;
+		}
+
+		const inside = segments.some(
+			(segment) =>
+				token.index >= segment.startIndex &&
+				token.index < segment.endIndex,
+		);
+
+		if (!inside) {
+			result.add(token.key);
+		}
+	});
+
+	return result;
+}
+
+/**
+ * Finds the exact collapsed segment corresponding to a collapsed token.
+ * Primarily matches by (key + startIndex), otherwise falls back to the first segment with the same key.
+ */
+function findSegmentFor(
+	token: Token,
+	segments: CollapsedSegment[],
+): CollapsedSegment | null {
+	const result = segments.find(
+		(segment) =>
+			segment.key === token.key && segment.startIndex === token.index,
+	);
+
+	return (
+		result ?? segments.find((segment) => segment.key === token.key) ?? null
+	);
+}
+
+/**
+ * Builds a subset (object + array view) from the given root and selection text.
+ * The array preserves textual order of included values.
+ * For collapsed parents that are objects, the function recurses into the parent's window.
+ */
+function buildSubsetFromSelection(
+	root: Record<string, unknown>,
+	selectionText: string,
+) {
+	const tokens = getRootTokens(root, selectionText);
+	const segments = getCollapsedSegments(root, selectionText, tokens);
+	const rootKeys = getRootKeysOutsideSegments(tokens, segments);
+
+	type Result = {
+		array: unknown[];
+		object: Record<string, unknown>;
+	};
+
+	const result: Result = {
+		array: [],
+		object: {},
+	};
+
+	function addToResult(key: string, value: unknown) {
+		result.array.push(value);
+		result.object[key] = value;
+	}
+
+	tokens.forEach((token) => {
+		if (token.key in result.object) {
+			return;
+		}
+
+		const value = root[token.key];
+
+		switch (token.type) {
+			case "key-value": {
+				if (rootKeys.has(token.key)) {
+					addToResult(token.key, value);
+				}
+
+				break;
+			}
+			case "collapsed": {
+				const segment = findSegmentFor(token, segments);
+				const windowText = segment
+					? selectionText.slice(segment.startIndex, segment.endIndex)
+					: selectionText;
+
+				if (!isPlainObject(value)) {
+					// non-objects (arrays/scalars) are included fully
+					addToResult(token.key, value);
+
+					break;
+				}
+
+				const nested = buildSubsetFromSelection(value, windowText);
+				const hasNested =
+					nested.array.length > 0 ||
+					Object.keys(nested.object).length > 0;
+
+				addToResult(token.key, hasNested ? nested.object : value);
+
+				break;
+			}
+			default: {
+				break;
+			}
+		}
+	});
+
+	const isResultEmpty =
+		result.array.length === 0 || Object.keys(result.object).length === 0;
+
+	if (tokens.length > 0 && isResultEmpty) {
+		// copy-all fallback: tokens exist but nothing assembled
+		Object.entries(root).forEach(([key, val]) => {
+			addToResult(key, val);
+		});
+	}
+
+	return {
+		array: result.array,
+		object: result.object,
+		tokenCount: tokens.length,
+	};
+}
+
+/**
+ * Builds a JSON subset from raw text selection and the current JSON `data`.
+ *
+ * Rules:
+ *  - Root key-value hits: `key: …` (the colon may appear on the next line).
+ *  - Collapsed hits: `key` followed by `Object{N}` or `Array[N]` (same line or next line).
+ *  - For a collapsed parent:
+ *      * If child keys appear within its window, only those children are included (recursively).
+ *      * Otherwise, the whole object/array is included.
+ *  - Root key-values inside a parent's window are treated as that parent's children.
+ *
+ * Return shape:
+ *  - If `data` is an object → a subset object.
+ *  - If `data` is an array  → a subset array preserving textual order.
+ *  - Otherwise              → empty object.
+ */
+export function selectionToJson(
+	data: ArrayOrObject,
+	rawSelectionText: string,
+): ArrayOrObject {
+	const selectionText = rawSelectionText.replace(/\r\n/g, "\n");
+
+	if (isPlainObject(data)) {
+		const { object } = buildSubsetFromSelection(data, selectionText);
+
+		return object;
+	}
+
+	if (Array.isArray(data)) {
+		// array root: project indices to string keys, reuse the same pipeline, map back to array
+		const projected: Record<string, unknown> = {};
+		data.forEach((item, itemIndex) => {
+			projected[String(itemIndex)] = item;
+		});
+
+		const { array, tokenCount } = buildSubsetFromSelection(
+			projected,
+			selectionText,
+		);
+
+		if (array.length > 0) {
+			return array;
+		}
+
+		// copy-all for root array if there were tokens or an explicit Array[N] mention
+		const rootArrayRegex = /(^|\n)\s*Array\[\d+\]/;
+		if (tokenCount > 0 || rootArrayRegex.test(selectionText)) {
+			return data.slice();
+		}
+
+		return [];
+	}
+
+	return {};
+}

--- a/src/ui/src/composables/useFilesEncoder/useFilesEncoder.ts
+++ b/src/ui/src/composables/useFilesEncoder/useFilesEncoder.ts
@@ -1,4 +1,5 @@
 import { MaybeRef, readonly, shallowRef, toValue } from "vue";
+import { isPlainObject } from "@/utils/object";
 import { useAbortController } from "../useAbortController";
 import { encodeFileAsDataURL, AbortError } from "./encodeFileAsDataURL";
 
@@ -30,8 +31,7 @@ export type EncodedFile = {
 
 function isEncodedFile(input: unknown): input is EncodedFile {
 	return (
-		typeof input === "object" &&
-		input !== null &&
+		isPlainObject(input) &&
 		"name" in input &&
 		"type" in input &&
 		"data" in input &&

--- a/src/ui/src/utils/object.ts
+++ b/src/ui/src/utils/object.ts
@@ -1,9 +1,15 @@
+export function isPlainObject(
+	input: unknown,
+): input is Record<string, unknown> {
+	return typeof input === "object" && input !== null && !Array.isArray(input);
+}
+
 export function* extractObjectPaths(
 	obj: unknown,
 	prefix = "",
 	visited = new WeakSet(),
 ): Generator<string> {
-	if (typeof obj !== "object" || obj === null) return;
+	if (!isPlainObject(obj)) return;
 	if (visited.has(obj)) return;
 	visited.add(obj);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - JSON Viewer: copy selected portions or the entire JSON to clipboard; output is pretty-printed and selection-aware.

- Improvements
  - Stricter plain-object detection across the UI and file-encoding checks to reduce edge-case behavior.
  - Selection-to-JSON extraction for precise subset copying.

- Refactor
  - Centralized plain-object check utility for consistent behavior.

- Tests
  - Added comprehensive tests covering selection-based copying scenarios and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->