### PR TITLE
fix: wait for release to propagate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -145,7 +145,7 @@ jobs:
                 echo "Version $VERSION is now available"
 
     trigger-agent-manager:
-        needs: wait-for-pypi
+        needs: [build, wait-for-pypi]
         if: github.ref_name == 'dev'
         uses: ./.github/workflows/trigger-workflow.yml
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,8 +118,34 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    trigger-agent-manager:
+    wait-for-pypi:
         needs: build
+        if: github.ref_name == 'dev'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Wait for PyPI propagation
+              run: |
+                VERSION=${{ needs.build.outputs.version }}
+                echo "Waiting for writer==$VERSION to be available..."
+
+                MAX_RETRIES=20
+                SLEEP_SECONDS=15
+                COUNT=0
+
+                until pip install --no-deps "writer==$VERSION" --dry-run; do
+                    COUNT=$((COUNT + 1))
+                    if [ $COUNT -ge $MAX_RETRIES ]; then
+                        echo "Timeout waiting for PyPI propagation. Version $VERSION still not available."
+                        exit 0
+                    fi
+                    echo "Version $VERSION not yet available, retrying in $SLEEP_SECONDS seconds..."
+                    sleep $SLEEP_SECONDS
+                done
+
+                echo "Version $VERSION is now available"
+
+    trigger-agent-manager:
+        needs: wait-for-pypi
         if: github.ref_name == 'dev'
         uses: ./.github/workflows/trigger-workflow.yml
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to add a validation step that waits for the published package version to be available in the package registry before continuing.
  * Ensures downstream processes only run after the version is confirmed and forwards release tag/version details to the downstream workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->