### PR TITLE
feat(CoreButton): add Lucide icon field and update template to display it - AB-281

### DIFF
--- a/src/ui/src/components/core/other/CoreButton.vue
+++ b/src/ui/src/components/core/other/CoreButton.vue
@@ -6,6 +6,10 @@
 		:disabled="!isBeingEdited && isDisabled"
 		@click="handleClick"
 	>
+		<WdsIcon
+			v-if="fields.lucideIcon.value"
+			:name="fields.lucideIcon.value"
+		/>
 		<span class="CoreButton__text">{{ fields.text.value }}</span>
 	</WdsButton>
 </template>
@@ -51,6 +55,11 @@ export default {
 				init: "Button Text",
 				type: FieldType.Text,
 			},
+			lucideIcon: {
+				name: "Icon",
+				type: FieldType.Text,
+				desc: 'Lucide icon name in kebab-case, e.g. "badge-check".',
+			},
 			isDisabled: createBooleanField({
 				name: "Disabled",
 				default: "no",
@@ -69,6 +78,7 @@ export default {
 <script setup lang="ts">
 import { ComponentPublicInstance, inject, ref } from "vue";
 import injectionKeys from "@/injectionKeys";
+import WdsIcon from "@/wds/WdsIcon.vue";
 
 const rootInstance = ref<ComponentPublicInstance | null>(null);
 const fields = inject(injectionKeys.evaluatedFields);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Buttons now support an optional icon displayed before the label. Provide a Lucide icon name (kebab-case, e.g., "badge-check") to show an icon on the button.
  * Icon rendering is optional and non-intrusive; buttons without an icon remain unchanged.
  * Existing interactions (click behavior, disabled state) are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->