### PR TITLE
fix(writer): fix default field for Ask KG / subqueries - AB-266

### DIFF
--- a/src/writer/blocks/writeraskkg.py
+++ b/src/writer/blocks/writeraskkg.py
@@ -92,7 +92,7 @@ class WriterAskGraphQuestion(WriterBlock):
                 raise ValueError(
                     "A state element must be provided when using streaming.")
             subqueries = self._get_field(
-                "subqueries", default_field_value="no") == "yes"
+                "subqueries", default_field_value="yes") == "yes"
 
             answer_so_far = ""
 


### PR DESCRIPTION
The field `subqueries` is enabled by default on frontend side, but on backend side it's disabled by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subqueries are now enabled by default in Ask Graph when the option isn’t specified, matching the UI’s “Yes” default. This ensures consistent behavior across the app and provides more comprehensive answers without additional configuration.
  * Users who previously omitted the subqueries setting will see results that include subquery processing by default, reducing confusion and aligning outcomes with on-screen expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->