### PR TITLE
feat(ui): persist changes in frontend after reconnection

### DIFF
--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -82,6 +82,8 @@ export function generateCore() {
 	let mailInbox: MailItem[] = [];
 	let mailSubscriptions: { mailType: string; fn: Function }[] = [];
 	const collaborationPingSubscriptions: { fn: Function }[] = [];
+	
+	let pendingComponentUpdate = false;
 
 	const activePageId = ref<Component["id"] | undefined>();
 
@@ -252,6 +254,14 @@ export function generateCore() {
 			syncHealth.value = "connected";
 			logger.log("WebSocket connected. Initialising stream...");
 			sendFrontendMessage("streamInit", { sessionId });
+			
+			if (pendingComponentUpdate) {
+				pendingComponentUpdate = false;
+				sendComponentUpdate().catch((error) => {
+					logger.error("Failed to retry component update after reconnect:", error);
+					pendingComponentUpdate = true;
+				});
+			}
 		};
 
 		function processMessage(message) {
@@ -779,7 +789,10 @@ export function generateCore() {
 				ok: boolean;
 				payload?: Record<string, any>;
 			}) => {
-				if (!r.ok) return reject("Couldn't connect to the server.");
+				if (!r.ok) {
+					pendingComponentUpdate = true;
+					return reject("Couldn't connect to the server.");
+				}
 				resolve();
 			};
 			sendFrontendMessage("componentUpdate", payload, messageCallback);

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -744,7 +744,7 @@ export function generateCore() {
 				trackingId,
 				payload: awaitedPayload,
 			};
-			if (webSocket.readyState !== webSocket.OPEN) {
+			if (webSocket.readyState !== WebSocket.OPEN) {
 				throw "Connection lost.";
 			}
 			webSocket.send(JSON.stringify(wsData, bigIntReplacer));


### PR DESCRIPTION
Refs: AB-311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Component updates now reliably resume after temporary connection loss: pending updates are automatically retried when connectivity returns, reducing transient errors and dropped changes. Real-time sync is more stable during reconnects with fewer retry prompts or manual refreshes; no changes to public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->