### PR TITLE
fix: limit strings in logs

### DIFF
--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -1,4 +1,5 @@
 import hashlib
+import itertools
 import json
 import logging
 import os
@@ -16,6 +17,8 @@ import writer.core_ui
 from writer.ss_types import BlueprintExecutionError, BlueprintExecutionLog, WriterConfigurationError
 
 MAX_DAG_DEPTH = 32
+MAX_LOG_ITERABLE_SIZE = 100
+MAX_LOG_STRING_LENGTH = 5000
 
 _current_block: ContextVar[Optional[writer.blocks.base_block.BlueprintBlock]] = \
     ContextVar("current_block", default=None)
@@ -691,16 +694,16 @@ class StatusLogger:
         if data is None:
             return None
 
-        MAX_ROWS = 100
         if isinstance(data, list):
-            return [self._summarize_data_for_log(item) for item in data[:MAX_ROWS]]
+            return [self._summarize_data_for_log(item) for item in data[:MAX_LOG_ITERABLE_SIZE]]
         if isinstance(data, dict):
             return {
                 k: self._summarize_data_for_log(v)
-                for i, (k, v) in enumerate(data.items())
-                if i < MAX_ROWS
+                for k, v in itertools.islice(data.items(), MAX_LOG_ITERABLE_SIZE)
             }
-        if isinstance(data, (str, int, float, bool, type(None))):
+        if isinstance(data, str):
+            return f"{data[:MAX_LOG_STRING_LENGTH]}... <truncated>"
+        if isinstance(data, (int, float, bool, type(None))):
             return data
 
         try:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized logging truncation: large iterables (lists/dicts) trimmed to 100 items and long strings to 5,000 characters.
  * Introduced two configurable logging limits to improve consistency and prevent oversized entries.
  * Numeric, boolean, and null values preserved; complex objects are serialized to JSON or replaced with a fallback message on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->