### PR TITLE
fix(ui): remove bindable mode for `wf-tab-change` - AB-279 AB-630

### DIFF
--- a/src/ui/src/components/core/layout/CoreTab.vue
+++ b/src/ui/src/components/core/layout/CoreTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="isVisible" ref="rootEl" class="CoreTab">
+	<div v-show="isVisible" class="CoreTab">
 		<button
 			v-if="isTabBit"
 			class="bit"
@@ -146,8 +146,9 @@ const getMatchingTabInstancePath = () => {
 
 const activateTab = () => {
 	const tabContainerData = getTabContainerData();
-	tabContainerData.value.activeTab = getMatchingTabInstancePath();
-	tabContainerData.value.activeTabName = fields.name.value;
+	tabContainerData.value = {
+		activeTab: getMatchingTabInstancePath(),
+	};
 };
 
 const checkIfTabIsParent = (childId: Component["id"]): boolean => {
@@ -179,13 +180,12 @@ const isTabActive = computed(() => {
 });
 
 onBeforeMount(() => {
-	if (!isTabBit.value) return;
+	if (isTabBit.value) return;
 	const tabContainerData = getTabContainerData();
-	tabContainerData.value.tabs.push({
-		name: fields.name.value,
-		instancePath: getMatchingTabInstancePath(),
-		componentId: componentId,
-	});
+	const activeTab = tabContainerData.value?.activeTab;
+	if (activeTab) return;
+	if (!isComponentVisible(componentId, instancePath)) return;
+	tabContainerData.value = { activeTab: instancePath };
 });
 </script>
 

--- a/src/ui/src/components/core/layout/CoreTab.vue
+++ b/src/ui/src/components/core/layout/CoreTab.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="isVisible" class="CoreTab">
+	<div v-show="isVisible" ref="rootEl" class="CoreTab">
 		<button
 			v-if="isTabBit"
 			class="bit"
@@ -75,10 +75,11 @@ export default {
 };
 </script>
 <script setup lang="ts">
-import { computed, inject, onBeforeMount, watch } from "vue";
+import { computed, inject, onBeforeMount, useTemplateRef, watch } from "vue";
 import injectionKeys from "@/injectionKeys";
 import BaseContainer from "../base/BaseContainer.vue";
 
+const rootEl = useTemplateRef("rootEl");
 const fields = inject(injectionKeys.evaluatedFields);
 const instancePath = inject(injectionKeys.instancePath);
 const instanceData = inject(injectionKeys.instanceData);
@@ -149,6 +150,17 @@ const activateTab = () => {
 	tabContainerData.value = {
 		activeTab: getMatchingTabInstancePath(),
 	};
+
+	if (rootEl.value) {
+		const payload = fields.name.value;
+		const event = new CustomEvent("wf-tab-change", {
+			detail: {
+				payload,
+			},
+			bubbles: true,
+		});
+		rootEl.value.dispatchEvent(event);
+	}
 };
 
 const checkIfTabIsParent = (childId: Component["id"]): boolean => {

--- a/src/ui/src/components/core/layout/CoreTabs.vue
+++ b/src/ui/src/components/core/layout/CoreTabs.vue
@@ -48,7 +48,6 @@ export default {
 				desc: "Sent when the active tab changes.",
 				stub: tabChangeHandlerStub.trim(),
 				eventPayloadExample: "Tab Name",
-				bindable: true,
 			},
 		},
 		fields: {

--- a/src/ui/src/components/core/layout/CoreTabs.vue
+++ b/src/ui/src/components/core/layout/CoreTabs.vue
@@ -1,5 +1,5 @@
 <template>
-	<div ref="rootInstance" class="CoreTabs">
+	<div class="CoreTabs">
 		<nav
 			class="tabSelector horizontal"
 			data-writer-cage
@@ -26,14 +26,6 @@ import {
 	buttonShadow,
 	cssClasses,
 } from "@/renderer/sharedStyleFields";
-import { useFormValueBroker } from "@/renderer/useFormValueBroker";
-
-const tabChangeHandlerStub = `
-def tab_change_handler(state, payload):
-
-	# The payload contains the name of the newly activated tab
-
-	state["active_tab"] = payload`;
 
 const description =
 	"A container component for organising and displaying Tab components in a tabbed interface.";
@@ -44,14 +36,6 @@ export default {
 		description,
 		category: "Layout",
 		allowedChildrenTypes: ["tab", "repeater"],
-		events: {
-			"wf-tab-change": {
-				desc: "Sent when the active tab changes.",
-				stub: tabChangeHandlerStub.trim(),
-				eventPayloadExample: "Tab Name",
-				bindable: true,
-			},
-		},
 		fields: {
 			accentColor,
 			primaryTextColor,
@@ -68,76 +52,11 @@ export default {
 };
 </script>
 <script setup lang="ts">
-import { ComponentPublicInstance, inject, onMounted, ref, watch } from "vue";
-import { useEvaluator } from "@/renderer/useEvaluator";
+import { inject } from "vue";
 import injectionKeys from "@/injectionKeys";
-const rootInstance = ref<ComponentPublicInstance | null>(null);
-const wf = inject(injectionKeys.core);
-const instancePath = inject(injectionKeys.instancePath);
+
 const instanceData = inject(injectionKeys.instanceData);
-const containerState = instanceData.at(-1);
-const { isComponentVisible } = useEvaluator(wf);
-
-const { formValue, handleInput } = useFormValueBroker(
-	wf,
-	instancePath,
-	rootInstance,
-);
-
-containerState.value = {
-	activeTab: undefined,
-	activeTabName: formValue.value,
-	tabs: [],
-};
-
-watch(
-	() => containerState.value?.activeTabName,
-	(activeTabName) => {
-		if (!rootInstance.value) return;
-		if (activeTabName === formValue.value) return;
-		handleInput(activeTabName, "wf-tab-change");
-	},
-);
-
-watch(formValue, (newTabName) => {
-	if (newTabName === containerState.value.activeTabName) return;
-	if (!containerState.value.tabs?.length) return;
-
-	const visibleTabs = containerState.value.tabs.filter((t) =>
-		isComponentVisible(t.componentId, t.instancePath),
-	);
-	if (!visibleTabs.length) return;
-
-	let tabToActivate = visibleTabs.find((t) => t.name === newTabName);
-
-	if (!tabToActivate) {
-		const currentActiveInState = visibleTabs.find(
-			(t) => t.name === containerState.value.activeTabName,
-		);
-		tabToActivate = currentActiveInState ?? visibleTabs[0];
-	}
-
-	containerState.value.activeTab = tabToActivate.instancePath;
-	containerState.value.activeTabName = tabToActivate.name;
-});
-
-onMounted(() => {
-	if (containerState.value.activeTab) return;
-	if (!containerState.value.tabs) return;
-
-	const visibleTabs = containerState.value.tabs.filter((t) =>
-		isComponentVisible(t.componentId, t.instancePath),
-	);
-	if (visibleTabs.length === 0) return;
-
-	const initialActiveTabName = containerState.value.activeTabName;
-	const tabToActivate =
-		visibleTabs.find((t) => t.name === initialActiveTabName) ??
-		visibleTabs[0];
-
-	containerState.value.activeTab = tabToActivate.instancePath;
-	containerState.value.activeTabName = tabToActivate.name;
-});
+instanceData.at(-1).value = { activeTab: undefined };
 </script>
 
 <style scoped>

--- a/src/ui/src/components/core/layout/CoreTabs.vue
+++ b/src/ui/src/components/core/layout/CoreTabs.vue
@@ -27,6 +27,13 @@ import {
 	cssClasses,
 } from "@/renderer/sharedStyleFields";
 
+const tabChangeHandlerStub = `
+def tab_change_handler(state, payload):
+
+	# The payload contains the name of the newly activated tab
+
+	state["active_tab"] = payload`;
+
 const description =
 	"A container component for organising and displaying Tab components in a tabbed interface.";
 
@@ -36,6 +43,14 @@ export default {
 		description,
 		category: "Layout",
 		allowedChildrenTypes: ["tab", "repeater"],
+		events: {
+			"wf-tab-change": {
+				desc: "Sent when the active tab changes.",
+				stub: tabChangeHandlerStub.trim(),
+				eventPayloadExample: "Tab Name",
+				bindable: true,
+			},
+		},
 		fields: {
 			accentColor,
 			primaryTextColor,


### PR DESCRIPTION
revert https://github.com/writer/writer-framework/pull/1149 and keep only the `wf-tab-change` part

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tab activation now emits custom events for change notifications.

* **Bug Fixes**
  * Corrected tab initialization behavior to trigger when tab content is displayed.

* **Refactor**
  * Simplified tab state management and lifecycle handling.
  * Updated event configuration for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->