### PR TITLE
fix(app_runner): run reload in executor to prevent blocking event loop - AB-561

### DIFF
--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -1178,12 +1178,23 @@ class AppRunner:
                 
                 if self.observer is not None:
                     logging.info("[Import Debug] Unscheduling file system observer")
-                    self.observer.unschedule_all()
+                    try:
+                        self.observer.unschedule_all()
+                        logging.info("[Import Debug] File system observer unscheduled successfully")
+                    except Exception as e:
+                        logging.error("[Import Debug] Error unscheduling observer: %s", e, exc_info=True)
 
                 self._sync_folders(main_py_dir, self.app_path)
                 logging.info("[Import Debug] Folder sync complete")
+                
+                # Force log flush to ensure we see this even if process crashes
+                import sys
+                sys.stdout.flush()
+                sys.stderr.flush()
 
-                logging.info("[Import Debug] Restarting file system observer")
+                logging.info("[Import Debug] About to restart file system observer - process still alive")
+                sys.stdout.flush()
+                sys.stderr.flush()
                 try:
                     self._start_fs_observer()
                     logging.info("[Import Debug] File system observer restarted successfully")

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -1165,16 +1165,21 @@ class AppRunner:
                 self.bmc_components = self._load_persisted_components()
                 
                 # Run reload in executor to avoid blocking the event loop
-                # This allows the HTTP response to be sent while the app restarts
+                # Use a short timeout to detect failures quickly
                 loop = asyncio.get_event_loop()
                 with concurrent.futures.ThreadPoolExecutor() as executor:
                     try:
