### PR TITLE
feat(ui): prevent socket to be closed after a background job - AB-714

### DIFF
--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -189,7 +189,9 @@ const collaborationManager = inject(injectionKeys.collaborationManager);
 const tracking = useWriterTracking(wf);
 const toasts = useToasts();
 
-provide(injectionKeys.socketTimeout, useSocketTimeout(wf, 10));
+const SOCKET_TIMEOUT_MIN =
+	Number(localStorage.getItem("socketTimeoutMin")) || 10;
+provide(injectionKeys.socketTimeout, useSocketTimeout(wf, SOCKET_TIMEOUT_MIN));
 
 const noteEl = useTemplateRef("noteEl");
 const rendererEl = useTemplateRef("rendererEl");

--- a/src/ui/src/builder/useSocketTimeout.test.ts
+++ b/src/ui/src/builder/useSocketTimeout.test.ts
@@ -10,6 +10,7 @@ import {
 import { nextTick } from "vue";
 import { useSocketTimeout } from "./useSocketTimeout";
 import { buildMockCore } from "@/tests/mocks";
+import { flushPromises } from "@vue/test-utils";
 
 // Mock dependencies
 vi.mock("@/composables/useLogger", () => ({
@@ -89,7 +90,7 @@ describe("useSocketTimeout", () => {
 		expect(schedule()).toBe(true);
 	});
 
-	it("should not schedule timeout if frontend message exists", () => {
+	it("should not schedule timeout if frontend message exists", async () => {
 		mockCore.frontendMessageMap.value.set(1, { type: "event" });
 		const { schedule, onVisibilityChange } = useSocketTimeout(
 			mockCore.core,
@@ -99,6 +100,12 @@ describe("useSocketTimeout", () => {
 		onVisibilityChange();
 
 		expect(schedule()).toBe(false);
+		expect(vi.getTimerCount()).toBe(0);
+
+		// even if the task finished in background
+		mockCore.frontendMessageMap.value.clear();
+		await flushPromises();
+		expect(vi.getTimerCount()).toBe(0);
 	});
 
 	it("should clear schedule when clearSchedule is called", () => {

--- a/src/ui/src/builder/useSocketTimeout.ts
+++ b/src/ui/src/builder/useSocketTimeout.ts
@@ -12,6 +12,7 @@ const WEBSOCKET_INACTIVITY_CLOSE_CODE = 4000;
 export function useSocketTimeout(wf: Core, timeoutMin: number) {
 	const timeoutMs = timeoutMin * 60 * 1_000;
 	const logger = useLogger();
+	const abort = useAbortController();
 
 	let timer = undefined;
 
@@ -51,8 +52,6 @@ export function useSocketTimeout(wf: Core, timeoutMin: number) {
 		() => !prevent.value && !isMessagePending.value,
 	);
 
-	const abort = useAbortController();
-
 	function schedule() {
 		if (!canCloseSocket.value || document.visibilityState !== "hidden")
 			return false;
@@ -77,6 +76,7 @@ export function useSocketTimeout(wf: Core, timeoutMin: number) {
 		timer = undefined;
 	}
 
+	// cancel closing socket timer
 	watch(canCloseSocket, () => {
 		if (!canCloseSocket.value) {
 			clearSchedule();
@@ -84,6 +84,8 @@ export function useSocketTimeout(wf: Core, timeoutMin: number) {
 			schedule(); // Reschedule now that activity is complete
 		}
 	});
+
+	// reflect `preventTasks` changes in session storage
 	watch(
 		preventTasks,
 		() => {
@@ -91,6 +93,17 @@ export function useSocketTimeout(wf: Core, timeoutMin: number) {
 		},
 		{ deep: true },
 	);
+
+	// prevent closing socket when blueprint finish in background
+	watch(isMessagePending, (hasPending, hadPending) => {
+		const hadCompletedJob = hadPending && !hasPending;
+		if (hadCompletedJob && document.visibilityState === "hidden") {
+			logger.log(
+				`[SocketTimeout] Preventing socket to be closed due to finished task in background...`,
+			);
+			preventTasks.value.add("pendingMessageInBackground");
+		}
+	});
 
 	async function reconnect() {
 		logger.info(`[SocketTimeout] Attempting to reconnect socket...`);
@@ -112,6 +125,7 @@ export function useSocketTimeout(wf: Core, timeoutMin: number) {
 
 	function onVisibilityChange() {
 		if (document.visibilityState === "visible") {
+			preventTasks.value.delete("pendingMessageInBackground");
 			clearSchedule();
 		} else if (canCloseSocket.value) {
 			schedule();


### PR DESCRIPTION
We want to avoid the user to lose state after a long running blueprint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Socket timeout is now configurable via local storage with a default fallback value.
  * Session persistence for task prevention settings.

* **Bug Fixes**
  * Improved detection and handling of background job completion while the page is hidden.

* **Tests**
  * Enhanced test coverage for socket timeout behavior and visibility changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->