### PR TITLE
fix(AB-549): Fix HTTP block dropdown to show all methods by default

### DIFF
--- a/src/writer/blocks/httprequest.py
+++ b/src/writer/blocks/httprequest.py
@@ -28,7 +28,6 @@ class HTTPRequest(BlueprintBlock):
                                 "PATCH": "PATCH",
                                 "DELETE": "DELETE",
                             },
-                            "default": "GET",
                             "validator": {
                                 "type": "string",
                                 "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],


### PR DESCRIPTION
<img width="352" height="755" alt="image" src="https://github.com/user-attachments/assets/ff1e7482-c165-4c45-83b8-136b7cdc59c7" />
