### PR TITLE
fix(ui): Prevent the socket from being closed during activity - AB-680

### DIFF
--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -181,8 +181,7 @@ const collaborationManager = inject(injectionKeys.collaborationManager);
 const tracking = useWriterTracking(wf);
 const toasts = useToasts();
 
-const socketTimeoutMin = 20 * 60;
-provide(injectionKeys.socketTimeout, useSocketTimeout(wf, socketTimeoutMin));
+provide(injectionKeys.socketTimeout, useSocketTimeout(wf, 10));
 
 const noteEl = useTemplateRef("noteEl");
 

--- a/src/ui/src/builder/useSocketTimeout.test.ts
+++ b/src/ui/src/builder/useSocketTimeout.test.ts
@@ -1,0 +1,141 @@
+import {
+	describe,
+	it,
+	expect,
+	vi,
+	beforeEach,
+	afterEach,
+	MockInstance,
+} from "vitest";
+import { nextTick } from "vue";
+import { useSocketTimeout } from "./useSocketTimeout";
+import { buildMockCore } from "@/tests/mocks";
+
+// Mock dependencies
+vi.mock("@/composables/useLogger", () => ({
+	useLogger: () => ({
+		warn: vi.fn(),
+		log: vi.fn(),
+		info: vi.fn(),
+		error: vi.fn(),
+	}),
+}));
+
+describe("useSocketTimeout", () => {
+	let mockCore: ReturnType<typeof buildMockCore>;
+	let stopSync: MockInstance;
+
+	beforeEach(() => {
+		mockCore = buildMockCore();
+		stopSync = vi.spyOn(mockCore.core, "stopSync");
+		vi.useFakeTimers();
+
+		// Mock document.visibilityState
+		Object.defineProperty(document, "visibilityState", {
+			writable: true,
+			value: "visible",
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("should initialize with correct defaults", () => {
+		const { timeoutMin, socketClosed, reconnecting, prevent } =
+			useSocketTimeout(mockCore.core, 5);
+		expect(timeoutMin).toBe(5);
+		expect(socketClosed.value).toBe(false);
+		expect(reconnecting.value).toBe(false);
+		expect(prevent.value).toBe(false);
+	});
+
+	it("should schedule timeout when tab is hidden and can close socket", async () => {
+		const { schedule, socketClosed } = useSocketTimeout(mockCore.core, 1); // 1 minute
+		changeVisibilityState("hidden");
+		schedule();
+		vi.advanceTimersByTime(60 * 1000);
+		await nextTick();
+		expect(stopSync).toHaveBeenCalled();
+		expect(socketClosed.value).toBe(true);
+	});
+
+	it("should not schedule timeout if prevent is true", () => {
+		const { schedule, prevent, onVisibilityChange } = useSocketTimeout(
+			mockCore.core,
+			1,
+		);
+		prevent.value = true;
+		changeVisibilityState("hidden");
+		onVisibilityChange();
+
+		expect(schedule()).toBe(false);
+	});
+
+	it("should clear schedule when clearSchedule is called", () => {
+		const { schedule, clearSchedule } = useSocketTimeout(mockCore.core, 1);
+		changeVisibilityState("hidden");
+		schedule();
+		expect(vi.getTimerCount()).toBe(1);
+		clearSchedule();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	function changeVisibilityState(visibilityState: string) {
+		// @ts-expect-error mock `visibilityState`
+		document.visibilityState = visibilityState;
+	}
+
+	it("should clear schedule on visibility change to visible", async () => {
+		const { onVisibilityChange } = useSocketTimeout(mockCore.core, 1);
+		changeVisibilityState("hidden");
+		onVisibilityChange();
+		expect(vi.getTimerCount()).toBe(1);
+
+		changeVisibilityState("visible");
+		onVisibilityChange();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("should reschedule on visibility change to hidden if can close socket", async () => {
+		const { socketClosed, onVisibilityChange } = useSocketTimeout(
+			mockCore.core,
+			1,
+		);
+		changeVisibilityState("visible");
+		onVisibilityChange();
+		await nextTick();
+		expect(vi.getTimerCount()).toBe(0);
+
+		changeVisibilityState("hidden");
+		onVisibilityChange();
+
+		expect(vi.getTimerCount()).toBe(1);
+		await nextTick();
+
+		vi.advanceTimersByTime(10 * 60 * 1_000 + 2_000);
+		expect(socketClosed.value).toBe(true);
+	});
+
+	it("should reconnect successfully", async () => {
+		const init = vi.spyOn(mockCore.core, "init");
+		const { reconnect, socketClosed } = useSocketTimeout(mockCore.core, 1);
+		socketClosed.value = true;
+		await reconnect();
+		expect(init).toHaveBeenCalled();
+	});
+
+	it("should watch canCloseSocket and clear/reschedule accordingly", async () => {
+		const { prevent } = useSocketTimeout(mockCore.core, 1);
+		changeVisibilityState("hidden");
+		// Initially can close, so schedule
+		expect(vi.getTimerCount()).toBe(0); // No timer yet
+		prevent.value = true; // Now cannot close
+		await nextTick();
+		expect(vi.getTimerCount()).toBe(0); // Should clear
+		prevent.value = false; // Can close again
+		await nextTick();
+		expect(vi.getTimerCount()).toBe(1); // Should reschedule
+	});
+});

--- a/src/ui/src/builder/useSocketTimeout.test.ts
+++ b/src/ui/src/builder/useSocketTimeout.test.ts
@@ -73,6 +73,30 @@ describe("useSocketTimeout", () => {
 		expect(schedule()).toBe(false);
 	});
 
+	it("should schedule timeout if frontend message exists, but it's collaborationPing", () => {
+		mockCore.frontendMessageMap.value.set(1, { type: "collaborationPing" });
+		const { schedule, onVisibilityChange } = useSocketTimeout(
+			mockCore.core,
+			1,
+		);
+		changeVisibilityState("hidden");
+		onVisibilityChange();
+
+		expect(schedule()).toBe(true);
+	});
+
+	it("should not schedule timeout if frontend message exists", () => {
+		mockCore.frontendMessageMap.value.set(1, { type: "event" });
+		const { schedule, onVisibilityChange } = useSocketTimeout(
+			mockCore.core,
+			1,
+		);
+		changeVisibilityState("hidden");
+		onVisibilityChange();
+
+		expect(schedule()).toBe(false);
+	});
+
 	it("should clear schedule when clearSchedule is called", () => {
 		const { schedule, clearSchedule } = useSocketTimeout(mockCore.core, 1);
 		changeVisibilityState("hidden");

--- a/src/ui/src/builder/useSocketTimeout.ts
+++ b/src/ui/src/builder/useSocketTimeout.ts
@@ -1,7 +1,7 @@
 import { useAbortController } from "@/composables/useAbortController";
 import { useLogger } from "@/composables/useLogger";
 import type { Core } from "@/writerTypes";
-import { ref, onMounted, watch } from "vue";
+import { ref, onMounted, watch, computed } from "vue";
 
 /**
  * @param timeoutMin the inactivity time required to close the socket
@@ -16,23 +16,55 @@ export function useSocketTimeout(wf: Core, timeoutMin: number) {
 	const reconnecting = ref(false);
 	const prevent = ref(false);
 
+	const ignoreMessageType = new Set([
+		"collaborationPing",
+		"listResources",
+		"keepAlive",
+	]);
+
+	const isMessagePending = computed(() => {
+		for (const a of wf.frontendMessageMap.value.values()) {
+			if (!ignoreMessageType.has(a.type)) return true;
+		}
+		return false;
+	});
+
+	const canCloseSocket = computed(
+		() => !prevent.value && !isMessagePending.value,
+	);
+
+	const abort = useAbortController();
+
 	function schedule() {
-		if (document.visibilityState === "visible") return;
+		if (!canCloseSocket.value || document.visibilityState !== "hidden")
+			return false;
 		clearSchedule();
+		logger.log(`[SocketTimeout] planning timeout in ${timeoutMin}min`);
 		timer = setTimeout(() => {
-			logger.warn(`[SocketTimeout] Closing socket after ${timeoutMin} minutes of inactivity (tab hidden)`);
+			if (!canCloseSocket.value) return;
+			logger.warn(
+				`[SocketTimeout] Closing socket after ${timeoutMin} minutes of inactivity (tab hidden)`,
+			);
 			wf.stopSync();
 			socketClosed.value = true;
 			logger.info(`[SocketTimeout] Socket closed`);
 		}, timeoutMs);
+		return true;
 	}
 
 	function clearSchedule() {
-		if (timer) clearTimeout(timer);
+		if (!timer) return;
+		logger.log(`[SocketTimeout] canceling timeout `);
+		clearTimeout(timer);
+		timer = undefined;
 	}
 
-	watch(prevent, () => {
-		if (prevent.value) clearSchedule();
+	watch(canCloseSocket, () => {
+		if (!canCloseSocket.value) {
+			clearSchedule();
+		} else if (document.visibilityState === "hidden") {
+			schedule(); // Reschedule now that activity is complete
+		}
 	});
 
 	async function reconnect() {
@@ -43,27 +75,28 @@ export function useSocketTimeout(wf: Core, timeoutMin: number) {
 			socketClosed.value = false;
 			logger.info(`[SocketTimeout] Socket reconnected successfully`);
 		} catch (error) {
-			logger.error(`[SocketTimeout] Failed to reconnect socket, reloading page`, error);
+			logger.error(
+				`[SocketTimeout] Failed to reconnect socket, reloading page`,
+				error,
+			);
 			window.location.reload(); // fallback to full reload
 		} finally {
 			reconnecting.value = false;
 		}
 	}
 
-	const abort = useAbortController();
+	function onVisibilityChange() {
+		if (document.visibilityState === "visible") {
+			clearSchedule();
+		} else if (canCloseSocket.value) {
+			schedule();
+		}
+	}
 
 	onMounted(() => {
-		document.addEventListener(
-			"visibilitychange",
-			() => {
-				if (document.visibilityState === "visible") {
-					clearSchedule();
-				} else if (!prevent.value) {
-					schedule();
-				}
-			},
-			{ signal: abort.signal },
-		);
+		document.addEventListener("visibilitychange", onVisibilityChange, {
+			signal: abort.signal,
+		});
 	});
 
 	return {
@@ -71,6 +104,7 @@ export function useSocketTimeout(wf: Core, timeoutMin: number) {
 		socketClosed,
 		reconnecting,
 		prevent,
+		onVisibilityChange,
 		clearSchedule,
 		schedule,
 		reconnect,

--- a/src/ui/src/composables/useBlueprintRun.ts
+++ b/src/ui/src/composables/useBlueprintRun.ts
@@ -100,17 +100,14 @@ export function useBlueprintRun(
 	blueprintComponentId: string | Ref<string>,
 ) {
 	const isRunning = ref(false);
-	const socketTimeout = inject(injectionKeys.socketTimeout);
 
 	async function run(branchId?: string) {
 		if (isRunning.value) return;
 		isRunning.value = true;
-		if (socketTimeout) socketTimeout.prevent.value = true;
 		try {
 			await runBlueprint(wf, unref(blueprintComponentId), branchId);
 		} finally {
 			isRunning.value = false;
-			if (socketTimeout) socketTimeout.prevent.value = false;
 		}
 	}
 
@@ -131,7 +128,6 @@ export function useBlueprintsRun(
 	blueprintComponentIds: MaybeRef<BlueprintsRunListItem[]>,
 ) {
 	const runningBlueprintIds = ref<string[]>([]);
-	const socketTimeout = inject(injectionKeys.socketTimeout);
 
 	async function handleRunBlueprint({
 		blueprintId,
@@ -140,7 +136,6 @@ export function useBlueprintsRun(
 		if (runningBlueprintIds.value.includes(blueprintId)) return;
 
 		try {
-			if (socketTimeout) socketTimeout.prevent.value = true;
 			runningBlueprintIds.value = [
 				blueprintId,
 				...runningBlueprintIds.value,
@@ -150,7 +145,6 @@ export function useBlueprintsRun(
 			runningBlueprintIds.value = runningBlueprintIds.value.filter(
 				(id) => id !== blueprintId,
 			);
-			if (socketTimeout) socketTimeout.prevent.value = false;
 		}
 	}
 	async function run() {

--- a/src/ui/src/tests/mocks.ts
+++ b/src/ui/src/tests/mocks.ts
@@ -55,6 +55,10 @@ export function buildMockCore() {
 	core.featureFlags = featureFlags;
 	core.writerApplication = writerApplication;
 	core.mode = mode;
+	const frontendMessageMap = ref<
+		Map<number, { type: string; callback?: Function }>
+	>(new Map());
+	core.frontendMessageMap = frontendMessageMap;
 
 	core.isWriterCloudApp = computed(
 		() => writerApplication.value !== undefined,
@@ -75,6 +79,7 @@ export function buildMockCore() {
 		userFunctions,
 		featureFlags,
 		writerApplication,
+		frontendMessageMap,
 	};
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent socket closing while frontend messages are pending to avoid interrupted updates.
  * Shortened default socket timeout to 10s for faster reconnection and improved responsiveness.
  * Improved connection error/close logging for clearer diagnostics.

* **Chores**
  * Removed a runtime timeout toggle to simplify timeout behavior and make connections more predictable.

* **Tests**
  * Added comprehensive tests for scheduling, visibility handling, reconnection flow, and timer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->