### PR TITLE
feat: Ability to specify a default value for dropdowns

### DIFF
--- a/src/ui/src/components/core/input/CoreSelectInput.vue
+++ b/src/ui/src/components/core/input/CoreSelectInput.vue
@@ -145,7 +145,9 @@ const instancePath = inject(injectionKeys.instancePath);
 
 const defaultValue = computed(() => {
 	const value = fields.defaultValue.value?.trim();
-	if (!value) return [];
+	if (!value) {
+		return fields.allowMultiSelect.value ? [] : "";
+	}
 
 	if (fields.allowMultiSelect.value) {
 		return value
@@ -178,7 +180,7 @@ const options = computed(() =>
 	})),
 );
 
-const model = computed<string[]>({
+const model = computed<string | string[]>({
 	get() {
 		return formValue.value;
 	},

--- a/src/ui/src/components/core/input/CoreSelectInput.vue
+++ b/src/ui/src/components/core/input/CoreSelectInput.vue
@@ -68,6 +68,11 @@ export default {
 				default: JSON.stringify(defaultOptions, null, 2),
 				validator: validatorObjectRecordNotNested,
 			},
+			defaultValue: {
+				name: "Default value",
+				desc: "Default selected option(s). For single-select, provide a single value key. For multi-select, provide comma-separated value keys (e.g., 'a, b, c').",
+				type: FieldType.Text,
+			},
 			placeholder: {
 				name: "Placeholder",
 				desc: "Text to show when no options are selected.",
@@ -128,6 +133,7 @@ export default {
 </script>
 
 <script setup lang="ts">
+import { watch } from "vue";
 import injectionKeys from "@/injectionKeys";
 import { useFormValueBroker } from "@/renderer/useFormValueBroker";
 import WdsSelect, { Option } from "@/wds/WdsSelect.vue";
@@ -137,11 +143,33 @@ const rootInstance = ref<ComponentPublicInstance | null>(null);
 const wf = inject(injectionKeys.core);
 const instancePath = inject(injectionKeys.instancePath);
 
+const defaultValue = computed(() => {
+	const value = fields.defaultValue.value?.trim();
+	if (!value) return [];
+
+	if (fields.allowMultiSelect.value) {
+		return value
+			.split(",")
+			.map((item) => item.trim())
+			.filter((item) => Object.keys(fields.options.value).includes(item));
+	} else {
+		if (!Object.keys(fields.options.value).includes(value)) {
+			return "";
+		}
+		return value;
+	}
+});
+
 const { formValue, handleInput } = useFormValueBroker(
 	wf,
 	instancePath,
 	rootInstance,
+	defaultValue.value,
 );
+
+watch(fields.allowMultiSelect, () => {
+	formValue.value = defaultValue.value;
+});
 
 const options = computed(() =>
 	Object.entries(fields.options.value).map<Option>(([key, value]) => ({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select inputs now accept configurable default values: a single key for single-select or comma-separated keys for multi-select (e.g., "a, b, c").
  * Defaults initialize the form state and update when switching between single and multi-select modes.
  * Selection changes emit the appropriate events for single vs. multi-select so external listeners receive correct payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->