### PR TITLE
[AB-72] Hold mouse to select multiple blocks

### DIFF
--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -365,8 +365,6 @@ function handleRendererClick(ev: PointerEvent): void {
 	);
 	if (unselectableEl) return;
 
-	// In blueprints mode, if we have multiple selections, don't allow single-click selection
-	// This prevents interference with drag-to-select multi-selection
 	if (
 		builderMode.value === "blueprints" &&
 		ssbm.selectionStatus.value === SelectionStatus.Multiple
@@ -375,7 +373,6 @@ function handleRendererClick(ev: PointerEvent): void {
 			"[data-writer-id]",
 		);
 		if (targetEl && ssbm.isComponentIdSelected(targetEl.dataset.writerId)) {
-			// If clicking on an already-selected component in multi-selection mode, don't change selection
 			ev.preventDefault();
 			ev.stopPropagation();
 			return;

--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -24,15 +24,25 @@
 						<BuilderVault v-if="builderMode === 'vault'" />
 						<div
 							v-else
+							ref="rendererWrapperEl"
 							class="rendererWrapper"
 							:class="{
 								addNoteCursor:
 									notesManager.isAnnotating.value &&
 									ssbm.mode.value !== 'preview',
+								isSelecting: isCursorSelecting,
+								canSelect:
+									isHoveringSelectableArea &&
+									!isCursorSelecting,
 							}"
 							@scroll="refreshNotesPosition"
+							@mousedown.capture="handleRendererMousedown"
+							@mousemove="handleRendererMousemove"
+							@mouseup="handleRendererMouseup"
+							@mouseleave="handleRendererMouseleave"
 						>
 							<ComponentRenderer
+								ref="rendererEl"
 								class="componentRenderer"
 								:class="{
 									settingsOpen: ssbm.isSingleSelectionActive,
@@ -45,6 +55,17 @@
 								@dblclick="handleRendererDblClick"
 							>
 							</ComponentRenderer>
+							<!-- Selection rectangle overlay -->
+							<div
+								v-if="selectionRect.isSelecting"
+								class="selectionRectangle"
+								:style="{
+									left: `${selectionRect.left}px`,
+									top: `${selectionRect.top}px`,
+									width: `${selectionRect.width}px`,
+									height: `${selectionRect.height}px`,
+								}"
+							></div>
 						</div>
 						<BuilderSettings
 							v-if="ssbm.isSingleSelectionActive"
@@ -150,6 +171,7 @@ import BuilderCollaborationTracker from "./BuilderCollaborationTracker.vue";
 import BaseNote from "@/components/core/base/BaseNote.vue";
 import ShareResizeVertical from "@/components/shared/ShareResizeVertical.vue";
 import { defineAsyncComponentWithLoader } from "@/utils/defineAsyncComponentWithLoader";
+import { useDragToSelect } from "./composables/useDragToSelect";
 
 provide(injectionKeys.isAutogenModalShown, ref(false));
 
@@ -179,6 +201,27 @@ const tracking = useWriterTracking(wf);
 const toasts = useToasts();
 
 const noteEl = useTemplateRef("noteEl");
