### PR TITLE
ci: skip Windows build

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build:
+    if: false
     runs-on: windows-latest
     strategy:
       matrix:


### PR DESCRIPTION
Same as https://github.com/writer/writer-framework/commit/df8f54a9775e29584f62047c14a3bd1117da2511, but for Windows. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled Windows continuous integration pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->