### PR TITLE
fix(writer): set default value for "KV / Action" block - AB-629

### DIFF
--- a/src/writer/blocks/writerkeyvaluestorage.py
+++ b/src/writer/blocks/writerkeyvaluestorage.py
@@ -63,7 +63,7 @@ class WriterKeyValueStorage(WriterBlock):
         from writer.keyvalue_storage import KeyValueStorage
 
         try:
-            action = self._get_field("action", required=True)
+            action = self._get_field("action", default_field_value="Save")
             key = self._get_field("key", required=True)
             if not ALLOWED_CHARS.fullmatch(key):
                 raise ValueError("Key can only contain alphanumeric characters, underscores and hyphens")


### PR DESCRIPTION
<img width="937" height="455" alt="image" src="https://github.com/user-attachments/assets/494410fc-f599-40b4-b309-5ec2a3ad32be" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The action field is now optional and defaults to "Save" when omitted, simplifying usage for common operations.
  * Handling for explicit actions (Save, Get, Delete) is unchanged; unknown actions still produce an error to prevent invalid operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->