### PR TITLE
fix: feature flag for web search block

### DIFF
--- a/src/writer/blocks/writerwebsearch.py
+++ b/src/writer/blocks/writerwebsearch.py
@@ -17,6 +17,7 @@ class WriterWebSearch(WriterBlock):
                     "name": "Web search",
                     "description": "Search the web for information and return relevant results with source URLs.",
                     "category": "Writer",
+                    "featureFlags": ["web_search_block"],
                     "fields": {
                         "query": {
                             "name": "Query",


### PR DESCRIPTION
Enable a `"web_search_block"` feature flag for the relevant block due to backend issues with web search endpoint on test environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a controllable feature flag to enable the Web Search block for eligible users, allowing targeted rollout without affecting existing experiences by default.
* **Style**
  * Minor formatting cleanup with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->