+const rendererEl = useTemplateRef("rendererEl");
+const rendererWrapperEl = useTemplateRef("rendererWrapperEl");
+
+const justCompletedDragSelection = ref(false);
+
+const {
+	selectionRect,
+	isCursorSelecting,
+	isHoveringSelectableArea,
+	handleMousedown: handleRendererMousedown,
+	handleMousemove: handleRendererMousemove,
+	handleMouseup: handleRendererMouseup,
+	handleMouseleave: handleRendererMouseleave,
+	handleDocumentMouseup,
+} = useDragToSelect({
+	wrapperRef: rendererWrapperEl,
+	builderMode: ssbm.mode,
+	builderManager: ssbm,
+	isAnnotating: notesManager.isAnnotating,
+	justCompletedDragSelection,
+});
 
 function refreshNotesPosition() {
 	const isNotesIterable =
@@ -356,12 +399,16 @@ function handleRendererDrop(ev: DragEvent) {
 function handleRendererClick(ev: PointerEvent): void {
 	if (builderMode.value === "preview") return;
 
-	const unselectableEl: HTMLElement = (ev.target as HTMLElement).closest(
+	if (justCompletedDragSelection.value) {
+		return;
+	}
+
+	const unselectableEl = (ev.target as HTMLElement).closest<HTMLElement>(
 		"[data-writer-unselectable]",
 	);
 	if (unselectableEl) return;
 
-	const targetEl: HTMLElement = (ev.target as HTMLElement).closest(
+	const targetEl = (ev.target as HTMLElement).closest<HTMLElement>(
 		"[data-writer-id]",
 	);
 	if (!targetEl) return;
@@ -392,14 +439,16 @@ function handleRendererDblClick() {
 const handleRendererDragStart = (ev: DragEvent) => {
 	if (builderMode.value === "preview") return;
 
-	const targetEl: HTMLElement = (ev.target as HTMLElement).closest(
+	const targetEl = (ev.target as HTMLElement).closest<HTMLElement>(
 		"[data-writer-id]",
 	);
+	if (!targetEl) return;
 
 	const componentId = targetEl.dataset.writerId;
+	if (!componentId) return;
+
 	const { type } = wf.getComponentById(componentId);
 
-	// we don't support yet dragginfg multiple components in UI. If drag is starting with multiple selections, we select only one component
 	if (ssbm.selectionStatus.value === SelectionStatus.Multiple) {
 		ssbm.setSelection(componentId, undefined, "click");
 		ssbm.isSettingsBarCollapsed.value = true;
@@ -429,6 +478,9 @@ watch(ssbm.selection, () => {
 
 onMounted(() => {
 	document.addEventListener("keydown", handleKeydown, {
+		signal: abort.signal,
+	});
+	document.addEventListener("mouseup", handleDocumentMouseup, {
 		signal: abort.signal,
 	});
 });
@@ -526,9 +578,18 @@ onUnmounted(() => {
 	flex-direction: column;
 	height: 100%;
 	overflow-y: auto;
+	position: relative;
 }
 .rendererWrapper--annotating {
 	cursor: context-menu;
+}
+
+.rendererWrapper.isSelecting {
+	cursor: crosshair;
+}
+
+.rendererWrapper.canSelect {
+	cursor: crosshair;
 }
 
 .componentRenderer {
@@ -566,5 +627,13 @@ onUnmounted(() => {
 #tooltip {
 	position: absolute;
 	z-index: 11;
+}
+
+.selectionRectangle {
+	position: absolute;
+	border: 2px solid var(--builderAccentColor);
+	background: rgba(59, 130, 246, 0.1);
+	pointer-events: none;
+	z-index: 2;
 }
 </style>

--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -30,16 +30,8 @@
 								addNoteCursor:
 									notesManager.isAnnotating.value &&
 									ssbm.mode.value !== 'preview',
-								isSelecting: isCursorSelecting,
-								canSelect:
-									isHoveringSelectableArea &&
-									!isCursorSelecting,
 							}"
 							@scroll="refreshNotesPosition"
-							@mousedown.capture="handleRendererMousedown"
-							@mousemove="handleRendererMousemove"
-							@mouseup="handleRendererMouseup"
-							@mouseleave="handleRendererMouseleave"
 						>
 							<ComponentRenderer
 								ref="rendererEl"
@@ -55,17 +47,6 @@
 								@dblclick="handleRendererDblClick"
 							>
 							</ComponentRenderer>
-							<!-- Selection rectangle overlay -->
-							<div
-								v-if="selectionRect.isSelecting"
-								class="selectionRectangle"
-								:style="{
-									left: `${selectionRect.left}px`,
-									top: `${selectionRect.top}px`,
-									width: `${selectionRect.width}px`,
-									height: `${selectionRect.height}px`,
-								}"
-							></div>
 						</div>
 						<BuilderSettings
 							v-if="ssbm.isSingleSelectionActive"
@@ -171,7 +152,6 @@ import BuilderCollaborationTracker from "./BuilderCollaborationTracker.vue";
 import BaseNote from "@/components/core/base/BaseNote.vue";
 import ShareResizeVertical from "@/components/shared/ShareResizeVertical.vue";
 import { defineAsyncComponentWithLoader } from "@/utils/defineAsyncComponentWithLoader";
-import { useDragToSelect } from "./composables/useDragToSelect";
 
 provide(injectionKeys.isAutogenModalShown, ref(false));
 
@@ -203,23 +183,6 @@ const toasts = useToasts();
 const noteEl = useTemplateRef("noteEl");
 const rendererEl = useTemplateRef("rendererEl");
 const rendererWrapperEl = useTemplateRef("rendererWrapperEl");
-
-const {
-	selectionRect,
-	isCursorSelecting,
-	isHoveringSelectableArea,
-	justCompletedDragSelection,
-	handleMousedown: handleRendererMousedown,
-	handleMousemove: handleRendererMousemove,
-	handleMouseup: handleRendererMouseup,
-	handleMouseleave: handleRendererMouseleave,
-	handleDocumentMouseup,
-} = useDragToSelect({
-	wrapperRef: rendererWrapperEl,
-	builderMode: ssbm.mode,
-	builderManager: ssbm,
-	isAnnotating: notesManager.isAnnotating,
-});
 
 function refreshNotesPosition() {
 	const isNotesIterable =
@@ -397,14 +360,27 @@ function handleRendererDrop(ev: DragEvent) {
 function handleRendererClick(ev: PointerEvent): void {
 	if (builderMode.value === "preview") return;
 
-	if (justCompletedDragSelection.value) {
-		return;
-	}
-
 	const unselectableEl = (ev.target as HTMLElement).closest<HTMLElement>(
 		"[data-writer-unselectable]",
 	);
 	if (unselectableEl) return;
+
+	// In blueprints mode, if we have multiple selections, don't allow single-click selection
+	// This prevents interference with drag-to-select multi-selection
+	if (
+		builderMode.value === "blueprints" &&
+		ssbm.selectionStatus.value === SelectionStatus.Multiple
+	) {
+		const targetEl = (ev.target as HTMLElement).closest<HTMLElement>(
+			"[data-writer-id]",
+		);
+		if (targetEl && ssbm.isComponentIdSelected(targetEl.dataset.writerId)) {
+			// If clicking on an already-selected component in multi-selection mode, don't change selection
+			ev.preventDefault();
+			ev.stopPropagation();
+			return;
+		}
+	}
 
 	const targetEl = (ev.target as HTMLElement).closest<HTMLElement>(
 		"[data-writer-id]",
@@ -476,9 +452,6 @@ watch(ssbm.selection, () => {
 
 onMounted(() => {
 	document.addEventListener("keydown", handleKeydown, {
-		signal: abort.signal,
-	});
-	document.addEventListener("mouseup", handleDocumentMouseup, {
 		signal: abort.signal,
 	});
 });
@@ -625,13 +598,5 @@ onUnmounted(() => {
 #tooltip {
 	position: absolute;
 	z-index: 11;
-}
-
-.selectionRectangle {
-	position: absolute;
-	border: 2px solid var(--builderAccentColor);
-	background: rgba(59, 130, 246, 0.1);
-	pointer-events: none;
-	z-index: 2;
 }
 </style>

--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -204,12 +204,11 @@ const noteEl = useTemplateRef("noteEl");
 const rendererEl = useTemplateRef("rendererEl");
 const rendererWrapperEl = useTemplateRef("rendererWrapperEl");
 
-const justCompletedDragSelection = ref(false);
-
 const {
 	selectionRect,
 	isCursorSelecting,
 	isHoveringSelectableArea,
+	justCompletedDragSelection,
 	handleMousedown: handleRendererMousedown,
 	handleMousemove: handleRendererMousemove,
 	handleMouseup: handleRendererMouseup,
@@ -220,7 +219,6 @@ const {
 	builderMode: ssbm.mode,
 	builderManager: ssbm,
 	isAnnotating: notesManager.isAnnotating,
-	justCompletedDragSelection,
 });
 
 function refreshNotesPosition() {

--- a/src/ui/src/builder/composables/useDragToSelect.ts
+++ b/src/ui/src/builder/composables/useDragToSelect.ts
@@ -16,24 +16,16 @@ interface SelectionRectangle {
 
 const MIN_SELECTION_SIZE_PX = 5;
 const DRAG_SELECTION_CLICK_DELAY_MS = 100;
-const MOVEMENT_THRESHOLD = 3;
 
 interface UseDragToSelectOptions {
 	wrapperRef: Ref<HTMLElement | null>;
 	builderMode: Ref<BuilderManagerMode>;
 	builderManager: BuilderManager;
 	isAnnotating: Ref<boolean>;
-	justCompletedDragSelection: Ref<boolean>;
 }
 
 export function useDragToSelect(options: UseDragToSelectOptions) {
-	const {
-		wrapperRef,
-		builderMode,
-		builderManager,
-		isAnnotating,
-		justCompletedDragSelection,
-	} = options;
+	const { wrapperRef, builderMode, builderManager, isAnnotating } = options;
 
 	const selectionRect = ref<SelectionRectangle>({
 		isSelecting: false,
@@ -50,6 +42,7 @@ export function useDragToSelect(options: UseDragToSelectOptions) {
 	const isCursorSelecting = computed(() => selectionRect.value.isSelecting);
 
 	const isHoveringSelectableArea = ref(false);
+	const justCompletedDragSelection = ref(false);
 
 	function shouldAllowSelectionInBlueprints(target: HTMLElement): boolean {
 		const targetEl = target.closest<HTMLElement>("[data-writer-id]");
@@ -60,9 +53,7 @@ export function useDragToSelect(options: UseDragToSelectOptions) {
 		);
 		if (!blueprintsBlueprint) return false;
 
-		if (targetEl === blueprintsBlueprint) return true;
-
-		return false;
+		return targetEl === blueprintsBlueprint;
 	}
 
 	function isClickOnBlueprintsCanvas(target: HTMLElement): boolean {
@@ -340,6 +331,7 @@ export function useDragToSelect(options: UseDragToSelectOptions) {
 		isCursorSelecting,
 		isHoveringSelectableArea,
 		isSelecting: computed(() => selectionRect.value.isSelecting),
+		justCompletedDragSelection,
 		handleMousedown,
 		handleMousemove,
 		handleMouseup,

--- a/src/ui/src/builder/composables/useDragToSelect.ts
+++ b/src/ui/src/builder/composables/useDragToSelect.ts
@@ -1,0 +1,349 @@
+import { ref, computed, type Ref, onUnmounted } from "vue";
+import type { BuilderManagerMode } from "../builderManager";
+import { generateBuilderManager } from "../builderManager";
+
+type BuilderManager = ReturnType<typeof generateBuilderManager>;
+
+interface SelectionRectangle {
+	isSelecting: boolean;
+	startX: number;
+	startY: number;
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+}
+
+const MIN_SELECTION_SIZE_PX = 5;
+const DRAG_SELECTION_CLICK_DELAY_MS = 100;
+const MOVEMENT_THRESHOLD = 3;
+
+interface UseDragToSelectOptions {
+	wrapperRef: Ref<HTMLElement | null>;
+	builderMode: Ref<BuilderManagerMode>;
+	builderManager: BuilderManager;
+	isAnnotating: Ref<boolean>;
+	justCompletedDragSelection: Ref<boolean>;
+}
+
+export function useDragToSelect(options: UseDragToSelectOptions) {
+	const {
+		wrapperRef,
+		builderMode,
+		builderManager,
+		isAnnotating,
+		justCompletedDragSelection,
+	} = options;
+
+	const selectionRect = ref<SelectionRectangle>({
+		isSelecting: false,
+		startX: 0,
+		startY: 0,
+		left: 0,
+		top: 0,
+		width: 0,
+		height: 0,
+	});
+
+	const dragAbortController = new AbortController();
+
+	const isCursorSelecting = computed(() => selectionRect.value.isSelecting);
+
+	const isHoveringSelectableArea = ref(false);
+
+	function shouldAllowSelectionInBlueprints(target: HTMLElement): boolean {
+		const targetEl = target.closest<HTMLElement>("[data-writer-id]");
+		if (!targetEl) return true;
+
+		const blueprintsBlueprint = target.closest<HTMLElement>(
+			".BlueprintsBlueprint",
+		);
+		if (!blueprintsBlueprint) return false;
+
+		if (targetEl === blueprintsBlueprint) return true;
+
+		return false;
+	}
+
+	function isClickOnBlueprintsCanvas(target: HTMLElement): boolean {
+		const blueprintsBlueprint = target.closest<HTMLElement>(
+			".BlueprintsBlueprint",
+		);
+		if (!blueprintsBlueprint) return false;
+
+		const nodeContainer =
+			blueprintsBlueprint.querySelector<HTMLElement>(".nodeContainer");
+		return nodeContainer ? nodeContainer.contains(target) : true;
+	}
+
+	function cleanupDragSelection() {
+		if (!selectionRect.value.isSelecting) return;
+
+		selectionRect.value.isSelecting = false;
+		document.body.style.userSelect = "";
+		document.body.style.cursor = "";
+	}
+
+	function updateSelectionRect(ev: MouseEvent) {
+		if (!selectionRect.value.isSelecting) return;
+		if (builderMode.value === "preview") return;
+
+		const wrapper = wrapperRef.value;
+		if (!wrapper) return;
+
+		try {
+			const wrapperRect = wrapper.getBoundingClientRect();
+			const currentX = ev.clientX - wrapperRect.left;
+			const currentY = ev.clientY - wrapperRect.top + wrapper.scrollTop;
+
+			const { startX, startY } = selectionRect.value;
+			const left = Math.min(startX, currentX);
+			const top = Math.min(startY, currentY) - wrapper.scrollTop;
+			const width = Math.abs(currentX - startX);
+			const height = Math.abs(currentY - startY);
+
+			selectionRect.value = {
+				...selectionRect.value,
+				left,
+				top,
+				width,
+				height,
+			};
+		} catch {
+			cleanupDragSelection();
+		}
+	}
+
+	function handleDocumentMousemove(ev: MouseEvent) {
+		if (!selectionRect.value.isSelecting) return;
+		updateSelectionRect(ev);
+		ev.preventDefault();
+	}
+
+	function handleMousedown(ev: MouseEvent) {
+		if (builderMode.value === "preview") return;
+		if (isAnnotating.value) return;
+
+		if (ev.shiftKey || ev.ctrlKey || ev.metaKey) return;
+
+		if (builderMode.value === "blueprints" && !ev.altKey) return;
+
+		const target = ev.target as HTMLElement;
+
+		const targetEl = target.closest<HTMLElement>("[data-writer-id]");
+		if (targetEl) {
+			if (builderMode.value === "blueprints") {
+				if (!shouldAllowSelectionInBlueprints(target)) return;
+			} else {
+				return;
+			}
+		}
+
+		const unselectableEl = target.closest<HTMLElement>(
+			"[data-writer-unselectable]",
+		);
+		if (unselectableEl) return;
+
+		if (target.classList.contains("selectionRectangle")) return;
+
+		const wrapper = wrapperRef.value;
+		if (!wrapper) return;
+
+		if (!wrapper.contains(target)) return;
+
+		if (builderMode.value === "blueprints") {
+			if (!isClickOnBlueprintsCanvas(target)) return;
+		}
+
+		const wrapperRect = wrapper.getBoundingClientRect();
+		const startX = ev.clientX - wrapperRect.left;
+		const startY = ev.clientY - wrapperRect.top + wrapper.scrollTop;
+
+		selectionRect.value = {
+			isSelecting: true,
+			startX,
+			startY,
+			left: startX,
+			top: startY - wrapper.scrollTop,
+			width: 0,
+			height: 0,
+		};
+
+		document.body.style.userSelect = "none";
+		document.body.style.cursor = "crosshair";
+
+		document.addEventListener("mousemove", handleDocumentMousemove, {
+			signal: dragAbortController.signal,
+		});
+
+		ev.stopPropagation();
+		ev.preventDefault();
+	}
+
+	function handleMousemove(ev: MouseEvent) {
+		if (selectionRect.value.isSelecting) {
+			if (builderMode.value === "blueprints") {
+				ev.stopPropagation();
+			}
+			updateSelectionRect(ev);
+			ev.preventDefault();
+			return;
+		}
+
+		if (builderMode.value === "preview") return;
+		if (isAnnotating.value) return;
+
+		if (ev.shiftKey || ev.ctrlKey || ev.metaKey) {
+			isHoveringSelectableArea.value = false;
+			return;
+		}
+
+		if (builderMode.value === "blueprints" && !ev.altKey) {
+			isHoveringSelectableArea.value = false;
+			return;
+		}
+
+		const target = ev.target as HTMLElement;
+		const wrapper = wrapperRef.value;
+		if (!wrapper || !wrapper.contains(target)) {
+			isHoveringSelectableArea.value = false;
+			return;
+		}
+
+		const targetEl = target.closest<HTMLElement>("[data-writer-id]");
+		if (targetEl) {
+			if (builderMode.value === "blueprints") {
+				if (!shouldAllowSelectionInBlueprints(target)) {
+					isHoveringSelectableArea.value = false;
+					return;
+				}
+			} else {
+				isHoveringSelectableArea.value = false;
+				return;
+			}
+		}
+
+		const unselectableEl = target.closest<HTMLElement>(
+			"[data-writer-unselectable]",
+		);
+		if (unselectableEl || target.classList.contains("selectionRectangle")) {
+			isHoveringSelectableArea.value = false;
+			return;
+		}
+
+		if (builderMode.value === "blueprints") {
+			if (!isClickOnBlueprintsCanvas(target)) {
+				isHoveringSelectableArea.value = false;
+				return;
+			}
+		}
+
+		isHoveringSelectableArea.value = true;
+	}
+
+	function handleMouseup(ev: MouseEvent) {
+		if (!selectionRect.value.isSelecting) return;
+		if (builderMode.value === "preview") return;
+
+		const { left, top, width, height } = selectionRect.value;
+
+		if (width < MIN_SELECTION_SIZE_PX || height < MIN_SELECTION_SIZE_PX) {
+			cleanupDragSelection();
+			return;
+		}
+
+		const wrapper = wrapperRef.value;
+		if (!wrapper) {
+			cleanupDragSelection();
+			return;
+		}
+
+		const wrapperRect = wrapper.getBoundingClientRect();
+		const selectionRectAbsolute = {
+			left: wrapperRect.left + left,
+			top: wrapperRect.top + top,
+			right: wrapperRect.left + left + width,
+			bottom: wrapperRect.top + top + height,
+		};
+
+		const allComponentEls =
+			wrapper.querySelectorAll<HTMLElement>("[data-writer-id]");
+		const selectedComponents: Array<{
+			componentId: string;
+			instancePath: string;
+		}> = [];
+
+		for (const element of Array.from(allComponentEls)) {
+			if (element.closest("[data-writer-unselectable]")) continue;
+
+			const componentRect = element.getBoundingClientRect();
+
+			if (
+				componentRect.left >= selectionRectAbsolute.left &&
+				componentRect.right <= selectionRectAbsolute.right &&
+				componentRect.top >= selectionRectAbsolute.top &&
+				componentRect.bottom <= selectionRectAbsolute.bottom
+			) {
+				const componentId = element.dataset.writerId;
+				const instancePath = element.dataset.writerInstancePath;
+				if (componentId) {
+					selectedComponents.push({ componentId, instancePath });
+				}
+			}
+		}
+
+		if (selectedComponents.length > 0) {
+			builderManager.setSelection(null);
+			selectedComponents.forEach(({ componentId, instancePath }) => {
+				builderManager.appendSelection(
+					componentId,
+					instancePath,
+					"click",
+				);
+			});
+			justCompletedDragSelection.value = true;
+			setTimeout(() => {
+				justCompletedDragSelection.value = false;
+			}, DRAG_SELECTION_CLICK_DELAY_MS);
+		} else {
+			builderManager.setSelection(null);
+		}
+
+		cleanupDragSelection();
+
+		ev.preventDefault();
+		ev.stopPropagation();
+		ev.stopImmediatePropagation();
+	}
+
+	function handleDocumentMouseup(ev: MouseEvent) {
+		if (selectionRect.value.isSelecting) {
+			const wrapper = wrapperRef.value;
+			if (wrapper && wrapper.contains(ev.target as Node)) {
+				return;
+			}
+			cleanupDragSelection();
+		}
+	}
+
+	onUnmounted(() => {
+		dragAbortController.abort();
+		cleanupDragSelection();
+	});
+
+	function handleMouseleave(_ev: MouseEvent) {
+		isHoveringSelectableArea.value = false;
+	}
+
+	return {
+		selectionRect,
+		isCursorSelecting,
+		isHoveringSelectableArea,
+		isSelecting: computed(() => selectionRect.value.isSelecting),
+		handleMousedown,
+		handleMousemove,
+		handleMouseup,
+		handleMouseleave,
+		handleDocumentMouseup,
+	};
+}

--- a/src/ui/src/builder/composables/useDragToSelect.ts
+++ b/src/ui/src/builder/composables/useDragToSelect.ts
@@ -1,8 +1,13 @@
-import { ref, computed, type Ref, onUnmounted } from "vue";
-import type { BuilderManagerMode } from "../builderManager";
-import { generateBuilderManager } from "../builderManager";
-
-type BuilderManager = ReturnType<typeof generateBuilderManager>;
+import {
+	ref,
+	shallowRef,
+	computed,
+	type Ref,
+	onUnmounted,
+	nextTick,
+} from "vue";
+import type { BuilderManager } from "@/writerTypes";
+import { useAbortController } from "@/composables/useAbortController";
 
 interface SelectionRectangle {
 	isSelecting: boolean;
@@ -14,20 +19,25 @@ interface SelectionRectangle {
 	height: number;
 }
 
+interface ScreenCoordinates {
+	left: number;
+	top: number;
+	right: number;
+	bottom: number;
+}
+
 const MIN_SELECTION_SIZE_PX = 5;
-const DRAG_SELECTION_CLICK_DELAY_MS = 100;
 
 interface UseDragToSelectOptions {
 	wrapperRef: Ref<HTMLElement | null>;
-	builderMode: Ref<BuilderManagerMode>;
 	builderManager: BuilderManager;
 	isAnnotating: Ref<boolean>;
 }
 
 export function useDragToSelect(options: UseDragToSelectOptions) {
-	const { wrapperRef, builderMode, builderManager, isAnnotating } = options;
+	const { wrapperRef, builderManager, isAnnotating } = options;
 
-	const selectionRect = ref<SelectionRectangle>({
+	const selectionRect = shallowRef<SelectionRectangle>({
 		isSelecting: false,
 		startX: 0,
 		startY: 0,
@@ -37,12 +47,101 @@ export function useDragToSelect(options: UseDragToSelectOptions) {
 		height: 0,
 	});
 
-	const dragAbortController = new AbortController();
+	const dragAbortController = useAbortController();
 
 	const isCursorSelecting = computed(() => selectionRect.value.isSelecting);
 
 	const isHoveringSelectableArea = ref(false);
 	const justCompletedDragSelection = ref(false);
+
+	let dragMousemoveAbortController: AbortController | null = null;
+	let hoverUpdateRafId: number | null = null;
+	let pendingHoverEvent: MouseEvent | null = null;
+	let selectionUpdateRafId: number | null = null;
+	let pendingSelectionEvent: MouseEvent | null = null;
+	let clickBlockerTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+	function updateHoverState(ev: MouseEvent) {
+		if (builderManager.mode.value === "preview") {
+			isHoveringSelectableArea.value = false;
+			return;
+		}
+		if (isAnnotating.value) {
+			isHoveringSelectableArea.value = false;
+			return;
+		}
+
+		if (ev.shiftKey || ev.ctrlKey || ev.metaKey) {
+			isHoveringSelectableArea.value = false;
+			return;
+		}
+
+		if (builderManager.mode.value === "blueprints" && !ev.altKey) {
+			isHoveringSelectableArea.value = false;
+			return;
+		}
+
+		if (!(ev.target instanceof Element)) {
+			isHoveringSelectableArea.value = false;
+			return;
+		}
+
+		const target = ev.target as HTMLElement;
+		const wrapper = wrapperRef.value;
+		if (!wrapper || !wrapper.contains(target)) {
+			isHoveringSelectableArea.value = false;
+			return;
+		}
+
+		const targetEl = target.closest<HTMLElement>("[data-writer-id]");
+		if (targetEl) {
+			if (builderManager.mode.value === "blueprints") {
+				if (!shouldAllowSelectionInBlueprints(target)) {
+					isHoveringSelectableArea.value = false;
+					return;
+				}
+			} else {
+				isHoveringSelectableArea.value = false;
+				return;
+			}
+		}
+
+		if (!isTargetSelectable(target)) {
+			isHoveringSelectableArea.value = false;
+			return;
+		}
+
+		if (builderManager.mode.value === "blueprints") {
+			if (!isClickOnBlueprintsCanvas(target)) {
+				isHoveringSelectableArea.value = false;
+				return;
+			}
+		}
+
+		isHoveringSelectableArea.value = true;
+	}
+
+	function shouldAllowDragSelection(event: MouseEvent): boolean {
+		if (builderManager.mode.value === "preview" || isAnnotating.value) {
+			return false;
+		}
+
+		if (builderManager.mode.value === "blueprints") {
+			if (!event.altKey) return false;
+			if (event.shiftKey || event.ctrlKey || event.metaKey) return false;
+			return true;
+		} else {
+			if (
+				event.shiftKey ||
+				event.ctrlKey ||
+				event.metaKey ||
+				event.altKey
+			) {
+				return false;
+			}
+			return true;
+		}
+	}
 
 	function shouldAllowSelectionInBlueprints(target: HTMLElement): boolean {
 		const targetEl = target.closest<HTMLElement>("[data-writer-id]");
@@ -64,28 +163,156 @@ export function useDragToSelect(options: UseDragToSelectOptions) {
 
 		const nodeContainer =
 			blueprintsBlueprint.querySelector<HTMLElement>(".nodeContainer");
-		return nodeContainer ? nodeContainer.contains(target) : true;
+		return nodeContainer ? nodeContainer.contains(target) : false;
+	}
+
+	function isTargetSelectable(target: HTMLElement): boolean {
+		const unselectableEl = target.closest<HTMLElement>(
+			"[data-writer-unselectable]",
+		);
+		if (unselectableEl) return false;
+
+		if (target.classList.contains("selectionRectangle")) return false;
+
+		return true;
+	}
+
+	function findComponentsInSelectionRect(
+		wrapper: HTMLElement,
+		selectionRectAbsolute: ScreenCoordinates,
+	): Array<{ componentId: string; instancePath?: string }> {
+		const allComponentEls =
+			wrapper.querySelectorAll<HTMLElement>("[data-writer-id]");
+		const selectedComponents: Array<{
+			componentId: string;
+			instancePath?: string;
+		}> = [];
+
+		for (const element of Array.from(allComponentEls)) {
+			if (element.closest("[data-writer-unselectable]")) continue;
+
+			const componentRect = element.getBoundingClientRect();
+
+			const isContained =
+				componentRect.left >= selectionRectAbsolute.left &&
+				componentRect.right <= selectionRectAbsolute.right &&
+				componentRect.top >= selectionRectAbsolute.top &&
+				componentRect.bottom <= selectionRectAbsolute.bottom;
+
+			if (isContained) {
+				const componentId = element.dataset.writerId;
+				const instancePath = element.dataset.writerInstancePath;
+				if (componentId) {
+					selectedComponents.push({
+						componentId,
+						instancePath:
+							instancePath && instancePath.trim()
+								? instancePath
+								: undefined,
+					});
+				}
+			}
+		}
+
+		return selectedComponents;
 	}
 
 	function cleanupDragSelection() {
 		if (!selectionRect.value.isSelecting) return;
 
-		selectionRect.value.isSelecting = false;
+		if (dragMousemoveAbortController) {
+			dragMousemoveAbortController.abort();
+			dragMousemoveAbortController = null;
+		}
+
+		if (hoverUpdateRafId !== null) {
+			cancelAnimationFrame(hoverUpdateRafId);
+			hoverUpdateRafId = null;
+		}
+		pendingHoverEvent = null;
+
+		if (selectionUpdateRafId !== null) {
+			cancelAnimationFrame(selectionUpdateRafId);
+			selectionUpdateRafId = null;
+		}
+		pendingSelectionEvent = null;
+
+		if (clickBlockerTimeoutId !== null) {
+			clearTimeout(clickBlockerTimeoutId);
+			clickBlockerTimeoutId = null;
+		}
+
+		selectionRect.value = {
+			...selectionRect.value,
+			isSelecting: false,
+		};
 		document.body.style.userSelect = "";
 		document.body.style.cursor = "";
 	}
 
-	function updateSelectionRect(ev: MouseEvent) {
+	function getTransformScale(element: HTMLElement): {
+		scaleX: number;
+		scaleY: number;
+	} {
+		const computedStyle = window.getComputedStyle(element);
+		const transform = computedStyle.transform;
+		let scaleX = 1;
+		let scaleY = 1;
+
+		if (transform && transform !== "none") {
+			const matrix = transform.match(/matrix\(([^)]+)\)/);
+			if (matrix) {
+				const values = matrix[1]
+					.split(",")
+					.map((v) => parseFloat(v.trim()));
+				if (values.length >= 4) {
+					scaleX = values[0];
+					scaleY = values[3];
+				}
+			}
+		}
+
+		return { scaleX, scaleY };
+	}
+
+	function convertSelectionRectToScreenCoordinates(
+		wrapper: HTMLElement,
+		selectionRect: {
+			left: number;
+			top: number;
+			width: number;
+			height: number;
+		},
+	): ScreenCoordinates {
+		const wrapperRect = wrapper.getBoundingClientRect();
+		const { scaleX, scaleY } = getTransformScale(wrapper);
+
+		return {
+			left: wrapperRect.left + selectionRect.left * scaleX,
+			top: wrapperRect.top + selectionRect.top * scaleY,
+			right:
+				wrapperRect.left +
+				(selectionRect.left + selectionRect.width) * scaleX,
+			bottom:
+				wrapperRect.top +
+				(selectionRect.top + selectionRect.height) * scaleY,
+		};
+	}
+
+	function updateSelectionRectImpl(ev: MouseEvent) {
 		if (!selectionRect.value.isSelecting) return;
-		if (builderMode.value === "preview") return;
+		if (builderManager.mode.value === "preview") return;
 
 		const wrapper = wrapperRef.value;
 		if (!wrapper) return;
 
 		try {
 			const wrapperRect = wrapper.getBoundingClientRect();
-			const currentX = ev.clientX - wrapperRect.left;
-			const currentY = ev.clientY - wrapperRect.top + wrapper.scrollTop;
+			const { scaleX, scaleY } = getTransformScale(wrapper);
+
+			const currentX = (ev.clientX - wrapperRect.left) / scaleX;
+			const currentY =
+				(ev.clientY - wrapperRect.top) / scaleY + wrapper.scrollTop;
 
 			const { startX, startY } = selectionRect.value;
 			const left = Math.min(startX, currentX);
@@ -105,50 +332,69 @@ export function useDragToSelect(options: UseDragToSelectOptions) {
 		}
 	}
 
-	function handleDocumentMousemove(ev: MouseEvent) {
+	function updateSelectionRect(ev: MouseEvent) {
+		if (!selectionRect.value.isSelecting) return;
+		if (builderManager.mode.value === "preview") return;
+
+		pendingSelectionEvent = ev;
+		if (selectionUpdateRafId === null) {
+			selectionUpdateRafId = requestAnimationFrame(() => {
+				if (pendingSelectionEvent) {
+					updateSelectionRectImpl(pendingSelectionEvent);
+					pendingSelectionEvent = null;
+				}
+				selectionUpdateRafId = null;
+			});
+		}
+	}
+
+	function handleDragSelectionMousemove(ev: MouseEvent) {
 		if (!selectionRect.value.isSelecting) return;
 		updateSelectionRect(ev);
 		ev.preventDefault();
 	}
 
 	function handleMousedown(ev: MouseEvent) {
-		if (builderMode.value === "preview") return;
-		if (isAnnotating.value) return;
+		if (!shouldAllowDragSelection(ev)) {
+			return;
+		}
 
-		if (ev.shiftKey || ev.ctrlKey || ev.metaKey) return;
-
-		if (builderMode.value === "blueprints" && !ev.altKey) return;
+		if (!(ev.target instanceof Element)) return;
 
 		const target = ev.target as HTMLElement;
 
 		const targetEl = target.closest<HTMLElement>("[data-writer-id]");
 		if (targetEl) {
-			if (builderMode.value === "blueprints") {
-				if (!shouldAllowSelectionInBlueprints(target)) return;
+			if (builderManager.mode.value === "blueprints") {
+				const allowed = shouldAllowSelectionInBlueprints(target);
+				if (!allowed) return;
 			} else {
 				return;
 			}
 		}
 
-		const unselectableEl = target.closest<HTMLElement>(
-			"[data-writer-unselectable]",
-		);
-		if (unselectableEl) return;
-
-		if (target.classList.contains("selectionRectangle")) return;
-
-		const wrapper = wrapperRef.value;
-		if (!wrapper) return;
-
-		if (!wrapper.contains(target)) return;
-
-		if (builderMode.value === "blueprints") {
-			if (!isClickOnBlueprintsCanvas(target)) return;
+		if (!isTargetSelectable(target)) {
+			return;
 		}
 
+		const wrapper = wrapperRef.value;
+		if (!wrapper) {
+			return;
+		}
+
+		if (!wrapper.contains(target)) {
+			return;
+		}
+
+		ev.stopPropagation();
+		ev.preventDefault();
+
 		const wrapperRect = wrapper.getBoundingClientRect();
-		const startX = ev.clientX - wrapperRect.left;
-		const startY = ev.clientY - wrapperRect.top + wrapper.scrollTop;
+		const { scaleX, scaleY } = getTransformScale(wrapper);
+
+		const startX = (ev.clientX - wrapperRect.left) / scaleX;
+		const startY =
+			(ev.clientY - wrapperRect.top) / scaleY + wrapper.scrollTop;
 
 		selectionRect.value = {
 			isSelecting: true,
@@ -163,17 +409,15 @@ export function useDragToSelect(options: UseDragToSelectOptions) {
 		document.body.style.userSelect = "none";
 		document.body.style.cursor = "crosshair";
 
-		document.addEventListener("mousemove", handleDocumentMousemove, {
-			signal: dragAbortController.signal,
+		dragMousemoveAbortController = new AbortController();
+		wrapper.addEventListener("mousemove", handleDragSelectionMousemove, {
+			signal: dragMousemoveAbortController.signal,
 		});
-
-		ev.stopPropagation();
-		ev.preventDefault();
 	}
 
 	function handleMousemove(ev: MouseEvent) {
 		if (selectionRect.value.isSelecting) {
-			if (builderMode.value === "blueprints") {
+			if (builderManager.mode.value === "blueprints") {
 				ev.stopPropagation();
 			}
 			updateSelectionRect(ev);
@@ -181,60 +425,26 @@ export function useDragToSelect(options: UseDragToSelectOptions) {
 			return;
 		}
 
-		if (builderMode.value === "preview") return;
-		if (isAnnotating.value) return;
-
-		if (ev.shiftKey || ev.ctrlKey || ev.metaKey) {
-			isHoveringSelectableArea.value = false;
-			return;
-		}
-
-		if (builderMode.value === "blueprints" && !ev.altKey) {
-			isHoveringSelectableArea.value = false;
-			return;
-		}
-
-		const target = ev.target as HTMLElement;
-		const wrapper = wrapperRef.value;
-		if (!wrapper || !wrapper.contains(target)) {
-			isHoveringSelectableArea.value = false;
-			return;
-		}
-
-		const targetEl = target.closest<HTMLElement>("[data-writer-id]");
-		if (targetEl) {
-			if (builderMode.value === "blueprints") {
-				if (!shouldAllowSelectionInBlueprints(target)) {
-					isHoveringSelectableArea.value = false;
-					return;
+		pendingHoverEvent = ev;
+		if (hoverUpdateRafId === null) {
+			hoverUpdateRafId = requestAnimationFrame(() => {
+				if (pendingHoverEvent) {
+					updateHoverState(pendingHoverEvent);
+					pendingHoverEvent = null;
 				}
-			} else {
-				isHoveringSelectableArea.value = false;
-				return;
-			}
+				hoverUpdateRafId = null;
+			});
 		}
-
-		const unselectableEl = target.closest<HTMLElement>(
-			"[data-writer-unselectable]",
-		);
-		if (unselectableEl || target.classList.contains("selectionRectangle")) {
-			isHoveringSelectableArea.value = false;
-			return;
-		}
-
-		if (builderMode.value === "blueprints") {
-			if (!isClickOnBlueprintsCanvas(target)) {
-				isHoveringSelectableArea.value = false;
-				return;
-			}
-		}
-
-		isHoveringSelectableArea.value = true;
 	}
 
 	function handleMouseup(ev: MouseEvent) {
-		if (!selectionRect.value.isSelecting) return;
-		if (builderMode.value === "preview") return;
+		if (!selectionRect.value.isSelecting) {
+			return;
+		}
+		if (builderManager.mode.value === "preview") {
+			cleanupDragSelection();
+			return;
+		}
 
 		const { left, top, width, height } = selectionRect.value;
 
@@ -243,49 +453,34 @@ export function useDragToSelect(options: UseDragToSelectOptions) {
 			return;
 		}
 
+		ev.stopPropagation();
+		ev.preventDefault();
+		ev.stopImmediatePropagation();
+
 		const wrapper = wrapperRef.value;
 		if (!wrapper) {
 			cleanupDragSelection();
 			return;
 		}
 
-		const wrapperRect = wrapper.getBoundingClientRect();
-		const selectionRectAbsolute = {
-			left: wrapperRect.left + left,
-			top: wrapperRect.top + top,
-			right: wrapperRect.left + left + width,
-			bottom: wrapperRect.top + top + height,
-		};
+		const selectionRectAbsolute = convertSelectionRectToScreenCoordinates(
+			wrapper,
+			{ left, top, width, height },
+		);
 
-		const allComponentEls =
-			wrapper.querySelectorAll<HTMLElement>("[data-writer-id]");
-		const selectedComponents: Array<{
-			componentId: string;
-			instancePath: string;
-		}> = [];
-
-		for (const element of Array.from(allComponentEls)) {
-			if (element.closest("[data-writer-unselectable]")) continue;
-
-			const componentRect = element.getBoundingClientRect();
-
-			if (
-				componentRect.left >= selectionRectAbsolute.left &&
-				componentRect.right <= selectionRectAbsolute.right &&
-				componentRect.top >= selectionRectAbsolute.top &&
-				componentRect.bottom <= selectionRectAbsolute.bottom
-			) {
-				const componentId = element.dataset.writerId;
-				const instancePath = element.dataset.writerInstancePath;
-				if (componentId) {
-					selectedComponents.push({ componentId, instancePath });
-				}
-			}
-		}
+		const selectedComponents = findComponentsInSelectionRect(
+			wrapper,
+			selectionRectAbsolute,
+		);
 
 		if (selectedComponents.length > 0) {
-			builderManager.setSelection(null);
-			selectedComponents.forEach(({ componentId, instancePath }) => {
+			const [first, ...rest] = selectedComponents;
+			builderManager.setSelection(
+				first.componentId,
+				first.instancePath,
+				"click",
+			);
+			rest.forEach(({ componentId, instancePath }) => {
 				builderManager.appendSelection(
 					componentId,
 					instancePath,
@@ -293,31 +488,48 @@ export function useDragToSelect(options: UseDragToSelectOptions) {
 				);
 			});
 			justCompletedDragSelection.value = true;
-			setTimeout(() => {
-				justCompletedDragSelection.value = false;
-			}, DRAG_SELECTION_CLICK_DELAY_MS);
+			if (clickBlockerTimeoutId) {
+				clearTimeout(clickBlockerTimeoutId);
+			}
+			nextTick().then(() => {
+				requestAnimationFrame(() => {
+					justCompletedDragSelection.value = false;
+					clickBlockerTimeoutId = null;
+				});
+			});
 		} else {
 			builderManager.setSelection(null);
 		}
 
 		cleanupDragSelection();
-
-		ev.preventDefault();
-		ev.stopPropagation();
-		ev.stopImmediatePropagation();
 	}
 
 	function handleDocumentMouseup(ev: MouseEvent) {
 		if (selectionRect.value.isSelecting) {
 			const wrapper = wrapperRef.value;
-			if (wrapper && wrapper.contains(ev.target as Node)) {
+			if (
+				wrapper &&
+				ev.target instanceof Node &&
+				wrapper.contains(ev.target)
+			) {
 				return;
 			}
 			cleanupDragSelection();
 		}
 	}
 
+	function handleDocumentClick(ev: MouseEvent) {
+		if (justCompletedDragSelection.value) {
+			ev.preventDefault();
+			ev.stopPropagation();
+			ev.stopImmediatePropagation();
+		}
+	}
+
 	onUnmounted(() => {
+		if (clickBlockerTimeoutId) {
+			clearTimeout(clickBlockerTimeoutId);
+		}
 		dragAbortController.abort();
 		cleanupDragSelection();
 	});
@@ -330,12 +542,12 @@ export function useDragToSelect(options: UseDragToSelectOptions) {
 		selectionRect,
 		isCursorSelecting,
 		isHoveringSelectableArea,
-		isSelecting: computed(() => selectionRect.value.isSelecting),
 		justCompletedDragSelection,
 		handleMousedown,
 		handleMousemove,
 		handleMouseup,
 		handleMouseleave,
 		handleDocumentMouseup,
+		handleDocumentClick,
 	};
 }

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -4,6 +4,8 @@
 		class="BlueprintsBlueprint"
 		:class="{
 			isPanning: activeCanvasMove !== null,
+			isSelecting: isCursorSelecting,
+			canSelect: isHoveringSelectableArea && !isCursorSelecting,
 		}"
 		:data-writer-unselectable="isUnselectable"
 		@click="handleClick"
@@ -13,7 +15,14 @@
 		@mousedown="handleMousedown"
 		@mouseup="handleMouseup"
 	>
-		<div ref="nodeContainerEl" class="nodeContainer">
+		<div
+			ref="nodeContainerEl"
+			class="nodeContainer"
+			@mousedown="handleDragToSelectMousedown"
+			@mousemove="handleDragToSelectMousemove"
+			@mouseup="handleDragToSelectMouseup"
+			@mouseleave="handleDragToSelectMouseleave"
+		>
 			<svg class="BlueprintsBlueprint__svg">
 				<defs>
 					<pattern
@@ -90,6 +99,17 @@
 					left: `${(temporaryNodeCoordinates?.[node.id]?.x ?? node.x) - renderOffset.x}px`,
 				}"
 			/>
+			<!-- Selection rectangle overlay -->
+			<div
+				v-if="selectionRect.isSelecting"
+				class="selectionRectangle"
+				:style="{
+					left: `${selectionRect.left}px`,
+					top: `${selectionRect.top}px`,
+					width: `${selectionRect.width}px`,
+					height: `${selectionRect.height}px`,
+				}"
+			></div>
 		</div>
 		<BlueprintToolbar
 			class="blueprintsToolbar"
@@ -202,6 +222,8 @@ import {
 } from "@/utils/geometry";
 import BaseNote from "@/components/core/base/BaseNote.vue";
 import { defineAsyncComponentWithLoader } from "@/utils/defineAsyncComponentWithLoader";
+import { useDragToSelect } from "@/builder/composables/useDragToSelect";
+import { useAbortController } from "@/composables/useAbortController";
 
 const BlueprintToolbar = defineAsyncComponentWithLoader({
 	loader: () => import("./base/BlueprintToolbar.vue"),
@@ -224,6 +246,23 @@ function showAutogen() {
 
 const rootEl = useTemplateRef("rootEl");
 const nodeContainerEl = useTemplateRef("nodeContainerEl");
+
+const {
+	selectionRect,
+	isCursorSelecting,
+	isHoveringSelectableArea,
+	justCompletedDragSelection: _justCompletedDragSelection,
+	handleMousedown: handleDragToSelectMousedown,
+	handleMousemove: handleDragToSelectMousemove,
+	handleMouseup: handleDragToSelectMouseup,
+	handleMouseleave: handleDragToSelectMouseleave,
+	handleDocumentMouseup,
+	handleDocumentClick,
+} = useDragToSelect({
+	wrapperRef: nodeContainerEl,
+	builderManager: wfbm,
+	isAnnotating: notesManager.isAnnotating,
+});
 
 const arrows = shallowRef<BlueprintArrowData[]>([]);
 const renderOffset = shallowRef({ x: 0, y: 0 });
@@ -310,6 +349,12 @@ const isUnselectable = computed(() => {
 });
 
 function handleClick(ev: MouseEvent) {
+	if (_justCompletedDragSelection) {
+		ev.preventDefault();
+		ev.stopPropagation();
+		return;
+	}
+
 	selectedArrow.value = null;
 
 	if (!(ev.target instanceof Element)) return;
@@ -734,11 +779,18 @@ function moveCanvas(ev: MouseEvent) {
 }
 
 function isDragToSelectActive(): boolean {
-	const selectionRect = document.querySelector(".selectionRectangle");
-	return selectionRect !== null;
+	return selectionRect.value.isSelecting;
 }
 
 function handleMousemove(ev: MouseEvent) {
+	// Call drag-to-select handler first (it's also attached to nodeContainerEl)
+	handleDragToSelectMousemove(ev);
+
+	// If drag-to-select is active, don't process other mouse move logic
+	if (isDragToSelectActive()) {
+		return;
+	}
+
 	if (ev.buttons != 1) return;
 
 	if (activeConnection.value) {
@@ -756,6 +808,12 @@ function handleMousemove(ev: MouseEvent) {
 }
 
 function handleMousedown(ev: MouseEvent) {
+	// Drag-to-select is handled directly on nodeContainerEl
+	// This handler is for canvas panning (when not in drag-to-select mode)
+	if (isDragToSelectActive()) {
+		return;
+	}
+
 	clearActiveOperations();
 	if (ev.buttons != 1) return;
 
@@ -770,6 +828,8 @@ function handleMousedown(ev: MouseEvent) {
 }
 
 async function handleMouseup(ev: MouseEvent) {
+	// Drag-to-select is handled directly on nodeContainerEl
+
 	if (activeNodeMove.value) {
 		saveNodeMove();
 	}
@@ -1035,7 +1095,7 @@ function handleKeydown(event: KeyboardEvent) {
 	changeCoordinatesMultipleWithCheck(coordinates);
 }
 
-const abort = new AbortController();
+const abort = useAbortController();
 
 onMounted(async () => {
 	await resetZoom();
@@ -1047,6 +1107,13 @@ onMounted(async () => {
 
 	document.addEventListener("keydown", handleKeydown, {
 		signal: abort.signal,
+	});
+	document.addEventListener("mouseup", handleDocumentMouseup, {
+		signal: abort.signal,
+	});
+	document.addEventListener("click", handleDocumentClick, {
+		signal: abort.signal,
+		capture: true,
 	});
 	arrowRefresherObserver.observe(nodeContainerEl.value, {
 		attributes: true,
@@ -1086,6 +1153,14 @@ onUnmounted(() => {
 	cursor: grabbing;
 }
 
+.BlueprintsBlueprint.isSelecting {
+	cursor: crosshair;
+}
+
+.BlueprintsBlueprint.canSelect {
+	cursor: crosshair;
+}
+
 .blueprintsToolbar {
 	position: absolute;
 	display: flex;
@@ -1123,5 +1198,13 @@ onUnmounted(() => {
 	left: 0;
 	width: 100%;
 	height: 100%;
+}
+
+.selectionRectangle {
+	position: absolute;
+	border: 2px solid var(--builderAccentColor);
+	background: rgba(59, 130, 246, 0.1);
+	pointer-events: none;
+	z-index: 2;
 }
 </style>

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -1195,7 +1195,6 @@ onUnmounted(() => {
 </style>
 
 <style>
-/* Non-scoped styles for selection rectangle to ensure CSS variables are accessible */
 .BlueprintsBlueprint .selectionRectangle {
 	position: absolute;
 	border: 2px solid var(--builderAccentColor, #3b82f6);

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -1192,12 +1192,16 @@ onUnmounted(() => {
 	width: 100%;
 	height: 100%;
 }
+</style>
 
-.selectionRectangle {
+<style>
+/* Non-scoped styles for selection rectangle to ensure CSS variables are accessible */
+.BlueprintsBlueprint .selectionRectangle {
 	position: absolute;
-	border: 2px solid var(--builderAccentColor);
+	border: 2px solid var(--builderAccentColor, #3b82f6);
 	background: rgba(59, 130, 246, 0.1);
 	pointer-events: none;
-	z-index: 2;
+	z-index: 1000;
+	box-sizing: border-box;
 }
 </style>

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -99,7 +99,6 @@
 					left: `${(temporaryNodeCoordinates?.[node.id]?.x ?? node.x) - renderOffset.x}px`,
 				}"
 			/>
-			<!-- Selection rectangle overlay -->
 			<div
 				v-if="selectionRect.isSelecting"
 				class="selectionRectangle"
@@ -783,10 +782,8 @@ function isDragToSelectActive(): boolean {
 }
 
 function handleMousemove(ev: MouseEvent) {
-	// Call drag-to-select handler first (it's also attached to nodeContainerEl)
 	handleDragToSelectMousemove(ev);
 
-	// If drag-to-select is active, don't process other mouse move logic
 	if (isDragToSelectActive()) {
 		return;
 	}
@@ -808,8 +805,6 @@ function handleMousemove(ev: MouseEvent) {
 }
 
 function handleMousedown(ev: MouseEvent) {
-	// Drag-to-select is handled directly on nodeContainerEl
-	// This handler is for canvas panning (when not in drag-to-select mode)
 	if (isDragToSelectActive()) {
 		return;
 	}
@@ -828,8 +823,6 @@ function handleMousedown(ev: MouseEvent) {
 }
 
 async function handleMouseup(ev: MouseEvent) {
-	// Drag-to-select is handled directly on nodeContainerEl
-
 	if (activeNodeMove.value) {
 		saveNodeMove();
 	}

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -349,7 +349,7 @@ const isUnselectable = computed(() => {
 });
 
 function handleClick(ev: MouseEvent) {
-	if (_justCompletedDragSelection) {
+	if (_justCompletedDragSelection.value) {
 		ev.preventDefault();
 		ev.stopPropagation();
 		return;

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -2,6 +2,9 @@
 	<div
 		ref="rootEl"
 		class="BlueprintsBlueprint"
+		:class="{
+			isPanning: activeCanvasMove !== null,
+		}"
 		:data-writer-unselectable="isUnselectable"
 		@click="handleClick"
 		@dragover.prevent.stop
@@ -730,6 +733,11 @@ function moveCanvas(ev: MouseEvent) {
 	);
 }
 
+function isDragToSelectActive(): boolean {
+	const selectionRect = document.querySelector(".selectionRectangle");
+	return selectionRect !== null;
+}
+
 function handleMousemove(ev: MouseEvent) {
 	if (ev.buttons != 1) return;
 
@@ -741,7 +749,7 @@ function handleMousemove(ev: MouseEvent) {
 		moveNode(ev);
 		return;
 	}
-	if (activeCanvasMove.value) {
+	if (activeCanvasMove.value && !isDragToSelectActive()) {
 		moveCanvas(ev);
 		return;
 	}
@@ -1071,6 +1079,11 @@ onUnmounted(() => {
 	align-items: stretch;
 	position: relative;
 	overflow: hidden;
+	cursor: grab;
+}
+
+.BlueprintsBlueprint.isPanning {
+	cursor: grabbing;
 }
 
 .blueprintsToolbar {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-to-select with a visible selection rectangle and cursor feedback (crosshair when selecting; grab/grabbing when panning)
  * Selection overlay and unified click/drag controls across builder and blueprint views

* **Bug Fixes / Improvements**
  * Prevents accidental single-click selection during multi-selection and after incomplete drags
  * More robust hit-testing that respects zoom/scroll and cleans up document-level event handling to avoid errant interactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->