### PR TITLE
fix: implement unsaved changes modal and cleanup code

### DIFF
--- a/src/ui/src/builder/composables/useKeyboardShortcuts.ts
+++ b/src/ui/src/builder/composables/useKeyboardShortcuts.ts
@@ -1,35 +1,45 @@
-import { onMounted, onUnmounted } from "vue";
+import { onMounted } from "vue";
+import { useAbortController } from "../../composables/useAbortController";
 
 interface KeyboardShortcut {
 	key: string;
-	modifier?: 'ctrl' | 'cmd' | 'alt' | 'shift';
+	modifier?: "ctrl" | "cmd" | "alt" | "shift";
 	handler: () => void;
 	preventDefault?: boolean;
 }
 
 export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[]) {
-	let abortController: AbortController | null = null;
+	const abortController = useAbortController();
 
-	function isModifierActive(event: KeyboardEvent, modifier?: string): boolean {
+	function isModifierActive(
+		event: KeyboardEvent,
+		modifier?: string,
+	): boolean {
 		switch (modifier) {
-			case 'ctrl':
+			case "ctrl":
 				return event.ctrlKey && !event.metaKey;
-			case 'cmd':
+			case "cmd":
 				return event.metaKey && !event.ctrlKey;
-			case 'alt':
+			case "alt":
 				return event.altKey;
-			case 'shift':
+			case "shift":
 				return event.shiftKey;
 			default:
-				return true;
+				return (
+					!event.ctrlKey &&
+					!event.metaKey &&
+					!event.altKey &&
+					!event.shiftKey
+				);
 		}
 	}
 
 	function handleKeydown(event: KeyboardEvent) {
 		for (const shortcut of shortcuts) {
-			const keyMatches = event.key.toLowerCase() === shortcut.key.toLowerCase();
+			const keyMatches =
+				event.key.toLowerCase() === shortcut.key.toLowerCase();
 			const modifierMatches = isModifierActive(event, shortcut.modifier);
-			
+
 			if (keyMatches && modifierMatches) {
 				if (shortcut.preventDefault !== false) {
 					event.preventDefault();
@@ -41,16 +51,8 @@ export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[]) {
 	}
 
 	onMounted(() => {
-		abortController = new AbortController();
 		document.addEventListener("keydown", handleKeydown, {
 			signal: abortController.signal,
 		});
 	});
-
-	onUnmounted(() => {
-		if (abortController) {
-			abortController.abort();
-		}
-	});
 }
-

--- a/src/ui/src/builder/composables/useKeyboardShortcuts.ts
+++ b/src/ui/src/builder/composables/useKeyboardShortcuts.ts
@@ -1,7 +1,7 @@
 import { onMounted } from "vue";
 import { useAbortController } from "../../composables/useAbortController";
 
-interface KeyboardShortcut {
+export interface KeyboardShortcut {
 	key: string;
 	modifier?: "ctrl" | "cmd" | "alt" | "shift";
 	handler: () => void;

--- a/src/ui/src/builder/composables/useKeyboardShortcuts.ts
+++ b/src/ui/src/builder/composables/useKeyboardShortcuts.ts
@@ -1,0 +1,56 @@
+import { onMounted, onUnmounted } from "vue";
+
+interface KeyboardShortcut {
+	key: string;
+	modifier?: 'ctrl' | 'cmd' | 'alt' | 'shift';
+	handler: () => void;
+	preventDefault?: boolean;
+}
+
+export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[]) {
+	let abortController: AbortController | null = null;
+
+	function isModifierActive(event: KeyboardEvent, modifier?: string): boolean {
+		switch (modifier) {
+			case 'ctrl':
+				return event.ctrlKey && !event.metaKey;
+			case 'cmd':
+				return event.metaKey && !event.ctrlKey;
+			case 'alt':
+				return event.altKey;
+			case 'shift':
+				return event.shiftKey;
+			default:
+				return true;
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		for (const shortcut of shortcuts) {
+			const keyMatches = event.key.toLowerCase() === shortcut.key.toLowerCase();
+			const modifierMatches = isModifierActive(event, shortcut.modifier);
+			
+			if (keyMatches && modifierMatches) {
+				if (shortcut.preventDefault !== false) {
+					event.preventDefault();
+				}
+				shortcut.handler();
+				return;
+			}
+		}
+	}
+
+	onMounted(() => {
+		abortController = new AbortController();
+		document.addEventListener("keydown", handleKeydown, {
+			signal: abortController.signal,
+		});
+	});
+
+	onUnmounted(() => {
+		if (abortController) {
+			abortController.abort();
+		}
+	});
+}
+

--- a/src/ui/src/builder/composables/useUnsavedChangesModal.ts
+++ b/src/ui/src/builder/composables/useUnsavedChangesModal.ts
@@ -1,0 +1,49 @@
+import { ref } from "vue";
+
+interface PendingAction {
+	action: () => void;
+	description?: string;
+}
+
+export function useUnsavedChangesModal() {
+	const showModal = ref(false);
+	const pendingAction = ref<PendingAction | null>(null);
+
+	const showUnsavedChangesModal = (action: () => void, description?: string) => {
+		showModal.value = true;
+		pendingAction.value = { action, description };
+	};
+
+	const executePendingAction = () => {
+		if (pendingAction.value) {
+			pendingAction.value.action();
+			pendingAction.value = null;
+		}
+		showModal.value = false;
+	};
+
+	const cancelPendingAction = () => {
+		pendingAction.value = null;
+		showModal.value = false;
+	};
+
+	const checkUnsavedChanges = (
+		hasUnsavedChanges: boolean,
+		action: () => void,
+		description?: string,
+	): boolean => {
+		if (hasUnsavedChanges) {
+			showUnsavedChangesModal(action, description);
+			return true;
+		}
+		return false;
+	};
+
+	return {
+		showModal,
+		executePendingAction,
+		cancelPendingAction,
+		checkUnsavedChanges,
+	};
+}
+

--- a/src/ui/src/builder/composables/useUnsavedChangesModal.ts
+++ b/src/ui/src/builder/composables/useUnsavedChangesModal.ts
@@ -1,4 +1,4 @@
-import { ref } from "vue";
+import { shallowRef } from "vue";
 
 interface PendingAction {
 	action: () => void;
@@ -6,10 +6,13 @@ interface PendingAction {
 }
 
 export function useUnsavedChangesModal() {
-	const showModal = ref(false);
-	const pendingAction = ref<PendingAction | null>(null);
+	const showModal = shallowRef(false);
+	const pendingAction = shallowRef<PendingAction | null>(null);
 
-	const showUnsavedChangesModal = (action: () => void, description?: string) => {
+	const showUnsavedChangesModal = (
+		action: () => void,
+		description?: string,
+	) => {
 		showModal.value = true;
 		pendingAction.value = { action, description };
 	};
@@ -46,4 +49,3 @@ export function useUnsavedChangesModal() {
 		checkUnsavedChanges,
 	};
 }
-

--- a/src/ui/src/builder/modals/UnsavedChangesModal.vue
+++ b/src/ui/src/builder/modals/UnsavedChangesModal.vue
@@ -4,7 +4,7 @@
 		description="You have unsaved changes. What would you like to do?"
 		:actions="modalActions"
 		display-close-button
-		@close="() => emits('cancel')"
+		@close="emits('cancel')"
 	>
 		<div class="UnsavedChangesModal__content">
 			<div class="UnsavedChangesModal__icon">
@@ -26,21 +26,15 @@ import { computed, withDefaults } from "vue";
 import WdsModal, { type ModalAction } from "@/wds/WdsModal.vue";
 import WdsIcon from "@/wds/WdsIcon.vue";
 
-interface UnsavedChangesModalProps {
-	filename: string;
-	isSaving?: boolean;
-}
-
-interface UnsavedChangesModalEmits {
-	save: [];
-	cancel: [];
-}
-
-const props = withDefaults(defineProps<UnsavedChangesModalProps>(), {
-	isSaving: false,
+const props = defineProps({
+	filename: { type: String, required: true },
+	isSaving: { type: Boolean, required: false },
 });
 
-const emits = defineEmits<UnsavedChangesModalEmits>();
+const emits = defineEmits({
+	save: () => true,
+	cancel: () => true,
+});
 
 const modalActions = computed<ModalAction[]>(() => [
 	{

--- a/src/ui/src/builder/modals/UnsavedChangesModal.vue
+++ b/src/ui/src/builder/modals/UnsavedChangesModal.vue
@@ -1,0 +1,94 @@
+<template>
+	<WdsModal
+		title="Unsaved Changes"
+		description="You have unsaved changes. What would you like to do?"
+		:actions="modalActions"
+		display-close-button
+		@close="() => emits('cancel')"
+	>
+		<div class="UnsavedChangesModal__content">
+			<div class="UnsavedChangesModal__icon">
+				<WdsIcon name="alert-triangle" />
+			</div>
+			<div class="UnsavedChangesModal__message">
+				<p>
+					The file <strong>{{ filename }}</strong> has unsaved
+					changes.
+				</p>
+				<p>Your changes will be lost if you don't save them.</p>
+			</div>
+		</div>
+	</WdsModal>
+</template>
+
+<script setup lang="ts">
+import { computed, withDefaults } from "vue";
+import WdsModal, { type ModalAction } from "@/wds/WdsModal.vue";
+import WdsIcon from "@/wds/WdsIcon.vue";
+
+interface UnsavedChangesModalProps {
+	filename: string;
+	isSaving?: boolean;
+}
+
+interface UnsavedChangesModalEmits {
+	save: [];
+	cancel: [];
+}
+
+const props = withDefaults(defineProps<UnsavedChangesModalProps>(), {
+	isSaving: false,
+});
+
+const emits = defineEmits<UnsavedChangesModalEmits>();
+
+const modalActions = computed<ModalAction[]>(() => [
+	{
+		desc: "Cancel",
+		fn: () => emits("cancel"),
+	},
+	{
+		desc: "Save",
+		fn: () => emits("save"),
+		disabled: props.isSaving,
+	},
+]);
+</script>
+
+<style scoped>
+.UnsavedChangesModal__content {
+	display: flex;
+	align-items: flex-start;
+	gap: 16px;
+	padding: 16px 0;
+}
+
+.UnsavedChangesModal__icon {
+	flex-shrink: 0;
+	width: 48px;
+	height: 48px;
+	background-color: var(--wdsColorOrange1);
+	border-radius: 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--wdsColorOrange6);
+	font-size: 24px;
+}
+
+.UnsavedChangesModal__message {
+	flex: 1;
+}
+
+.UnsavedChangesModal__message p {
+	margin: 0 0 8px 0;
+	color: var(--primaryTextColor);
+	line-height: 1.5;
+}
+
+.UnsavedChangesModal__message p:last-child {
+	margin-bottom: 0;
+	color: var(--secondaryTextColor);
+	font-size: 14px;
+}
+</style>

--- a/src/ui/src/builder/modals/UnsavedChangesModal.vue
+++ b/src/ui/src/builder/modals/UnsavedChangesModal.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, withDefaults } from "vue";
+import { computed } from "vue";
 import WdsModal, { type ModalAction } from "@/wds/WdsModal.vue";
 import WdsIcon from "@/wds/WdsIcon.vue";
 

--- a/src/ui/src/builder/panels/BuilderCodePanel.vue
+++ b/src/ui/src/builder/panels/BuilderCodePanel.vue
@@ -20,8 +20,8 @@
 					:paths-unsaved="pathsUnsaved"
 					:source-files="sourceFileDraft"
 					@add-file="handleAddFile"
-					@select="openFile"
-					@delete="handleDeleteFile"
+					@select="handleFileSelect"
+					@delete="handleFileDelete"
 				/>
 				<div class="BuilderCodePanel__tree__actions">
 					<WdsButtonLink
@@ -82,6 +82,14 @@
 			</div>
 		</template>
 	</BuilderPanel>
+
+	<UnsavedChangesModal
+		v-if="showModal"
+		:filename="filepathOpenStr"
+		:is-saving="isDisabled"
+		@save="handleModalSave"
+		@cancel="handleModalCancel"
+	/>
 </template>
 
 <script setup lang="ts">
@@ -94,6 +102,7 @@ import {
 	ref,
 	useTemplateRef,
 	watch,
+	watchEffect,
 } from "vue";
 import BuilderPanel from "./BuilderPanel.vue";
 import injectionKeys from "@/injectionKeys";
@@ -109,6 +118,11 @@ import BuilderCodePanelFileUploadBtn from "./BuilderCodePanelFileUploadBtn.vue";
 import WdsButtonLink from "@/wds/WdsButtonLink.vue";
 import { useWriterTracking } from "@/composables/useWriterTracking";
 import { defineAsyncComponentWithLoader } from "@/utils/defineAsyncComponentWithLoader";
+import { useUnsavedChangesPrevention } from "@/composables/useUnsavedChangesPrevention";
+import { useUnsavedChangesModal } from "../composables/useUnsavedChangesModal";
+import { useKeyboardShortcuts } from "../composables/useKeyboardShortcuts";
+import UnsavedChangesModal from "../modals/UnsavedChangesModal.vue";
+import { findSourceFileFromPath } from "@/core/sourceFiles";
 
 const SharedMoreDropdown = defineAsyncComponentWithLoader({
 	loader: () => import("@/components/shared/SharedMoreDropdown.vue"),
@@ -123,6 +137,7 @@ defineProps<{
 }>();
 
 const wf = inject(injectionKeys.core);
+const wfbm = inject(injectionKeys.builderManager);
 
 const moreOptions: Option[] = [
 	{
@@ -152,6 +167,15 @@ const {
 	pathsUnsaved,
 	save,
 } = useSourceFiles(wf);
+
+const { enablePrevention, disablePrevention } = useUnsavedChangesPrevention();
+
+const {
+	showModal,
+	checkUnsavedChanges,
+	executePendingAction,
+	cancelPendingAction,
+} = useUnsavedChangesModal();
 
 async function handleUpload(files: File[]) {
 	await Promise.all(files.map(handleFileUpload));
@@ -184,7 +208,7 @@ function useKeydownCmdS(callback: () => void | Promise<void>) {
 				const isSKey = event.key === "s" || event.key === "S";
 				if (!isCmdOrCtrl || !isSKey) return;
 
-				event.preventDefault(); // Prevent the default save dialog
+				event.preventDefault();
 				await callback();
 			},
 			{ signal: abortController.signal },
@@ -192,7 +216,22 @@ function useKeydownCmdS(callback: () => void | Promise<void>) {
 	});
 	onUnmounted(() => abortController.abort());
 }
-useKeydownCmdS(handleSave);
+useKeydownCmdS(async () => {
+	await handleSave();
+});
+
+useKeyboardShortcuts([
+	{
+		key: "w",
+		modifier: "ctrl",
+		handler: handleClosePanel,
+	},
+	{
+		key: "w",
+		modifier: "cmd",
+		handler: handleClosePanel,
+	},
+]);
 
 const filenameEl = useTemplateRef("filenameEl");
 const filename = ref("");
@@ -210,9 +249,15 @@ const isCodeSaved = computed(() => {
 	if (isRenaming.value) return false;
 	if (filepathOpen.value === undefined) return true;
 
-	return !pathsUnsaved.value
+	const isInUnsavedPaths = pathsUnsaved.value
 		.map((p) => p.join("/"))
 		.includes(filepathOpenStr.value);
+
+	const isNewFile =
+		filepathOpen.value &&
+		!findSourceFileFromPath(filepathOpen.value, wf.sourceFiles.value);
+
+	return !isInUnsavedPaths && !isNewFile;
 });
 
 watch(filepathOpen, () => {
@@ -222,6 +267,23 @@ watch(filepathOpen, () => {
 watch(wf.sessionTimestamp, () => {
 	isDisabled.value = false;
 });
+
+watchEffect(() => {
+	if (isCodeSaved.value) {
+		disablePrevention();
+	} else {
+		enablePrevention();
+	}
+});
+
+watch(
+	() => wfbm.openPanels.value.has("code"),
+	(isOpen, wasOpen) => {
+		if (wasOpen && !isOpen) {
+			handlePanelClosing();
+		}
+	},
+);
 
 function onOpenPanel(open: boolean) {
 	if (!open) return;
@@ -266,7 +328,7 @@ async function handleSave() {
 	} else if (isCodeSaved.value) {
 		return pushToast({
 			type: "info",
-			message: "There are not file changes to save",
+			message: "There are no file changes to save",
 		});
 	}
 
@@ -295,6 +357,62 @@ async function handleSave() {
 		return;
 	} finally {
 		isDisabled.value = false;
+	}
+}
+
+async function handleModalSave() {
+	await handleSave();
+	executePendingAction();
+}
+
+function handleModalCancel() {
+	cancelPendingAction();
+}
+
+async function handleFileSelect(path: string[]) {
+	if (
+		checkUnsavedChanges(
+			!isCodeSaved.value,
+			() => openFile(path),
+			"switch file",
+		)
+	) {
+		return;
+	}
+	openFile(path);
+}
+
+async function handleFileDelete(path: string[]) {
+	if (
+		checkUnsavedChanges(
+			!isCodeSaved.value,
+			() => handleDeleteFile(path),
+			"delete file",
+		)
+	) {
+		return;
+	}
+	await handleDeleteFile(path);
+}
+
+function handleClosePanel() {
+	if (
+		checkUnsavedChanges(
+			!isCodeSaved.value,
+			() => wfbm.openPanels.value.delete("code"),
+			"close panel",
+		)
+	) {
+		return;
+	}
+	wfbm.openPanels.value.delete("code");
+}
+
+function handlePanelClosing() {
+	if (checkUnsavedChanges(!isCodeSaved.value, () => {}, "close panel")) {
+		nextTick(() => {
+			wfbm.openPanels.value.add("code");
+		});
 	}
 }
 

--- a/src/ui/src/composables/useUnsavedChangesPrevention.ts
+++ b/src/ui/src/composables/useUnsavedChangesPrevention.ts
@@ -1,0 +1,41 @@
+import { ref, onMounted, onUnmounted } from "vue";
+
+const BEFORE_UNLOAD_MESSAGE = "You have unsaved changes. Are you sure you want to leave?";
+
+export function useUnsavedChangesPrevention() {
+	const hasUnsavedChanges = ref(false);
+	const beforeUnloadHandler = ref<((event: BeforeUnloadEvent) => void) | null>(null);
+
+	function enablePrevention() {
+		hasUnsavedChanges.value = true;
+	}
+
+	function disablePrevention() {
+		hasUnsavedChanges.value = false;
+	}
+
+	function handleBeforeUnload(event: BeforeUnloadEvent) {
+		if (hasUnsavedChanges.value) {
+			event.preventDefault();
+			event.returnValue = BEFORE_UNLOAD_MESSAGE;
+			return BEFORE_UNLOAD_MESSAGE;
+		}
+	}
+
+	onMounted(() => {
+		beforeUnloadHandler.value = handleBeforeUnload;
+		window.addEventListener("beforeunload", beforeUnloadHandler.value);
+	});
+
+	onUnmounted(() => {
+		if (beforeUnloadHandler.value) {
+			window.removeEventListener("beforeunload", beforeUnloadHandler.value);
+		}
+	});
+
+	return {
+		enablePrevention,
+		disablePrevention,
+	};
+}
+

--- a/src/ui/src/composables/useUnsavedChangesPrevention.ts
+++ b/src/ui/src/composables/useUnsavedChangesPrevention.ts
@@ -1,10 +1,14 @@
 import { ref, onMounted, onUnmounted } from "vue";
+import { useAbortController } from "@/composables/useAbortController";
 
-const BEFORE_UNLOAD_MESSAGE = "You have unsaved changes. Are you sure you want to leave?";
+const BEFORE_UNLOAD_MESSAGE =
+	"You have unsaved changes. Are you sure you want to leave?";
 
 export function useUnsavedChangesPrevention() {
 	const hasUnsavedChanges = ref(false);
-	const beforeUnloadHandler = ref<((event: BeforeUnloadEvent) => void) | null>(null);
+	const beforeUnloadHandler = ref<
+		((event: BeforeUnloadEvent) => void) | null
+	>(null);
 
 	function enablePrevention() {
 		hasUnsavedChanges.value = true;
@@ -29,8 +33,18 @@ export function useUnsavedChangesPrevention() {
 
 	onUnmounted(() => {
 		if (beforeUnloadHandler.value) {
-			window.removeEventListener("beforeunload", beforeUnloadHandler.value);
+			window.removeEventListener(
+				"beforeunload",
+				beforeUnloadHandler.value,
+			);
 		}
+	});
+
+	const abort = useAbortController();
+	onMounted(() => {
+		window.addEventListener("beforeunload", handleBeforeUnload, {
+			signal: abort.signal,
+		});
 	});
 
 	return {
@@ -38,4 +52,3 @@ export function useUnsavedChangesPrevention() {
 		disablePrevention,
 	};
 }
-


### PR DESCRIPTION
- Add unsaved changes modal with warning icon and save/cancel actions
- Implement keyboard shortcuts for Ctrl/Cmd+W to close panel
- Add browser beforeunload prevention for unsaved changes
- Create composables for modal management and keyboard shortcuts
- Remove unused Tab shortcuts and clean up code formatting
- Fix typo in error message and simplify error handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global keyboard shortcuts (e.g., Ctrl/Cmd+W to close the code panel).
  * Unsaved-changes confirmation modal with save/cancel workflow.
  * Page-unload prevention prompt when there are unsaved changes.

* **Improvements**
  * File operations and panel closing now respect unsaved-change checks.
  * Clearer save warning message and smoother modal-driven save/cancel flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->