### PR TITLE
feat: Add tab change event to tab container + binding for active tab

### DIFF
--- a/src/ui/src/components/core/layout/CoreTab.vue
+++ b/src/ui/src/components/core/layout/CoreTab.vue
@@ -75,11 +75,10 @@ export default {
 };
 </script>
 <script setup lang="ts">
-import { computed, inject, onBeforeMount, useTemplateRef, watch } from "vue";
+import { computed, inject, onBeforeMount, watch } from "vue";
 import injectionKeys from "@/injectionKeys";
 import BaseContainer from "../base/BaseContainer.vue";
 
-const rootEl = useTemplateRef("rootEl");
 const fields = inject(injectionKeys.evaluatedFields);
 const instancePath = inject(injectionKeys.instancePath);
 const instanceData = inject(injectionKeys.instanceData);
@@ -147,10 +146,8 @@ const getMatchingTabInstancePath = () => {
 
 const activateTab = () => {
 	const tabContainerData = getTabContainerData();
-	tabContainerData.value = {
-		activeTab: getMatchingTabInstancePath(),
-		activeTabName: fields.name.value,
-	};
+	tabContainerData.value.activeTab = getMatchingTabInstancePath();
+	tabContainerData.value.activeTabName = fields.name.value;
 };
 
 const checkIfTabIsParent = (childId: Component["id"]): boolean => {

--- a/src/ui/src/components/core/layout/CoreTab.vue
+++ b/src/ui/src/components/core/layout/CoreTab.vue
@@ -149,18 +149,8 @@ const activateTab = () => {
 	const tabContainerData = getTabContainerData();
 	tabContainerData.value = {
 		activeTab: getMatchingTabInstancePath(),
+		activeTabName: fields.name.value,
 	};
-
-	if (rootEl.value) {
-		const payload = fields.name.value;
-		const event = new CustomEvent("wf-tab-change", {
-			detail: {
-				payload,
-			},
-			bubbles: true,
-		});
-		rootEl.value.dispatchEvent(event);
-	}
 };
 
 const checkIfTabIsParent = (childId: Component["id"]): boolean => {
@@ -192,12 +182,13 @@ const isTabActive = computed(() => {
 });
 
 onBeforeMount(() => {
-	if (isTabBit.value) return;
+	if (!isTabBit.value) return;
 	const tabContainerData = getTabContainerData();
-	const activeTab = tabContainerData.value?.activeTab;
-	if (activeTab) return;
-	if (!isComponentVisible(componentId, instancePath)) return;
-	tabContainerData.value = { activeTab: instancePath };
+	tabContainerData.value.tabs.push({
+		name: fields.name.value,
+		instancePath: getMatchingTabInstancePath(),
+		componentId: componentId,
+	});
 });
 </script>
 

--- a/src/ui/src/components/core/layout/CoreTab.vue
+++ b/src/ui/src/components/core/layout/CoreTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="isVisible" class="CoreTab">
+	<div v-show="isVisible" ref="rootEl" class="CoreTab">
 		<button
 			v-if="isTabBit"
 			class="bit"
@@ -75,10 +75,11 @@ export default {
 };
 </script>
 <script setup lang="ts">
-import { computed, inject, onBeforeMount, watch } from "vue";
+import { computed, inject, onBeforeMount, useTemplateRef, watch } from "vue";
 import injectionKeys from "@/injectionKeys";
 import BaseContainer from "../base/BaseContainer.vue";
 
+const rootEl = useTemplateRef("rootEl");
 const fields = inject(injectionKeys.evaluatedFields);
 const instancePath = inject(injectionKeys.instancePath);
 const instanceData = inject(injectionKeys.instanceData);
@@ -149,6 +150,17 @@ const activateTab = () => {
 	tabContainerData.value = {
 		activeTab: getMatchingTabInstancePath(),
 	};
+
+	if (rootEl.value) {
+		const payload = fields.name.value;
+		const event = new CustomEvent("wf-tab-change", {
+			detail: {
+				payload,
+			},
+			bubbles: true,
+		});
+		rootEl.value.dispatchEvent(event);
+	}
 };
 
 const checkIfTabIsParent = (childId: Component["id"]): boolean => {

--- a/src/ui/src/components/core/layout/CoreTabs.vue
+++ b/src/ui/src/components/core/layout/CoreTabs.vue
@@ -123,14 +123,12 @@ onMounted(() => {
 	const visibleTabs = containerState.value.tabs.filter((t) =>
 		isComponentVisible(t.componentId, t.instancePath),
 	);
-	if (!visibleTabs) return;
+	if (visibleTabs.length === 0) return;
 
 	const initialActiveTabName = containerState.value.activeTabName;
-	let tabToActivate = initialActiveTabName
-		? visibleTabs.find((t) => t.name === initialActiveTabName)
-		: visibleTabs[0];
-
-	if (!tabToActivate) return;
+	const tabToActivate =
+		visibleTabs.find((t) => t.name === initialActiveTabName) ??
+		visibleTabs[0];
 
 	containerState.value.activeTab = tabToActivate.instancePath;
 	containerState.value.activeTabName = tabToActivate.name;

--- a/src/ui/src/components/core/layout/CoreTabs.vue
+++ b/src/ui/src/components/core/layout/CoreTabs.vue
@@ -108,12 +108,17 @@ watch(formValue, (newTabName) => {
 	);
 	if (!visibleTabs.length) return;
 
-	const tabToActivate = visibleTabs.find((t) => t.name === newTabName);
+	let tabToActivate = visibleTabs.find((t) => t.name === newTabName);
 
-	if (tabToActivate) {
-		containerState.value.activeTab = tabToActivate.instancePath;
-		containerState.value.activeTabName = tabToActivate.name;
+	if (!tabToActivate) {
+		const currentActiveInState = visibleTabs.find(
+			(t) => t.name === containerState.value.activeTabName,
+		);
+		tabToActivate = currentActiveInState ?? visibleTabs[0];
 	}
+
+	containerState.value.activeTab = tabToActivate.instancePath;
+	containerState.value.activeTabName = tabToActivate.name;
 });
 
 onMounted(() => {

--- a/src/ui/src/components/core/layout/CoreTabs.vue
+++ b/src/ui/src/components/core/layout/CoreTabs.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="CoreTabs">
+	<div ref="rootInstance" class="CoreTabs">
 		<nav
 			class="tabSelector horizontal"
 			data-writer-cage
@@ -26,6 +26,7 @@ import {
 	buttonShadow,
 	cssClasses,
 } from "@/renderer/sharedStyleFields";
+import { useFormValueBroker } from "@/renderer/useFormValueBroker";
 
 const tabChangeHandlerStub = `
 def tab_change_handler(state, payload):
@@ -48,6 +49,7 @@ export default {
 				desc: "Sent when the active tab changes.",
 				stub: tabChangeHandlerStub.trim(),
 				eventPayloadExample: "Tab Name",
+				bindable: true,
 			},
 		},
 		fields: {
@@ -66,11 +68,52 @@ export default {
 };
 </script>
 <script setup lang="ts">
-import { inject } from "vue";
+import { ComponentPublicInstance, inject, onMounted, ref, watch } from "vue";
+import { useEvaluator } from "@/renderer/useEvaluator";
 import injectionKeys from "@/injectionKeys";
-
+const rootInstance = ref<ComponentPublicInstance | null>(null);
+const wf = inject(injectionKeys.core);
+const instancePath = inject(injectionKeys.instancePath);
 const instanceData = inject(injectionKeys.instanceData);
-instanceData.at(-1).value = { activeTab: undefined };
+const containerState = instanceData.at(-1);
+const { isComponentVisible } = useEvaluator(wf);
+
+const { formValue, handleInput } = useFormValueBroker(
+	wf,
+	instancePath,
+	rootInstance,
+);
+
+containerState.value = {
+	activeTab: undefined,
+	activeTabName: formValue.value,
+	tabs: [],
+};
+
+watch(containerState, (newVal) => {
+	if (!rootInstance.value) return;
+	handleInput(newVal.activeTabName, "wf-tab-change");
+});
+
+onMounted(() => {
+	if (containerState.value.activeTab) return;
+	if (!containerState.value.tabs) return;
+
+	const visibleTabs = containerState.value.tabs.filter((t) =>
+		isComponentVisible(t.componentId, t.instancePath),
+	);
+	if (!visibleTabs) return;
+
+	const initialActiveTabName = containerState.value.activeTabName;
+	let tabToActivate = initialActiveTabName
+		? visibleTabs.find((t) => t.name === initialActiveTabName)
+		: visibleTabs[0];
+
+	if (!tabToActivate) return;
+
+	containerState.value.activeTab = tabToActivate.instancePath;
+	containerState.value.activeTabName = tabToActivate.name;
+});
 </script>
 
 <style scoped>

--- a/src/ui/src/components/core/layout/CoreTabs.vue
+++ b/src/ui/src/components/core/layout/CoreTabs.vue
@@ -48,7 +48,6 @@ export default {
 				desc: "Sent when the active tab changes.",
 				stub: tabChangeHandlerStub.trim(),
 				eventPayloadExample: "Tab Name",
-				bindable: true,
 			},
 		},
 		fields: {

--- a/src/ui/src/components/core/layout/CoreTabs.vue
+++ b/src/ui/src/components/core/layout/CoreTabs.vue
@@ -27,6 +27,13 @@ import {
 	cssClasses,
 } from "@/renderer/sharedStyleFields";
 
+const tabChangeHandlerStub = `
+def tab_change_handler(state, payload):
+
+	# The payload contains the name of the newly activated tab
+
+	state["active_tab"] = payload`;
+
 const description =
 	"A container component for organising and displaying Tab components in a tabbed interface.";
 
@@ -36,6 +43,14 @@ export default {
 		description,
 		category: "Layout",
 		allowedChildrenTypes: ["tab", "repeater"],
+		events: {
+			"wf-tab-change": {
+				desc: "Sent when the active tab changes.",
+				stub: tabChangeHandlerStub.trim(),
+				eventPayloadExample: "Tab Name",
+				bindable: true,
+			},
+		},
 		fields: {
 			accentColor,
 			primaryTextColor,

--- a/src/ui/src/components/core/layout/CoreTabs.vue
+++ b/src/ui/src/components/core/layout/CoreTabs.vue
@@ -90,9 +90,30 @@ containerState.value = {
 	tabs: [],
 };
 
-watch(containerState, (newVal) => {
-	if (!rootInstance.value) return;
-	handleInput(newVal.activeTabName, "wf-tab-change");
+watch(
+	() => containerState.value?.activeTabName,
+	(activeTabName) => {
+		if (!rootInstance.value) return;
+		if (activeTabName === formValue.value) return;
+		handleInput(activeTabName, "wf-tab-change");
+	},
+);
+
+watch(formValue, (newTabName) => {
+	if (newTabName === containerState.value.activeTabName) return;
+	if (!containerState.value.tabs?.length) return;
+
+	const visibleTabs = containerState.value.tabs.filter((t) =>
+		isComponentVisible(t.componentId, t.instancePath),
+	);
+	if (!visibleTabs.length) return;
+
+	const tabToActivate = visibleTabs.find((t) => t.name === newTabName);
+
+	if (tabToActivate) {
+		containerState.value.activeTab = tabToActivate.instancePath;
+		containerState.value.activeTabName = tabToActivate.name;
+	}
 });
 
 onMounted(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New wf-tab-change event emitted when the active tab changes for reactive integrations.
  * Tabs now initialize to a sensible visible/default tab on mount and stay synchronized with form-driven state.
  * Root container references added to improve DOM interactions and lifecycle handling.

* **Bug Fixes**
  * More reliable tab registration, activation and visibility handling for correct switching behavior.

* **Documentation**
  * Added event documentation and example handler clarifying payload and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->