### PR TITLE
fix: remove requirements observer

### DIFF
--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -776,10 +776,11 @@ class AppRunner:
             path=self.app_path,
             recursive=True,
         )
-        self.observer.schedule(
-            FileEventHandler(self._install_requirements, patterns=["requirements.txt"]),
-            path=self.app_path,
-        )
+        # See _install_requirements docstring for info
+        # self.observer.schedule(
+        #     FileEventHandler(self._install_requirements, patterns=["requirements.txt"]),
+        #     path=self.app_path,
+        # )
         if not self.observer.is_alive():
             self.observer.start()
 
@@ -789,6 +790,11 @@ class AppRunner:
         )
 
     def _install_requirements(self) -> None:
+        """
+        Not used anywhere anymore as this method of installing dependencies is not supported.
+        Left because might change in the future.
+        """
+
         logger = logging.getLogger("writer")
         logger.debug("\nDetected changes in requirements.txt. Installing dependencies...")
         try:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Adjusted file-change monitoring to stop tracking dependency file updates. Users will no longer experience background installs triggered by edits to the dependency list; manage dependencies using your usual workflow. Monitoring of source file changes remains unaffected.
- Documentation
  - Clarified that the previous in-app dependency installation path is no longer used, reflecting the current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->