### PR TITLE
feat: allow manual publishing trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,11 @@ on:
         tags:
             - 'agent-builder-turbo-[0-9]+.[0-9]+.[0-9]+-image-[0-9]+.[0-9]+.[0-9]+-main'
             - 'agent-builder-turbo-[0-9]+.[0-9]+.[0-9]+rc[0-9]+-image-[0-9]+.[0-9]+.[0-9]+-main'
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: 'Tag to publish'
+                required: true
 
 jobs:
     build:
@@ -13,11 +18,13 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+              with:
+                ref: ${{ github.event.inputs.tag || github.ref_name }}
 
             - name: Extract version from tag
               id: extract_version
               run: |
-                REF="${{ github.ref_name }}"
+                REF="${{ github.event.inputs.tag || github.ref_name }}"
                 if [[ "$REF" =~ ^agent-builder-turbo-([0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?)-image-([0-9]+\.[0-9]+\.[0-9]+)-main$ ]]; then
                   echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
                 else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ on:
             tag:
                 description: 'Tag to publish'
                 required: true
+            version:
+                description: 'Version to set before publishing (optional, overrides extracted version)'
+                required: false
 
 jobs:
     build:
@@ -24,12 +27,16 @@ jobs:
             - name: Extract version from tag
               id: extract_version
               run: |
-                REF="${{ github.event.inputs.tag || github.ref_name }}"
-                if [[ "$REF" =~ ^agent-builder-turbo-([0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?)-image-([0-9]+\.[0-9]+\.[0-9]+)-main$ ]]; then
-                  echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+                if [[ -n "${{ github.event.inputs.version }}" ]]; then
+                    echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
                 else
-                  echo "Unable to parse version from tag: $REF" >&2
-                  exit 1
+                    REF="${{ github.event.inputs.tag || github.ref_name }}"
+                    if [[ "$REF" =~ ^agent-builder-turbo-([0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?)-image-([0-9]+\.[0-9]+\.[0-9]+)-main$ ]]; then
+                        echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+                    else
+                        echo "Unable to parse version from tag: $REF" >&2
+                        exit 1
+                    fi
                 fi
 
             - name: Show extracted version


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled manual publishing via workflow dispatch with inputs for tag (required) and version (optional).
  * Improved version determination: uses provided version when set, otherwise derives from the tag and fails on invalid formats.
  * Ensured publishing checks out the specified tag or falls back to the current branch for consistency.
  * Aligned subsequent publish steps to rely on the updated extracted version without altering their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->