### PR TITLE
fix(ui): improve restart server toast notification - AB-178

### DIFF
--- a/src/ui/src/builder/useSyncHealth.ts
+++ b/src/ui/src/builder/useSyncHealth.ts
@@ -46,19 +46,13 @@ export function useSyncHealth(wf: Core) {
 			});
 		}
 
-		if (prevSyncHealth === "suspended" && syncHealth === "connected") {
-			if (restartingToast) {
-				toast.updateToast({
-					id: restartingToast,
-					message: "Server restarted successfully",
-					type: "info",
-				});
-			} else {
-				toast.pushToast({
-					message: "Server restarted successfully",
-					type: "info",
-				});
-			}
+		if (syncHealth === "connected" && restartingToast !== undefined) {
+			toast.updateToast({
+				id: restartingToast,
+				message: "Server restarted successfully",
+				type: "info",
+			});
+			restartingToast = undefined;
 		}
 	});
 

--- a/src/ui/src/wds/WdsToast.vue
+++ b/src/ui/src/wds/WdsToast.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="WdsToast" :class="`WdsToast--${type}`">
 		<div class="WdsToast__icon">
-			<WdsLoaderDots v-if="type === 'loading'" :size="18" />
+			<WdsLoaderDots v-if="type === 'loading'" :size="18" color="white" />
 			<template v-else-if="type === 'info'">i</template>
 			<WdsIcon v-else :name="icon" />
 		</div>
@@ -85,8 +85,6 @@ const icon = computed(() => {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-
-	background-color: var(--wdsColorBlue2);
 }
 
 .WdsToast__action {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevent duplicate or unexpected success toasts on reconnect: the app now updates an existing restart toast when the connection restores and clears the toast reference afterward; no new toast is emitted if none exists.

- Style
  - Loading indicator now uses white dots for improved contrast.
  - Toast icon background removed for a cleaner, sleeker appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->