### PR TITLE
feat(ui): display disconnection toast instead of modal - WF-178

### DIFF
--- a/src/ui/src/builder/BuilderHeader.vue
+++ b/src/ui/src/builder/BuilderHeader.vue
@@ -101,12 +101,6 @@
 			>
 			</WdsModal>
 		</div>
-		<WdsModal
-			v-if="alertModal"
-			:title="alertModal.title"
-			:description="alertModal.description"
-			size="normal"
-		/>
 	</div>
 </template>
 
@@ -135,7 +129,7 @@ const isInviteCollaboratorsShown = ref(false);
 const tracking = useWriterTracking(wf);
 const toasts = useToasts();
 const clipboard = useClipboard();
-const { alertModal, stateDotState, syncHealthStatus } = useSyncHealth(wf);
+const { stateDotState, syncHealthStatus } = useSyncHealth(wf);
 
 const {
 	canDeploy,

--- a/src/ui/src/builder/BuilderToasts.vue
+++ b/src/ui/src/builder/BuilderToasts.vue
@@ -9,7 +9,9 @@
 				:message="toast.message"
 				:type="toast.type"
 				:action="toast.action"
-				@click="removeToast(toast.id)"
+				@click="
+					toast.closable !== false ? removeToast(toast.id) : undefined
+				"
 			/>
 		</TransitionGroup>
 	</div>

--- a/src/ui/src/builder/useSyncHealth.ts
+++ b/src/ui/src/builder/useSyncHealth.ts
@@ -1,58 +1,53 @@
 import type { WdsStateDotState } from "@/wds/WdsStateDot.vue";
 import type { Core } from "@/writerTypes";
-import { computed, shallowRef, watch } from "vue";
-import { useToasts } from "./useToast";
-
-type AlertModal = { title: string; description: string };
+import { computed, watch } from "vue";
+import { Toast, useToasts } from "./useToast";
 
 export function useSyncHealth(wf: Core) {
-	const alertModal = shallowRef<AlertModal | undefined>();
-	const toast = useToasts();
+	const toastManager = useToasts();
 
-	let restartingToast: number | undefined = undefined;
+	let activeToastId: Toast["id"] | undefined = undefined;
 
-	let syncHealthTimer: ReturnType<typeof setTimeout>;
-
-	function displayAlertModal(ms: number) {
-		if (syncHealthTimer) clearTimeout(syncHealthTimer);
-
-		syncHealthTimer = setTimeout(() => {
-			alertModal.value = {
-				title: "We’re trying to reconnect...",
-				description:
-					"Connection was lost due to a network issue or an ongoing update. Please hang tight!",
-			};
-		}, ms);
+	function displayToast(toast: Omit<Toast, "id">) {
+		if (activeToastId) {
+			toastManager.pushToast({ id: activeToastId, ...toast });
+		} else {
+			activeToastId = toastManager.pushToast(toast);
+		}
 	}
 
-	function closeAlertModal() {
-		if (alertModal.value) alertModal.value = undefined;
-		if (syncHealthTimer) clearTimeout(syncHealthTimer);
-	}
-
-	watch(wf.syncHealth, (syncHealth, prevSyncHealth) => {
-		if (syncHealth === "offline") {
-			return displayAlertModal(1_000);
-		}
-		closeAlertModal();
-
-		if (prevSyncHealth === "connected" && syncHealth === "suspended") {
-			displayAlertModal(10_000);
-			restartingToast = toast.pushToast({
-				message: "Restarting the server...",
-				type: "loading",
-				closable: false,
-				delayMs: Infinity,
-			});
-		}
-
-		if (syncHealth === "connected" && restartingToast !== undefined) {
-			toast.updateToast({
-				id: restartingToast,
-				message: "Server restarted successfully",
-				type: "info",
-			});
-			restartingToast = undefined;
+	watch(wf.syncHealth, (syncHealth, previousSyncHealth) => {
+		switch (syncHealth) {
+			case "idle":
+				return displayToast({
+					type: "loading",
+					message: "Connecting to the server",
+					closable: false,
+					delayMs: Infinity,
+				});
+			case "connected":
+				return displayToast({
+					message:
+						previousSyncHealth === "suspended"
+							? "The server has restarded"
+							: "The connection to the server has been restored.",
+					type: "success",
+				});
+			case "offline":
+				return displayToast({
+					type: "loading",
+					message:
+						"Connection was lost due to a network issue or an ongoing update. Please hang tight!",
+					closable: false,
+					delayMs: Infinity,
+				});
+			case "suspended":
+				return displayToast({
+					message: "Restarting the server...",
+					type: "loading",
+					closable: false,
+					delayMs: Infinity,
+				});
 		}
 	});
 
@@ -91,5 +86,5 @@ export function useSyncHealth(wf: Core) {
 		}
 	});
 
-	return { alertModal, syncHealthStatus, stateDotState };
+	return { syncHealthStatus, stateDotState };
 }

--- a/src/ui/src/builder/useSyncHealth.ts
+++ b/src/ui/src/builder/useSyncHealth.ts
@@ -29,7 +29,7 @@ export function useSyncHealth(wf: Core) {
 				return displayToast({
 					message:
 						previousSyncHealth === "suspended"
-							? "The server has restarded"
+							? "The server has restarted"
 							: "The connection to the server has been restored.",
 					type: "success",
 				});

--- a/src/ui/src/builder/useToast.ts
+++ b/src/ui/src/builder/useToast.ts
@@ -14,34 +14,54 @@ export type Toast = {
 const toasts = shallowRef<Toast[]>([]);
 
 export function useToasts() {
+	const scheduleClosingTimers: Record<
+		Toast["id"],
+		ReturnType<typeof setTimeout>
+	> = {};
+
 	function removeToast(id: number) {
-		toasts.value = toasts.value.filter((t) => t.id !== id);
+		const toastIndex = toasts.value.findIndex((t) => t.id === id);
+		if (toastIndex === -1) return;
+		toasts.value = toasts.value.filter((_, i) => toastIndex !== i);
 	}
 
-	function pscheduleClosing(toast: Toast) {
+	function scheduleClosing(toast: Toast) {
+		if (scheduleClosingTimers[toast.id]) {
+			clearTimeout(scheduleClosingTimers[toast.id]);
+			delete scheduleClosingTimers[toast.id];
+		}
+
 		if (!toast.closable && toast.delayMs !== Infinity) {
-			setTimeout(() => removeToast(toast.id), toast.delayMs ?? 3_000);
+			scheduleClosingTimers[toast.id] = setTimeout(
+				() => removeToast(toast.id),
+				toast.delayMs ?? 3_000,
+			);
 		}
 	}
 
-	function pushToast(toastData: Omit<Toast, "id">) {
-		const id = new Date().getTime();
+	function pushToast(toastData: Omit<Toast, "id"> | Toast) {
+		if (
+			"id" in toastData &&
+			toasts.value.some((t) => t.id === toastData.id)
+		) {
+			toasts.value = toasts.value.map((t) =>
+				t.id === toastData.id ? toastData : t,
+			);
+			scheduleClosing(toastData);
+			return toastData.id;
+		}
+
+		const id = "id" in toastData ? toastData.id : new Date().getTime();
 		const toast: Toast = { ...toastData, id };
 		toasts.value = [...toasts.value, toast];
-		pscheduleClosing(toast);
+		scheduleClosing(toast);
 
 		return id;
-	}
-
-	function updateToast(toast: Toast) {
-		toasts.value = toasts.value.map((t) => (t.id === toast.id ? toast : t));
-		pscheduleClosing(toast);
 	}
 
 	return {
 		pushToast,
 		removeToast,
-		updateToast,
 		toasts: readonly(toasts),
 	};
 }

--- a/src/ui/src/components/shared/SharedDropZone.vue
+++ b/src/ui/src/components/shared/SharedDropZone.vue
@@ -40,17 +40,6 @@
 				</template>
 			</span>
 		</div>
-		<p class="SharedDropZone__restrictions">
-			<template v-if="restrictions">{{ restrictions }}</template>
-			<template v-else>
-				<span>
-					{{ formattedAcceptedFileTypes }}
-				</span>
-				<span v-if="formattedTotalSizeLimit">
-					Total files size limit is {{ formattedTotalSizeLimit }}.
-				</span>
-			</template>
-		</p>
 	</label>
 </template>
 
@@ -89,10 +78,9 @@ const emit = defineEmits({
 
 const inputId = useId();
 
-const { acceptAttr, checkIsFileAccepted, normalizedAcceptedFileTypes } =
-	useFileTypeAccept({
-		acceptedFileTypes: toRef(props, "acceptedFileTypes"),
-	});
+const { acceptAttr, checkIsFileAccepted } = useFileTypeAccept({
+	acceptedFileTypes: toRef(props, "acceptedFileTypes"),
+});
 
 function emitAcceptedFiles(files: File[]) {
 	const acceptedFiles = files.filter((file) => checkIsFileAccepted(file));
@@ -104,22 +92,6 @@ function emitAcceptedFiles(files: File[]) {
 		);
 	}
 }
-
-const formattedAcceptedFileTypes = computed<string>(() => {
-	if (normalizedAcceptedFileTypes.value.length > 0) {
-		return `${normalizedAcceptedFileTypes.value.join(", ")} accepted.`;
-	}
-
-	return "All file types accepted.";
-});
-
-const formattedTotalSizeLimit = computed<string>(() => {
-	if (typeof props.totalSizeLimit === "number" && props.totalSizeLimit > 0) {
-		return prettyBytes(props.totalSizeLimit);
-	}
-
-	return "";
-});
 
 const dropZoneElement = useTemplateRef("dropZoneElement");
 const { isOverDropZone } = useDropZone(dropZoneElement, {
@@ -160,14 +132,6 @@ function onSelectFiles(event: Event): void {
 	border-color: var(--wdsColorBlue3);
 	border-radius: 12px;
 	width: 100%;
-}
-
-.SharedDropZone__restrictions {
-	font-size: 12px;
-	font-weight: 500;
-	line-height: 180%;
-	text-align: center;
-	color: var(--wdsColorGray4);
 }
 
 .SharedDropZone__labelWrapper {

--- a/src/ui/src/composables/useFileTypeAccept.ts
+++ b/src/ui/src/composables/useFileTypeAccept.ts
@@ -46,7 +46,6 @@ export function useFileTypeAccept({
 	}
 
 	return {
-		normalizedAcceptedFileTypes,
 		acceptAttr,
 		checkIsFileAccepted,
 	};


### PR DESCRIPTION

https://github.com/user-attachments/assets/6fae0617-7e45-488b-a01c-2fbc8608d756



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Connection status is now shown with persistent toasts (connecting, offline, restarting, reconnected) for clearer, non-blocking feedback.
- Bug Fixes
  - Non-closable toasts can no longer be dismissed by clicking.
- Refactor
  - Streamlined toast behavior to prevent stacking and ensure a single, updatable status toast.
- Style
  - Removed file-type restriction text from the file drop zone for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->