### PR TITLE
fix(writer): allow empty value for HTTP req - AB-549

### DIFF
--- a/src/writer/blocks/httprequest.py
+++ b/src/writer/blocks/httprequest.py
@@ -30,7 +30,7 @@ class HTTPRequest(BlueprintBlock):
                             },
                             "validator": {
                                 "type": "string",
-                                "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+                                "enum": ["GET", "POST", "PUT", "PATCH", "DELETE", ""],
                             },
                         },
                         "url": {


### PR DESCRIPTION
Fix the validation error bellow 

<img width="616" height="445" alt="image" src="https://github.com/user-attachments/assets/72371589-c9c2-4ef6-9677-83f71818cf14" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation for HTTP method inputs now accepts an empty/unspecified value, reducing unnecessary validation errors and allowing more flexible request configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->