-                        await asyncio.wait_for(
-                            loop.run_in_executor(executor, self.reload_code_from_saved),
-                            timeout=10.0
+                        success = await asyncio.wait_for(
+                            loop.run_in_executor(
+                                executor, 
+                                lambda: self.reload_code_from_saved_nonblocking(wait_timeout=5.0)
+                            ),
+                            timeout=8.0  # Outer timeout slightly longer than inner
                         )
+                        if not success:
+                            logging.warning("App process failed to start after import. Check main.py for errors.")
                     except asyncio.TimeoutError:
-                        logging.warning("App process restart timed out after 10 seconds, continuing in background")
+                        logging.warning("App process restart timed out after import, continuing in background")
         except zipfile.BadZipFile:
             raise ValueError("Uploaded file is not a valid ZIP.")
 
@@ -1255,6 +1260,52 @@ class AppRunner:
         if not self.is_app_process_server_ready.is_set():
             return
         self.update_code(None, self.load_persisted_script())
+
+    def reload_code_from_saved_nonblocking(self, wait_timeout: Optional[float] = None) -> bool:
+        """
+        Reloads code from saved files without blocking indefinitely.
+        Used during import to restart the app without hanging on errors.
+        
+        Args:
+            wait_timeout: Maximum seconds to wait for app to be ready. None = don't wait.
+        
+        Returns:
+            True if app started successfully, False otherwise.
+        """
+        if not self.is_app_process_server_ready.is_set():
+            return False
+        
+        try:
+            run_code = self.load_persisted_script()
+            if self.mode != "edit":
+                raise PermissionError("Cannot update code in non-edit mode.")
+            if not self.is_app_process_server_ready.is_set():
+                return False
+            
+            self.run_code = run_code
+            self.source_files = wf_project.build_source_files(self.app_path)
+            self._clean_process()
+            self._start_app_process()
+            
+            if wait_timeout is not None:
+                # Poll with timeout instead of blocking indefinitely
+                elapsed = 0.0
+                poll_interval = 0.1
+                while elapsed < wait_timeout:
+                    if self.is_app_process_server_ready.is_set():
+                        self.queue_announcement("codeUpdate", None)
+                        return True
+                    if self.is_app_process_server_failed.is_set():
+                        return False
+                    threading.Event().wait(poll_interval)
+                    elapsed += poll_interval
+                return False
+            else:
+                # Don't wait at all, just start and return
+                return True
+        except Exception as e:
+            logging.error(f"Error during non-blocking reload: {e}")
+            return False
 
     def update_code(self, session_id: Optional[str], run_code: str) -> None:
         """

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -944,9 +944,14 @@ class AppRunner:
                 contents = f.read()
             return contents
         except FileNotFoundError as error:
-            logger.error("Couldn't find %s in the path provided: %s.", file, self.app_path)
+            error_msg = f"Couldn't find {file} in the path provided: {self.app_path}"
+            logger.error(error_msg)
             if file == "main.py":
-                sys.exit(1)
+                # Don't use sys.exit() - raise exception so it can be caught and handled
+                if self.mode == "run":
+                    sys.exit(1)
+                else:
+                    raise ValueError(error_msg) from error
             else:
                 raise error
 
@@ -968,8 +973,13 @@ class AppRunner:
             wf_project.create_default_blueprints_root(self.app_path)
 
         if not os.path.isdir(os.path.join(self.app_path, ".wf")):
-            logger.error("Couldn't find .wf in the path provided: %s.", self.app_path)
-            sys.exit(1)
+            error_msg = f"Couldn't find .wf directory in the path provided: {self.app_path}"
+            logger.error(error_msg)
+            # Don't use sys.exit() - raise exception so it can be caught and handled
+            if self.mode == "run":
+                sys.exit(1)
+            else:
+                raise ValueError(error_msg)
 
         _, components = wf_project.read_files(self.app_path)
         components = audit_and_fix.fix_components(components)
@@ -1174,30 +1184,49 @@ class AppRunner:
                 logging.info("[Import Debug] Folder sync complete")
 
                 logging.info("[Import Debug] Restarting file system observer")
-                self._start_fs_observer()
+                try:
+                    self._start_fs_observer()
+                    logging.info("[Import Debug] File system observer restarted successfully")
+                except Exception as e:
+                    logging.error("[Import Debug] Failed to start file system observer: %s", e, exc_info=True)
+                    raise
                 
                 logging.info("[Import Debug] Loading persisted components")
-                self.bmc_components = self._load_persisted_components()
+                try:
+                    self.bmc_components = self._load_persisted_components()
+                    logging.info("[Import Debug] Loaded %d components", len(self.bmc_components) if self.bmc_components else 0)
+                except Exception as e:
+                    logging.error("[Import Debug] Failed to load persisted components: %s", e, exc_info=True)
+                    raise
                 
                 # Run reload in executor to avoid blocking the event loop
                 # Use a short timeout to detect failures quickly
                 logging.info("[Import Debug] Starting async reload process")
-                loop = asyncio.get_event_loop()
-                with concurrent.futures.ThreadPoolExecutor() as executor:
-                    try:
-                        success = await asyncio.wait_for(
-                            loop.run_in_executor(
-                                executor, 
-                                lambda: self.reload_code_from_saved_nonblocking(wait_timeout=5.0)
-                            ),
-                            timeout=8.0  # Outer timeout slightly longer than inner
-                        )
-                        if not success:
-                            logging.warning("[Import Debug] App process failed to start after import. Check main.py for errors.")
-                        else:
-                            logging.info("[Import Debug] App process started successfully")
-                    except asyncio.TimeoutError:
-                        logging.warning("[Import Debug] App process restart timed out after import, continuing in background")
+                try:
+                    loop = asyncio.get_event_loop()
+                    logging.info("[Import Debug] Got event loop, creating executor")
+                    with concurrent.futures.ThreadPoolExecutor() as executor:
+                        logging.info("[Import Debug] Executor created, submitting reload task")
+                        try:
+                            success = await asyncio.wait_for(
+                                loop.run_in_executor(
+                                    executor, 
+                                    lambda: self.reload_code_from_saved_nonblocking(wait_timeout=5.0)
+                                ),
+                                timeout=8.0  # Outer timeout slightly longer than inner
+                            )
+                            if not success:
+                                logging.warning("[Import Debug] App process failed to start after import. Check main.py for errors.")
+                            else:
+                                logging.info("[Import Debug] App process started successfully")
+                        except asyncio.TimeoutError:
+                            logging.warning("[Import Debug] App process restart timed out after import, continuing in background")
+                        except Exception as e:
+                            logging.error("[Import Debug] Exception during reload task execution: %s", e, exc_info=True)
+                            raise
+                except Exception as e:
+                    logging.error("[Import Debug] Exception in async reload process setup: %s", e, exc_info=True)
+                    raise
                 
                 logging.info("[Import Debug] Import completed successfully")
         except zipfile.BadZipFile as e:

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -1300,6 +1300,15 @@ class AppRunner:
         self._clean_process()
 
     def _start_app_process(self) -> None:
+        """Starts app process and waits (blocking) for it to be ready."""
+        self._start_app_process_nonblocking()
+        self.is_app_process_server_ready.wait()
+        if self.mode == "run" and self.is_app_process_server_failed.is_set():
+            self.shut_down()
+            sys.exit(1)
+    
+    def _start_app_process_nonblocking(self) -> None:
+        """Starts app process without waiting for it to be ready."""
         if self.run_code is None:
             raise ValueError("Cannot start app process. Code hasn't been set.")
         if self.bmc_components is None:
@@ -1331,10 +1340,6 @@ class AppRunner:
             self.response_events,
         )
         self.app_process_listener.start()
-        self.is_app_process_server_ready.wait()
-        if self.mode == "run" and self.is_app_process_server_failed.is_set():
-            self.shut_down()
-            sys.exit(1)
 
     def reload_code_from_saved(self) -> None:
         if not self.is_app_process_server_ready.is_set():
@@ -1369,8 +1374,9 @@ class AppRunner:
             logging.info("[Import Debug] Cleaning existing process")
             self._clean_process()
             
-            logging.info("[Import Debug] Starting new app process")
-            self._start_app_process()
+            logging.info("[Import Debug] Starting new app process (non-blocking)")
+            self._start_app_process_nonblocking()
+            logging.info("[Import Debug] App process started, not waiting for ready signal yet")
             
             if wait_timeout is not None:
                 # Poll with timeout instead of blocking indefinitely

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -1130,42 +1130,58 @@ class AppRunner:
                     shutil.rmtree(dst_dir)
 
     async def import_zip(self, zip_path: str):
+        logging.info("[Import Debug] Starting import_zip, mode=%s", self.mode)
+        
         if self.mode != "edit":
+            logging.error("[Import Debug] Import rejected - not in edit mode")
             raise PermissionError("Cannot import in non-edit mode.")
 
         try:
+            logging.info("[Import Debug] Creating temporary directory for extraction")
             with tempfile.TemporaryDirectory() as tmpdir:
                 extracted_path = os.path.join(tmpdir, "imported_agent")
                 os.makedirs(extracted_path, exist_ok=True)
+                
+                logging.info("[Import Debug] Extracting zip file: %s", zip_path)
                 with zipfile.ZipFile(zip_path, "r") as zip_ref:
                     zip_ref.extractall(extracted_path)
 
+                logging.info("[Import Debug] Searching for main.py in extracted files")
                 main_py_dir = None
                 for root, _, files in os.walk(extracted_path):
                     if "main.py" in files:
                         main_py_dir = root
+                        logging.info("[Import Debug] Found main.py at: %s", root)
                         break
 
                 if main_py_dir is None:
+                    logging.error("[Import Debug] main.py not found in archive")
                     raise ValueError("main.py not found in the imported archive.")
 
                 wf_dir_path = os.path.join(main_py_dir, ".wf")
                 if not os.path.isdir(wf_dir_path):
+                    logging.error("[Import Debug] .wf directory not found at: %s", wf_dir_path)
                     raise ValueError(".wf directory not found alongside main.py in the archive.")
 
                 # Passed all checks; replace current app contents
-
-                logging.info("Copying app at %s", main_py_dir)
+                logging.info("[Import Debug] Validation passed, copying app from %s to %s", main_py_dir, self.app_path)
+                
                 if self.observer is not None:
+                    logging.info("[Import Debug] Unscheduling file system observer")
                     self.observer.unschedule_all()
 
                 self._sync_folders(main_py_dir, self.app_path)
+                logging.info("[Import Debug] Folder sync complete")
 
+                logging.info("[Import Debug] Restarting file system observer")
                 self._start_fs_observer()
+                
+                logging.info("[Import Debug] Loading persisted components")
                 self.bmc_components = self._load_persisted_components()
                 
                 # Run reload in executor to avoid blocking the event loop
                 # Use a short timeout to detect failures quickly
+                logging.info("[Import Debug] Starting async reload process")
                 loop = asyncio.get_event_loop()
                 with concurrent.futures.ThreadPoolExecutor() as executor:
                     try:
@@ -1177,11 +1193,19 @@ class AppRunner:
                             timeout=8.0  # Outer timeout slightly longer than inner
                         )
                         if not success:
-                            logging.warning("App process failed to start after import. Check main.py for errors.")
+                            logging.warning("[Import Debug] App process failed to start after import. Check main.py for errors.")
+                        else:
+                            logging.info("[Import Debug] App process started successfully")
                     except asyncio.TimeoutError:
-                        logging.warning("App process restart timed out after import, continuing in background")
-        except zipfile.BadZipFile:
+                        logging.warning("[Import Debug] App process restart timed out after import, continuing in background")
+                
+                logging.info("[Import Debug] Import completed successfully")
+        except zipfile.BadZipFile as e:
+            logging.error("[Import Debug] BadZipFile error: %s", e)
             raise ValueError("Uploaded file is not a valid ZIP.")
+        except Exception as e:
+            logging.error("[Import Debug] Unexpected exception in import_zip: %s", e, exc_info=True)
+            raise
 
     def _clean_process(self) -> None:
         # Terminate the AppProcess server by sending an empty message
@@ -1272,39 +1296,49 @@ class AppRunner:
         Returns:
             True if app started successfully, False otherwise.
         """
-        if not self.is_app_process_server_ready.is_set():
-            return False
+        logging.info(f"[Import Debug] Starting non-blocking reload, wait_timeout={wait_timeout}")
         
         try:
+            logging.info("[Import Debug] Loading persisted script")
             run_code = self.load_persisted_script()
-            if self.mode != "edit":
-                raise PermissionError("Cannot update code in non-edit mode.")
-            if not self.is_app_process_server_ready.is_set():
-                return False
             
+            if self.mode != "edit":
+                logging.error("[Import Debug] Cannot reload - not in edit mode")
+                raise PermissionError("Cannot update code in non-edit mode.")
+            
+            logging.info("[Import Debug] Building source files")
             self.run_code = run_code
             self.source_files = wf_project.build_source_files(self.app_path)
+            
+            logging.info("[Import Debug] Cleaning existing process")
             self._clean_process()
+            
+            logging.info("[Import Debug] Starting new app process")
             self._start_app_process()
             
             if wait_timeout is not None:
                 # Poll with timeout instead of blocking indefinitely
+                logging.info(f"[Import Debug] Waiting up to {wait_timeout}s for app to be ready")
                 elapsed = 0.0
                 poll_interval = 0.1
                 while elapsed < wait_timeout:
                     if self.is_app_process_server_ready.is_set():
+                        logging.info("[Import Debug] App process is ready!")
                         self.queue_announcement("codeUpdate", None)
                         return True
                     if self.is_app_process_server_failed.is_set():
+                        logging.warning("[Import Debug] App process failed to start")
                         return False
                     threading.Event().wait(poll_interval)
                     elapsed += poll_interval
+                logging.warning(f"[Import Debug] Timeout after {wait_timeout}s waiting for app to be ready")
                 return False
             else:
                 # Don't wait at all, just start and return
+                logging.info("[Import Debug] Not waiting for app to be ready, returning immediately")
                 return True
         except Exception as e:
-            logging.error(f"Error during non-blocking reload: {e}")
+            logging.error(f"[Import Debug] Exception during non-blocking reload: {e}", exc_info=True)
             return False
 
     def update_code(self, session_id: Optional[str], run_code: str) -> None:

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -1163,7 +1163,18 @@ class AppRunner:
 
                 self._start_fs_observer()
                 self.bmc_components = self._load_persisted_components()
-                self.reload_code_from_saved()
+                
+                # Run reload in executor to avoid blocking the event loop
+                # This allows the HTTP response to be sent while the app restarts
+                loop = asyncio.get_event_loop()
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    try:
+                        await asyncio.wait_for(
+                            loop.run_in_executor(executor, self.reload_code_from_saved),
+                            timeout=10.0
+                        )
+                    except asyncio.TimeoutError:
+                        logging.warning("App process restart timed out after 10 seconds, continuing in background")
         except zipfile.BadZipFile:
             raise ValueError("Uploaded file is not a valid ZIP.")
 

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -769,8 +769,22 @@ class AppRunner:
         self.log_listener.start()
 
     def _start_fs_observer(self):
+        # If observer exists but isn't alive, we need to recreate it
+        # (can't restart a stopped PollingObserver)
+        if self.observer is not None and not self.observer.is_alive():
+            logging.info("[Observer Debug] Stopping dead observer before recreating")
+            try:
+                self.observer.stop()
+                self.observer.join(timeout=2.0)
+            except Exception as e:
+                logging.warning("[Observer Debug] Error stopping dead observer: %s", e)
+            self.observer = None
+        
         if self.observer is None:
+            logging.info("[Observer Debug] Creating new PollingObserver")
             self.observer = PollingObserver(AppRunner.UPDATE_CHECK_INTERVAL_SECONDS)
+        
+        logging.info("[Observer Debug] Scheduling file event handler for path: %s", self.app_path)
         self.observer.schedule(
             FileEventHandler(self.reload_code_from_saved, patterns=["*.py"]),
             path=self.app_path,
@@ -782,7 +796,11 @@ class AppRunner:
         #     path=self.app_path,
         # )
         if not self.observer.is_alive():
+            logging.info("[Observer Debug] Starting observer")
             self.observer.start()
+            logging.info("[Observer Debug] Observer started successfully")
+        else:
+            logging.info("[Observer Debug] Observer already alive, not restarting")
 
     def _start_wf_project_process_write_files(self):
         wf_project.start_process_write_files_async(
@@ -1186,21 +1204,19 @@ class AppRunner:
 
                 self._sync_folders(main_py_dir, self.app_path)
                 logging.info("[Import Debug] Folder sync complete")
+                logging.info("[Import Debug] Observer state before restart: %s, alive=%s", 
+                            self.observer, 
+                            self.observer.is_alive() if self.observer else "N/A")
                 
-                # Force log flush to ensure we see this even if process crashes
-                import sys
-                sys.stdout.flush()
-                sys.stderr.flush()
-
-                logging.info("[Import Debug] About to restart file system observer - process still alive")
-                sys.stdout.flush()
-                sys.stderr.flush()
                 try:
+                    logging.info("[Import Debug] Starting file system observer (may fail on second import)")
                     self._start_fs_observer()
-                    logging.info("[Import Debug] File system observer restarted successfully")
+                    logging.info("[Import Debug] File system observer restarted successfully, alive=%s",
+                                self.observer.is_alive() if self.observer else "N/A")
                 except Exception as e:
-                    logging.error("[Import Debug] Failed to start file system observer: %s", e, exc_info=True)
-                    raise
+                    logging.error("[Import Debug] CRITICAL: Failed to start file system observer: %s", e, exc_info=True)
+                    # Don't raise - continue with import even if observer fails
+                    logging.warning("[Import Debug] Continuing import without file system observer")
                 
                 logging.info("[Import Debug] Loading persisted components")
                 try:

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -1182,10 +1182,22 @@ def _mount_render_index_html(app: FastAPI, server_static_path: pathlib.Path):
     def _render_index_html():
         with io.open(server_static_path.joinpath("index.html"), "r", encoding="utf-8") as f:
             index_html = f.read()
+            index_html = index_html.replace(
+                "<title>Writer</title>",
+                "<title>BANANA</title>",
+            )
+            index_html = index_html.replace(
+                "<title>Writer Framework</title>",
+                "<title>BANANA</title>",
+            )
             if hasattr(app.state, "title"):
                 index_html = index_html.replace(
                     "<title>Writer Framework</title>",
-                    f"<title>{html.escape(app.state.title)}</title>",
+                    "<title>BANANA</title>",
+                )
+                index_html = index_html.replace(
+                    "<title>Writer</title>",
+                    "<title>BANANA</title>",
                 )
 
             if hasattr(app.state, "meta"):

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -277,6 +277,7 @@ def get_asgi_app(
                 tmp_path = tmp.name
             await app_runner.import_zip(tmp_path)
             os.remove(tmp_path)
+            return {"status": "success", "message": "Import completed successfully"}
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid upload.")
 

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -262,6 +262,7 @@ def get_asgi_app(
             raise HTTPException(status_code=400, detail="Only .zip files are supported.")
 
         MAX_FILE_SIZE = 200 * 1024 * 1024
+        tmp_path = None
 
         try:
             with tempfile.NamedTemporaryFile(delete=False) as tmp:
@@ -276,10 +277,20 @@ def get_asgi_app(
                     tmp.write(chunk)
                 tmp_path = tmp.name
             await app_runner.import_zip(tmp_path)
-            os.remove(tmp_path)
             return {"status": "success", "message": "Import completed successfully"}
-        except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid upload.")
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=f"Invalid upload: {str(e)}")
+        except PermissionError as e:
+            raise HTTPException(status_code=403, detail=str(e))
+        except Exception as e:
+            logging.error(f"Unexpected error during import: {e}")
+            raise HTTPException(status_code=500, detail=f"Import failed: {str(e)}")
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                try:
+                    os.remove(tmp_path)
+                except Exception:
+                    pass
 
     @app.post("/api/autogen")
     async def autogen(requestBody: AutogenRequestBody, request: Request):

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -256,15 +256,22 @@ def get_asgi_app(
 
     @app.post("/api/import")
     async def import_zip(file: UploadFile = File(...)):
+        import traceback
+        
+        logging.info("[Import Debug] Received import request, filename=%s", file.filename)
+        
         if serve_mode != "edit":
+            logging.error("[Import Debug] Rejected - serve_mode is '%s', not 'edit'", serve_mode)
             raise HTTPException(status_code=403, detail="Invalid mode.")
         if not file.filename or not file.filename.endswith(".zip"):
+            logging.error("[Import Debug] Rejected - invalid filename: %s", file.filename)
             raise HTTPException(status_code=400, detail="Only .zip files are supported.")
 
         MAX_FILE_SIZE = 200 * 1024 * 1024
         tmp_path = None
 
         try:
+            logging.info("[Import Debug] Creating temporary file for upload")
             with tempfile.NamedTemporaryFile(delete=False) as tmp:
                 # Stream file to disk to avoid memory issues
                 size = 0
@@ -273,24 +280,38 @@ def get_asgi_app(
                     if size > MAX_FILE_SIZE:
                         tmp.close()
                         os.unlink(tmp.name)
+                        logging.error("[Import Debug] File too large: %d bytes", size)
                         raise HTTPException(status_code=413, detail=f"File too large. Max file size: {MAX_FILE_SIZE}")
                     tmp.write(chunk)
                 tmp_path = tmp.name
+            
+            logging.info("[Import Debug] File saved to temp path: %s (size: %d bytes)", tmp_path, size)
+            logging.info("[Import Debug] Calling app_runner.import_zip")
+            
             await app_runner.import_zip(tmp_path)
+            
+            logging.info("[Import Debug] app_runner.import_zip completed successfully")
             return {"status": "success", "message": "Import completed successfully"}
         except ValueError as e:
+            logging.error("[Import Debug] ValueError: %s", e, exc_info=True)
             raise HTTPException(status_code=400, detail=f"Invalid upload: {str(e)}")
         except PermissionError as e:
+            logging.error("[Import Debug] PermissionError: %s", e, exc_info=True)
             raise HTTPException(status_code=403, detail=str(e))
+        except HTTPException:
+            # Re-raise HTTP exceptions without modification
+            raise
         except Exception as e:
-            logging.error(f"Unexpected error during import: {e}")
+            error_details = traceback.format_exc()
+            logging.error(f"[Import Debug] Unexpected exception in endpoint handler:\n{error_details}")
             raise HTTPException(status_code=500, detail=f"Import failed: {str(e)}")
         finally:
             if tmp_path and os.path.exists(tmp_path):
                 try:
+                    logging.info("[Import Debug] Cleaning up temp file: %s", tmp_path)
                     os.remove(tmp_path)
-                except Exception:
-                    pass
+                except Exception as cleanup_error:
+                    logging.warning("[Import Debug] Failed to clean up temp file: %s", cleanup_error)
 
     @app.post("/api/autogen")
     async def autogen(requestBody: AutogenRequestBody, request: Request):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import reliability with non-blocking reloads, timeouts, safer cleanup of temp uploads, and expanded error handling and logging.

* **New Features**
  * Import endpoint now returns an explicit success status and message upon completion; asynchronous reloads report readiness or timeout.

* **UI Changes**
  * App page title is now fixed to "BANANA" across rendered pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->