### PR TITLE
docs: update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Whether you're interested in contributing to the repository, creating a fork, or
 - Writer Framework uses [Poetry](https://python-poetry.org/) for dependency management. Please see the [Poetry installation docs](https://python-poetry.org/docs/#installation) if you don't already have it installed.
 - You can install the package in editable mode using `poetry install  --with build`
 - Enable the virtual environment:
-	- Bash/Zsh/Csh: `eval $(poetry env activate)`
+  - Bash/Zsh/Csh: `eval "$(poetry env activate)"`
   - Fish: `eval (poetry env activate)`
   - PowerShell: `Invoke-Expression (poetry env activate)`
  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,6 @@ Pull requests should be done on the `dev` branch. When the release is finalised,
 Whether you're interested in contributing to the repository, creating a fork, or just improving your understanding of Writer Framework, these are the suggested steps for setting up a development environment.
 
 - You can install the package in editable mode using `poetry install  --with build`
-- Enable the virtual environment with `poetry shell`
+- Enable the virtual environment with `eval $(poetry env activate)`
 - Install all the dev dependencies with `alfred install.dev`
 - Run Writer Framework on port 5000. For example, `writer edit apps/hello --port 5000`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,13 @@ Pull requests should be done on the `dev` branch. When the release is finalised,
 
 Whether you're interested in contributing to the repository, creating a fork, or just improving your understanding of Writer Framework, these are the suggested steps for setting up a development environment.
 
+- Writer Framework uses [Poetry](https://python-poetry.org/) for dependency management. Please see the [Poetry installation docs](https://python-poetry.org/docs/#installation) if you don't already have it installed.
 - You can install the package in editable mode using `poetry install  --with build`
-- Enable the virtual environment with `eval $(poetry env activate)`
+- Enable the virtual environment:
+	- Bash/Zsh/Csh: `eval $(poetry env activate)`
+  - Fish: `eval (poetry env activate)`
+  - PowerShell: `Invoke-Expression (poetry env activate)`
+ 
+  (see [Poetry docs](https://python-poetry.org/docs/managing-environments/) for more info)
 - Install all the dev dependencies with `alfred install.dev`
 - Run Writer Framework on port 5000. For example, `writer edit apps/hello --port 5000`.


### PR DESCRIPTION
As of Poetry 2.0, the `poetry shell` command has been removed due to multiple issues with subshell compatibility and usability. The maintainers now recommend using `poetry env activate` instead.

Poetry docs [recommend using](https://python-poetry.org/docs/managing-environments/#bash-csh-zsh) `eval $(poetry env activate)` for Bash/Zsh/Csh as a drop-in replacement for former `poetry shell` command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor setup: replaced the single virtual‑env activation step with clear, shell-specific activation instructions for common shells.
  * Added an introductory note that the project uses Poetry for dependency management and links to Poetry resources.
  * No runtime or functional application changes; impact limited to developer onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->