### PR TITLE
fix: chat reply block doesn't show when KGs are configured as tools

### DIFF
--- a/src/ui/src/builder/settings/BuilderFieldsTools.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsTools.vue
@@ -320,13 +320,18 @@ function saveToolForm() {
 		return;
 	}
 
-	fieldViewModel.value = JSON.stringify({
-		...tools.value,
-		...(toolForm.value.originalName
-			? { [toolForm.value.originalName]: undefined }
-			: {}),
-		[toolForm.value.name]: toolFromForm,
-	});
+	const updatedTools = { ...tools.value };
+
+	if (
+		toolForm.value.originalName &&
+		toolForm.value.originalName !== toolForm.value.name
+	) {
+		delete updatedTools[toolForm.value.originalName];
+	}
+
+	updatedTools[toolForm.value.name] = toolFromForm;
+
+	fieldViewModel.value = JSON.stringify(updatedTools);
 
 	toolForm.value.isShown = false;
 }
@@ -386,10 +391,9 @@ function editTool(toolName: string) {
 }
 
 function deleteTool(toolName: string) {
-	fieldViewModel.value = JSON.stringify({
-		...tools.value,
-		[toolName]: undefined,
-	});
+	const updatedTools = { ...tools.value };
+	delete updatedTools[toolName];
+	fieldViewModel.value = JSON.stringify(updatedTools);
 }
 
 const modalActions = computed<ModalAction[]>(() => [

--- a/src/ui/src/builder/settings/BuilderFieldsTools.vue
+++ b/src/ui/src/builder/settings/BuilderFieldsTools.vue
@@ -320,16 +320,15 @@ function saveToolForm() {
 		return;
 	}
 
-	const updatedTools = { ...tools.value };
+	const { originalName, name } = toolForm.value;
+	let updatedTools = { ...tools.value };
 
-	if (
-		toolForm.value.originalName &&
-		toolForm.value.originalName !== toolForm.value.name
-	) {
-		delete updatedTools[toolForm.value.originalName];
+	if (originalName && originalName !== name) {
+		const { [originalName]: _, ...rest } = updatedTools;
+		updatedTools = rest;
 	}
 
-	updatedTools[toolForm.value.name] = toolFromForm;
+	updatedTools[name] = toolFromForm;
 
 	fieldViewModel.value = JSON.stringify(updatedTools);
 
@@ -391,8 +390,7 @@ function editTool(toolName: string) {
 }
 
 function deleteTool(toolName: string) {
-	const updatedTools = { ...tools.value };
-	delete updatedTools[toolName];
+	const { [toolName]: _, ...updatedTools } = { ...tools.value };
 	fieldViewModel.value = JSON.stringify(updatedTools);
 }
 

--- a/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
+++ b/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
@@ -61,17 +61,12 @@
 					display-label
 					@click="$emit('outMousedown', outId)"
 				/>
-				<div
-					v-if="Object.keys(outs).length == 0"
-					class="BlueprintsNode__main__outputs__output BlueprintsNode__main__outputs__empty"
-				>
-					{{
-						def.fields?.[fieldKey]?.type === FieldType.Tools &&
-						hasToolsButNoFunctionTools(fieldKey)
-							? "No outputs"
-							: "None configured."
-					}}
-				</div>
+				<BlueprintsNodeTools
+					:field-key="fieldKey"
+					:field-type="def.fields?.[fieldKey]?.type ?? ''"
+					:field-value="fields[fieldKey]?.value"
+					:has-outputs="Object.keys(outs).length > 0"
+				/>
 			</div>
 			<div
 				v-if="Object.keys(staticOuts).length > 0"
@@ -153,6 +148,8 @@ import { useComponentInformation } from "@/composables/useComponentInformation";
 import BlueprintsNodeActions from "./BlueprintsNodeActions.vue";
 import BlueprintsNodeOutput from "./BlueprintsNodeOutput.vue";
 import BlueprintsNodeLogs from "./BlueprintsNodeLogs.vue";
+import BlueprintsNodeTools from "./BlueprintsNodeTools.vue";
+import { useBlueprintNodeTools } from "@/composables/useBlueprintNodeTools";
 
 const emit = defineEmits(["outMousedown", "engaged"]);
 const wf = inject(injectionKeys.core);
@@ -185,66 +182,10 @@ const completionStyle = computed(() => {
 	return def.value?.outs?.[latestKnownOutcome.value]?.style ?? "success";
 });
 
-type Tool = {
-	type: "function" | "graph" | "web_search";
-	[key: string]: unknown;
-};
-
-type ToolsRecord = Record<string, Tool>;
-
-function parseToolsField(fieldValue: unknown): ToolsRecord {
-	if (!fieldValue) return {};
-
-	if (typeof fieldValue === "string") {
-		try {
-			const parsed = JSON.parse(fieldValue);
-			return typeof parsed === "object" && parsed !== null
-				? (parsed as ToolsRecord)
-				: {};
-		} catch {
-			return {};
-		}
-	}
-
-	if (typeof fieldValue === "object" && fieldValue !== null) {
-		return fieldValue as ToolsRecord;
-	}
-
-	return {};
-}
-
-function hasToolsButNoFunctionTools(fieldKey: string): boolean {
-	const tools = parseToolsField(fields[fieldKey]?.value);
-	const toolKeys = Object.keys(tools);
-	if (toolKeys.length === 0) return false;
-	return !toolKeys.some((key) => tools[key]?.type === "function");
-}
-
-const hasOnlyNonFunctionTools = computed(() => {
-	const toolsFields = Object.entries(def.value.fields ?? {}).filter(
-		([_, field]) => field.type === FieldType.Tools,
-	);
-
-	if (toolsFields.length === 0) return false;
-
-	const parsedTools = toolsFields.map(([fieldKey]) => ({
-		fieldKey,
-		tools: parseToolsField(fields[fieldKey]?.value),
-	}));
-
-	const hasAnyTools = parsedTools.some(
-		({ tools }) => Object.keys(tools).length > 0,
-	);
-
-	if (!hasAnyTools) return false;
-
-	return parsedTools.every(({ tools }) => {
-		const toolKeys = Object.keys(tools);
-		if (toolKeys.length === 0) return true;
-
-		return !toolKeys.some((key) => tools[key]?.type === "function");
-	});
-});
+const { hasOnlyNonFunctionTools } = useBlueprintNodeTools(
+	computed(() => def.value),
+	fields,
+);
 
 const hasDynamicNonToolOutputs = computed(() => {
 	const dynamicOutsEntries = Object.entries(def.value.outs ?? {});
@@ -661,10 +602,6 @@ watch(isEngaged, () => {
 .BlueprintsNode__main__outputs__output {
 	grid-column: 2;
 	text-align: right;
-}
-
-.BlueprintsNode__main__outputs__empty {
-	margin-right: 5px;
 }
 .BlueprintsNode__main__outputs--float {
 	position: absolute;

--- a/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
+++ b/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
@@ -61,7 +61,17 @@
 					display-label
 					@click="$emit('outMousedown', outId)"
 				/>
-				<div v-if="Object.keys(outs).length == 0">None configured.</div>
+				<div
+					v-if="Object.keys(outs).length == 0"
+					class="BlueprintsNode__main__outputs__output BlueprintsNode__main__outputs__empty"
+				>
+					{{
+						def.fields?.[fieldKey]?.type === FieldType.Tools &&
+						hasToolsButNoFunctionTools(fieldKey)
+							? "No outputs"
+							: "None configured."
+					}}
+				</div>
 			</div>
 			<div
 				v-if="Object.keys(staticOuts).length > 0"
@@ -72,10 +82,7 @@
 				}"
 			>
 				<h4
-					v-if="
-						!hasOnlySuccessOut &&
-						Object.keys(dynamicOuts).length > 0
-					"
+					v-if="shouldShowStaticOutLabel"
 					class="BlueprintsNode__main__outputs__title"
 				>
 					{{ staticOutLabel }}
@@ -178,9 +185,88 @@ const completionStyle = computed(() => {
 	return def.value?.outs?.[latestKnownOutcome.value]?.style ?? "success";
 });
 
-const staticOutLabel = computed(() =>
-	component.value?.type === "blueprints_writerclassification" ? "OR" : "THEN",
-);
+type Tool = {
+	type: "function" | "graph" | "web_search";
+	[key: string]: unknown;
+};
+
+type ToolsRecord = Record<string, Tool>;
+
+function parseToolsField(fieldValue: unknown): ToolsRecord {
+	if (!fieldValue) return {};
+
+	if (typeof fieldValue === "string") {
+		try {
+			const parsed = JSON.parse(fieldValue);
+			return typeof parsed === "object" && parsed !== null
+				? (parsed as ToolsRecord)
+				: {};
+		} catch {
+			return {};
+		}
+	}
+
+	if (typeof fieldValue === "object" && fieldValue !== null) {
+		return fieldValue as ToolsRecord;
+	}
+
+	return {};
+}
+
+function hasToolsButNoFunctionTools(fieldKey: string): boolean {
+	const tools = parseToolsField(fields[fieldKey]?.value);
+	const toolKeys = Object.keys(tools);
+	if (toolKeys.length === 0) return false;
+	return !toolKeys.some((key) => tools[key]?.type === "function");
+}
+
+const hasOnlyNonFunctionTools = computed(() => {
+	const toolsFields = Object.entries(def.value.fields ?? {}).filter(
+		([_, field]) => field.type === FieldType.Tools,
+	);
+
+	if (toolsFields.length === 0) return false;
+
+	const parsedTools = toolsFields.map(([fieldKey]) => ({
+		fieldKey,
+		tools: parseToolsField(fields[fieldKey]?.value),
+	}));
+
+	const hasAnyTools = parsedTools.some(
+		({ tools }) => Object.keys(tools).length > 0,
+	);
+
+	if (!hasAnyTools) return false;
+
+	return parsedTools.every(({ tools }) => {
+		const toolKeys = Object.keys(tools);
+		if (toolKeys.length === 0) return true;
+
+		return !toolKeys.some((key) => tools[key]?.type === "function");
+	});
+});
+
+const hasDynamicNonToolOutputs = computed(() => {
+	const dynamicOutsEntries = Object.entries(def.value.outs ?? {});
+	return dynamicOutsEntries.some(([_, out]) => {
+		if (out.style !== "dynamic" || !out.field) return false;
+		const fieldType = def.value.fields?.[out.field]?.type;
+		return fieldType !== FieldType.Tools;
+	});
+});
+
+const staticOutLabel = computed(() => {
+	if (hasDynamicNonToolOutputs.value) return "OR";
+	if (hasOnlyNonFunctionTools.value) return "No outputs";
+	return "THEN";
+});
+
+const shouldShowStaticOutLabel = computed(() => {
+	return (
+		hasOnlyNonFunctionTools.value ||
+		(!hasOnlySuccessOut.value && Object.keys(dynamicOuts.value).length > 0)
+	);
+});
 
 const latestRun = computed(() => {
 	const logEntries = wfbm.getLogEntries();
@@ -574,6 +660,11 @@ watch(isEngaged, () => {
 }
 .BlueprintsNode__main__outputs__output {
 	grid-column: 2;
+	text-align: right;
+}
+
+.BlueprintsNode__main__outputs__empty {
+	margin-right: 5px;
 }
 .BlueprintsNode__main__outputs--float {
 	position: absolute;

--- a/src/ui/src/components/blueprints/abstract/BlueprintsNodeTools.vue
+++ b/src/ui/src/components/blueprints/abstract/BlueprintsNodeTools.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { FieldType } from "@/writerTypes";
+import { parseToolsField } from "@/composables/useBlueprintNodeTools";
+
+const props = defineProps<{
+	fieldKey: string;
+	fieldType: string;
+	fieldValue: unknown;
+	hasOutputs: boolean;
+}>();
+
+const hasToolsButNoFunctionTools = computed(() => {
+	if (props.fieldType !== FieldType.Tools) return false;
+	const tools = parseToolsField(props.fieldValue);
+	const toolKeys = Object.keys(tools);
+	if (toolKeys.length === 0) return false;
+	return !toolKeys.some((key) => tools[key]?.type === "function");
+});
+
+const displayText = computed(() => {
+	if (!props.hasOutputs && hasToolsButNoFunctionTools.value) {
+		return "No outputs";
+	}
+	return "None configured.";
+});
+</script>
+
+<template>
+	<div
+		v-if="!hasOutputs"
+		class="BlueprintsNode__main__outputs__output BlueprintsNode__main__outputs__empty"
+	>
+		{{ displayText }}
+	</div>
+</template>
+
+<style scoped>
+.BlueprintsNode__main__outputs__empty {
+	margin-right: 5px;
+}
+</style>

--- a/src/ui/src/composables/useBlueprintNodeTools.ts
+++ b/src/ui/src/composables/useBlueprintNodeTools.ts
@@ -1,0 +1,73 @@
+import { computed, type ComputedRef } from "vue";
+import { FieldType, WriterComponentDefinition } from "@/writerTypes";
+
+type Tool = {
+	type: "function" | "graph" | "web_search";
+	[key: string]: unknown;
+};
+
+type ToolsRecord = Record<string, Tool>;
+
+export function parseToolsField(fieldValue: unknown): ToolsRecord {
+	if (!fieldValue) return {};
+
+	if (typeof fieldValue === "string") {
+		try {
+			const parsed = JSON.parse(fieldValue);
+			return typeof parsed === "object" && parsed !== null
+				? (parsed as ToolsRecord)
+				: {};
+		} catch {
+			return {};
+		}
+	}
+
+	if (typeof fieldValue === "object") {
+		return fieldValue as ToolsRecord;
+	}
+
+	return {};
+}
+
+export function useBlueprintNodeTools(
+	def: ComputedRef<WriterComponentDefinition | undefined>,
+	fields: Record<string, { value: unknown }>,
+) {
+	const hasOnlyNonFunctionTools = computed(() => {
+		const toolsFields = Object.entries(def.value?.fields ?? {}).filter(
+			([_, field]) => field.type === FieldType.Tools,
+		);
+
+		if (toolsFields.length === 0) return false;
+
+		const parsedTools = toolsFields.map(([fieldKey]) => ({
+			fieldKey,
+			tools: parseToolsField(fields[fieldKey]?.value),
+		}));
+
+		const hasAnyTools = parsedTools.some(
+			({ tools }) => Object.keys(tools).length > 0,
+		);
+
+		if (!hasAnyTools) return false;
+
+		return parsedTools.every(({ tools }) => {
+			const toolKeys = Object.keys(tools);
+			if (toolKeys.length === 0) return true;
+
+			return !toolKeys.some((key) => tools[key]?.type === "function");
+		});
+	});
+
+	function hasToolsButNoFunctionTools(fieldKey: string): boolean {
+		const tools = parseToolsField(fields[fieldKey]?.value);
+		const toolKeys = Object.keys(tools);
+		if (toolKeys.length === 0) return false;
+		return !toolKeys.some((key) => tools[key]?.type === "function");
+	}
+
+	return {
+		hasOnlyNonFunctionTools,
+		hasToolsButNoFunctionTools,
+	};
+}


### PR DESCRIPTION
<img width="530" height="518" alt="Screenshot 2025-11-13 at 16 43 48" src="https://github.com/user-attachments/assets/9adbbfb8-6e32-45fa-9779-d69835555df9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tools-aware output widget and a new utilities hook to detect and render dynamic tool outputs and their labels.

* **Bug Fixes**
  * Improved tool renaming and deletion logic to avoid stale entries and ensure serialized tool state remains consistent.

* **Style**
  * Right-aligned dynamic output items and adjusted spacing for cleaner blueprint output presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->