### PR TITLE
fix(ui): send `keepAlive` message only when needed - AB-714

### DIFF
--- a/src/ui/src/builder/useSocketTimeout.ts
+++ b/src/ui/src/builder/useSocketTimeout.ts
@@ -78,6 +78,8 @@ export function useSocketTimeout(wf: Core, timeoutMin: number) {
 
 	// cancel closing socket timer
 	watch(canCloseSocket, () => {
+		wf.skipKeepAliveSocketMsg.value = canCloseSocket.value;
+
 		if (!canCloseSocket.value) {
 			clearSchedule();
 		} else if (document.visibilityState === "hidden") {

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -87,6 +87,8 @@ export function generateCore() {
 
 	const activePageId = ref<Component["id"] | undefined>();
 
+	const skipKeepAliveSocketMsg = ref(false);
+
 	const writerOrgId = computed(
 		() => Number(writerApplication.value?.organizationId) || undefined,
 	);
@@ -185,7 +187,11 @@ export function generateCore() {
 
 	function sendKeepAliveMessage() {
 		setTimeout(() => {
-			sendFrontendMessage("keepAlive", {}, sendKeepAliveMessage);
+			if (skipKeepAliveSocketMsg.value) {
+				sendKeepAliveMessage();
+			} else {
+				sendFrontendMessage("keepAlive", {}, sendKeepAliveMessage);
+			}
 		}, KEEP_ALIVE_DELAY_MS);
 	}
 
@@ -962,6 +968,7 @@ export function generateCore() {
 		featureFlags: readonly(featureFlags),
 		getWebSocket,
 		stopSync,
+		skipKeepAliveSocketMsg,
 		// writer cloud variables
 		writerApplication: readonly(writerApplication),
 		isWriterCloudApp,


### PR DESCRIPTION
In https://github.com/WriterInternal/be.agent-manager/pull/203 , I'm updating activity time on `keepAlive` socket message. So we need to make sure that we are sending `keepAlive` only when `canCloseSocket` is false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Feature**
  * Added a toggle to control sending of keep-alive/socket heartbeat messages.

* **Refactor**
  * Updated socket management so the new toggle stays in sync with connection-close logic, giving finer control over keep-alive behavior and improving connection stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->