### PR TITLE
fix: set version env var

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
               run: poetry install --with build
 
             - name: install ci dependencies and generate code
-              run: poetry run alfred install.ci
+              run: WRITER_FRAMEWORK_VERSION=${{ steps.extract_version.outputs.version }} poetry run alfred install.ci
 
             - name: publish on pypi
               run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publish pipeline to pass the framework version from the release tag into the install step, aligning build artifacts with the tagged version.
  * Improves consistency and traceability of release builds across environments.

* **Notes**
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->