### PR TITLE
fix: don't save nested executions separately

### DIFF
--- a/src/ui/src/builder/BuilderJournal.vue
+++ b/src/ui/src/builder/BuilderJournal.vue
@@ -51,6 +51,7 @@ import { Component, WriterComponentDefinition } from "@/writerTypes";
 import injectionKeys from "@/injectionKeys";
 import type { JournalFilters } from "./journal/journalTypes";
 import { useComponentActions } from "./useComponentActions";
+import { JsonData } from "@/components/shared/SharedJsonViewer/SharedJsonViewer.vue";
 
 defineOptions({
 	name: "BuilderJournal",
@@ -69,23 +70,28 @@ type ComponentInfo = {
 	type: string;
 	id: string;
 	title: string;
+	category?: string;
 };
 type TriggerInfo = {
 	type: "On demand" | "UI" | "API" | "Cron";
 	event: string;
 	component: ComponentInfo;
-	payload: unknown;
+	payload: JsonData;
 };
 
-type BlockOutput = {
-	result: unknown;
+type BlockExecution = {
+	result: JsonData;
 	outcome: string;
-	component?: ComponentInfo | null;
 	startedAt?: number;
 	executionTimeInSeconds?: number;
 	stdout?: string;
 	logs?: string;
 	message?: string;
+};
+
+export type BlockOutput = {
+	component?: ComponentInfo | null;
+	executions: BlockExecution[];
 };
 
 export type RawJournalEntry = {

--- a/src/ui/src/builder/journal/BuilderJournalBlockOutput.vue
+++ b/src/ui/src/builder/journal/BuilderJournalBlockOutput.vue
@@ -1,5 +1,9 @@
 <template>
-	<div class="BuilderJournalBlockOutput" :class="rootClass">
+	<div
+		v-if="firstExecution"
+		class="BuilderJournalBlockOutput"
+		:class="rootClass"
+	>
 		<div
 			class="BuilderJournalBlockOutput__header"
 			:role="blockId ? 'button' : undefined"
@@ -37,21 +41,24 @@
 		</div>
 		<div class="BuilderJournalBlockOutput__meta">
 			<div class="BuilderJournalBlockOutput__status">
-				<span>Outcome: {{ output.outcome }}</span>
+				<span>Outcome: {{ firstExecution.outcome }}</span>
 			</div>
 			<div
 				v-if="
-					output.startedAt !== undefined ||
-					output.executionTimeInSeconds !== undefined
+					firstExecution.startedAt !== undefined ||
+					firstExecution.executionTimeInSeconds !== undefined
 				"
 				class="BuilderJournalBlockOutput__timing"
 			>
-				<span v-if="output.startedAt !== undefined">
-					Started: {{ formatTimestamp(output.startedAt) }}
+				<span v-if="firstExecution.startedAt !== undefined">
+					Started:
+					{{ formatTimestamp(firstExecution.startedAt) }}
 				</span>
-				<span v-if="output.executionTimeInSeconds !== undefined">
+				<span
+					v-if="firstExecution.executionTimeInSeconds !== undefined"
+				>
 					Duration:
-					{{ formatDuration(output.executionTimeInSeconds) }}
+					{{ formatDuration(firstExecution.executionTimeInSeconds) }}
 				</span>
 			</div>
 		</div>
@@ -68,31 +75,31 @@
 		<div class="BuilderJournalBlockOutput__tab-content">
 			<!-- Error Details Tab -->
 			<div
-				v-if="output.message && activeTab === 'error'"
+				v-if="firstExecution.message && activeTab === 'error'"
 				class="BuilderJournalBlockOutput__message"
 			>
 				<div class="BuilderJournalBlockOutput__message-content">
-					{{ output.message }}
+					{{ firstExecution.message }}
 				</div>
 			</div>
 
 			<!-- Stdout Tab -->
 			<div
-				v-if="output.stdout && activeTab === 'stdout'"
+				v-if="firstExecution.stdout && activeTab === 'stdout'"
 				class="BuilderJournalBlockOutput__log-section"
 			>
 				<pre class="BuilderJournalBlockOutput__log-content">{{
-					output.stdout
+					firstExecution.stdout
 				}}</pre>
 			</div>
 
 			<!-- Logs Tab -->
 			<div
-				v-if="output.logs && activeTab === 'logs'"
+				v-if="firstExecution.logs && activeTab === 'logs'"
 				class="BuilderJournalBlockOutput__log-section"
 			>
 				<pre class="BuilderJournalBlockOutput__log-content">{{
-					output.logs
+					firstExecution.logs
 				}}</pre>
 			</div>
 
@@ -102,7 +109,7 @@
 				class="BuilderJournalBlockOutput__result-section"
 			>
 				<SharedJsonViewer
-					:data="output.result"
+					:data="firstExecution.result"
 					is-root
 					is-root-open
 					enable-copy-to-json
@@ -119,21 +126,7 @@ import WdsTabs from "@/wds/WdsTabs.vue";
 import SharedImgWithFallback from "@/components/shared/SharedImgWithFallback.vue";
 import SharedJsonViewer from "@/components/shared/SharedJsonViewer/SharedJsonViewer.vue";
 import { convertAbsolutePathtoFullURL } from "@/utils/url";
-
-type BlockOutput = {
-	result: unknown;
-	outcome: string;
-	message?: string;
-	stdout?: string;
-	logs?: string;
-	startedAt?: number;
-	executionTimeInSeconds?: number;
-	component?: {
-		type?: string;
-		title?: string;
-		category?: string;
-	} | null;
-};
+import { BlockOutput } from "../BuilderJournal.vue";
 
 const props = defineProps({
 	blockId: { type: String, required: true },
@@ -145,19 +138,22 @@ defineEmits<{
 	"go-to-block": [blockId: string];
 }>();
 
+const firstExecution = computed(() => props.output.executions?.[0]);
 const activeTab = ref<string>("");
 
 // Build tabs based on available data
 const blockTabs = computed(() => {
+	if (!firstExecution.value) return [];
+
 	const tabs = [];
 
-	if (props.output.message) {
+	if (firstExecution.value.message) {
 		tabs.push({ label: "Error", value: "error" });
 	}
-	if (props.output.stdout) {
+	if (firstExecution.value.stdout) {
 		tabs.push({ label: "Stdout", value: "stdout" });
 	}
-	if (props.output.logs) {
+	if (firstExecution.value.logs) {
 		tabs.push({ label: "Logs", value: "logs" });
 	}
 	tabs.push({ label: "Result", value: "result" });
@@ -206,7 +202,7 @@ const rootClassByOutcome: Record<string, string> = {
 
 const rootClass = computed(
 	() =>
-		rootClassByOutcome[props.output.outcome] ||
+		rootClassByOutcome[firstExecution.value.outcome] ||
 		"BuilderJournalBlockOutput--success",
 );
 

--- a/src/ui/src/builder/journal/BuilderJournalEntryDetails.vue
+++ b/src/ui/src/builder/journal/BuilderJournalEntryDetails.vue
@@ -95,8 +95,8 @@ const blockOutputsArray = computed(() => {
 	const entries = Object.entries(props.entry.blockOutputs);
 	// Sort by startedAt timestamp (earliest first, missing timestamps go to bottom)
 	return entries.sort((a, b) => {
-		const timeA = a[1].startedAt ?? Infinity;
-		const timeB = b[1].startedAt ?? Infinity;
+		const timeA = a[1].executions?.[0]?.startedAt ?? Infinity;
+		const timeB = b[1].executions?.[0]?.startedAt ?? Infinity;
 		return timeA - timeB;
 	});
 });

--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -8,13 +8,13 @@ import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import contextmanager
 from contextvars import ContextVar, copy_context
-from typing import Any, Dict, Generator, List, Literal, Optional, OrderedDict, Union
+from typing import Any, Dict, Generator, List, Literal, Optional, Union
 
 import writer.blocks
 import writer.blocks.base_block
 import writer.core
 import writer.core_ui
-from writer.journal import JournalRecord
+from writer.journal import use_journal_record_context
 from writer.ss_types import BlueprintExecutionError, BlueprintExecutionLog, WriterConfigurationError
 
 MAX_DAG_DEPTH = 32
@@ -750,68 +750,61 @@ class GraphRunner:
                 return self._execute(executor, event)
 
     def _execute(self, executor: ThreadPoolExecutor, abort_event: threading.Event) -> Optional[Any]:
-        journal_record = JournalRecord(
-            execution_environment=self.execution_environment,
-            title=self.status_logger.title,
-            graph=self.graph
-        )
+        with use_journal_record_context(self.execution_environment, self.status_logger.title, self.graph) as journal_record:
+            while self.queue or self.futures:
+                while self.queue:
+                    node: GraphNode = self.queue.pop(0)
+                    if node.can_run() and node.outcome is None:
+                        self.futures.append(node.run(self.execution_environment, self.runner, executor))
 
-        while self.queue or self.futures:
-            while self.queue:
-                node: GraphNode = self.queue.pop(0)
-                if node.can_run() and node.outcome is None:
-                    self.futures.append(node.run(self.execution_environment, self.runner, executor))
+                self.status_logger.log("Executing...")
+                done, _ = wait(self.futures, timeout=self.CANCELATION_CHECK_INTERVAL, return_when=FIRST_COMPLETED)
+                if not done:
+                    if abort_event.is_set():
+                        self._cancel_all_jobs()
+                        self.status_logger.log("Terminated.", entry_type="info", exit="aborted")
+                        journal_record.set_result("stopped")
+                        return None
+                    else:
+                        continue
+                self.status_logger.log("Executing...")
+                for future in done:
+                    if future in self.futures:
+                        self.futures.remove(future)
+                    try:
+                        result_node: GraphNode = future.result()
+                    except BlueprintExecutionError as e:
+                        self._cancel_all_jobs()
+                        self.status_logger.log("Execution failed", entry_type="error", exit=str(e))
+                        raise e
+                    except BaseException as e:
+                        abort_event.set()
+                        self._cancel_all_jobs()
+                        self.status_logger.log("Execution failed.", entry_type="error", exit=str(e))
+                        raise BlueprintExecutionError(
+                            f"Blueprint execution was stopped due to an error - {e.__class__.__name__}: {e}"
+                        ) from e 
+                    if result_node.outcome == "stopped":
+                        continue 
+                    if result_node.return_value is not None:
+                        self._cancel_local_jobs()
+                        self.status_logger.log(
+                            f"Execution completed, node {result_node.id} returned value: {result_node.return_value}",
+                            entry_type="info",
+                            exit="return"
+                        )
+                        
+                        journal_record.set_result("success")
+                        return result_node.return_value
+                    for output in result_node.outputs:
+                        to_node_id = output.get("toNodeId")
+                        next_node = self.graph.get_node(to_node_id)
+                        if next_node:
+                            self.queue.append(next_node)
 
-            self.status_logger.log("Executing...")
-            done, _ = wait(self.futures, timeout=self.CANCELATION_CHECK_INTERVAL, return_when=FIRST_COMPLETED)
-            if not done:
-                if abort_event.is_set():
-                    self._cancel_all_jobs()
-                    self.status_logger.log("Terminated.", entry_type="info", exit="aborted")
-                    journal_record.save(result="stopped")
-                    return None
-                else:
-                    continue
-            self.status_logger.log("Executing...")
-            for future in done:
-                if future in self.futures:
-                    self.futures.remove(future)
-                try:
-                    result_node: GraphNode = future.result()
-                except BlueprintExecutionError as e:
-                    self._cancel_all_jobs()
-                    self.status_logger.log("Execution failed", entry_type="error", exit=str(e))
-                    journal_record.save(result="error")
-                    raise e
-                except BaseException as e:
-                    abort_event.set()
-                    self._cancel_all_jobs()
-                    self.status_logger.log("Execution failed.", entry_type="error", exit=str(e))
-                    journal_record.save(result="error")
-                    raise BlueprintExecutionError(
-                        f"Blueprint execution was stopped due to an error - {e.__class__.__name__}: {e}"
-                    ) from e 
-                if result_node.outcome == "stopped":
-                    continue 
-                if result_node.return_value is not None:
-                    self._cancel_local_jobs()
-                    self.status_logger.log(
-                        f"Execution completed, node {result_node.id} returned value: {result_node.return_value}",
-                        entry_type="info",
-                        exit="return"
-                    )
-                    
-                    journal_record.save(result="success")
-                    return result_node.return_value
-                for output in result_node.outputs:
-                    to_node_id = output.get("toNodeId")
-                    next_node = self.graph.get_node(to_node_id)
-                    if next_node:
-                        self.queue.append(next_node)
-
-        self.status_logger.log("Execution completed.", entry_type="info", exit="completed")
-        journal_record.save(result="success")
-        return None
+            self.status_logger.log("Execution completed.", entry_type="info", exit="completed")
+            journal_record.set_result("success")
+            return None
 
     def _cancel_local_jobs(self):
         self.queue.clear()

--- a/src/writer/journal.py
+++ b/src/writer/journal.py
@@ -1,14 +1,17 @@
+import contextlib
 import json
 import logging
+from contextvars import ContextVar
+from copy import deepcopy
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Dict, Literal
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional
 
 import writer.abstract
 from writer.core import Config
 from writer.keyvalue_storage import writer_kv_storage
 
 if TYPE_CHECKING:
-    from writer.blueprints import Graph
+    from writer.blueprints import Graph, GraphNode
     from writer.core import Component
 
 
@@ -33,6 +36,7 @@ class JournalRecord:
         # All nodes in a blueprint share the same parent blueprint component
         self.blueprint_id = graph.nodes[0].component.parentId if graph.nodes else None
 
+        self.execution_environment = execution_environment
         self.trigger = {
             "event": execution_environment.get("context", {}).get("event"),
             "payload": execution_environment.get("payload"),
@@ -61,12 +65,26 @@ class JournalRecord:
             self.trigger["type"] = "On demand"
 
         self.graph = graph
+        self.block_outputs: Dict[str, Any] = {}
+        for graph_node in self.graph.nodes:
+            block_info = self._get_block_info(graph_node.component)
+            self.block_outputs[graph_node.id] = {
+                "component": {
+                    "type": graph_node.component.type,
+                    "id": graph_node.component.id,
+                    "title": block_info["title"],
+                    "category": block_info["category"]
+                },
+                "executions": []
+            }
+
         self.is_runable = True
+        self.result: Optional[Literal["success", "error", "stopped"]] = None
 
     def _get_block_info(self, component: "Component") -> Dict[str, str]:
         block_title = component.content.get("alias")
         component_definition = writer.abstract.templates.get(component.type)
-        
+
         # If component has an alias, use it as title
         if block_title is not None:
             category = "Unknown category"
@@ -76,7 +94,7 @@ class JournalRecord:
                 "title": block_title,
                 "category": category
             }
-        
+
         # If no component definition found, return defaults
         if component_definition is None:
             return {
@@ -91,39 +109,9 @@ class JournalRecord:
         }
 
     def to_dict(self) -> Dict[str, Any]:
-        block_outputs = {}
+        block_outputs = deepcopy(self.block_outputs)
         for graph_node in self.graph.nodes:
-            block_info = self._get_block_info(graph_node.component)
-            block_data: Dict[str, Any] = {
-                "result": graph_node.result,
-                "outcome": graph_node.outcome,
-                "component": {
-                    "type": graph_node.component.type,
-                    "id": graph_node.component.id,
-                    "title": block_info["title"],
-                    "category": block_info["category"]
-                }
-            }
-            
-            # Add timing information if available
-            if graph_node.tool:
-                if hasattr(graph_node.tool, 'started_at') and graph_node.tool.started_at >= 0:
-                    block_data["startedAt"] = graph_node.tool.started_at
-                if hasattr(graph_node.tool, 'execution_time_in_seconds') and graph_node.tool.execution_time_in_seconds >= 0:
-                    block_data["executionTimeInSeconds"] = graph_node.tool.execution_time_in_seconds
-                
-                # Add captured logs if available
-                if hasattr(graph_node.tool, 'captured_stdout') and graph_node.tool.captured_stdout:
-                    block_data["stdout"] = graph_node.tool.captured_stdout
-                if hasattr(graph_node.tool, 'captured_logs') and graph_node.tool.captured_logs:
-                    block_data["logs"] = graph_node.tool.captured_logs
-                
-                # Add error message if available (contains the traceback for errors)
-                if hasattr(graph_node.tool, 'message') and graph_node.tool.message:
-                    block_data["message"] = graph_node.tool.message
-            
-            block_outputs[graph_node.id] = block_data
-        
+            block_outputs[graph_node.id]["executions"].append(self.get_execution_data(graph_node))
 
         data = {
             "timestamp": self.started_at.isoformat(),
@@ -131,12 +119,38 @@ class JournalRecord:
             "blueprintId": self.blueprint_id,
             "trigger": self.trigger,
             "blockOutputs": block_outputs,
+            "result": self.result,
         }
         sanitized_data = self._sanitize_data(data)
         return {
             **sanitized_data,
             "isRunable": self.is_runable,
         }
+
+    def get_execution_data(self, graph_node: "GraphNode") -> Dict[str, Any]:
+        execution_data: Dict[str, Any] = {
+            "result": graph_node.result,
+            "outcome": graph_node.outcome,
+        }
+
+        # Add timing information if available
+        if graph_node.tool:
+            if hasattr(graph_node.tool, 'started_at') and graph_node.tool.started_at >= 0:
+                execution_data["startedAt"] = graph_node.tool.started_at
+            if hasattr(graph_node.tool, 'execution_time_in_seconds') and graph_node.tool.execution_time_in_seconds >= 0:
+                execution_data["executionTimeInSeconds"] = graph_node.tool.execution_time_in_seconds
+
+            # Add captured logs if available
+            if hasattr(graph_node.tool, 'captured_stdout') and graph_node.tool.captured_stdout:
+                execution_data["stdout"] = graph_node.tool.captured_stdout
+            if hasattr(graph_node.tool, 'captured_logs') and graph_node.tool.captured_logs:
+                execution_data["logs"] = graph_node.tool.captured_logs
+
+            # Add error message if available (contains the traceback for errors)
+            if hasattr(graph_node.tool, 'message') and graph_node.tool.message:
+                execution_data["message"] = graph_node.tool.message
+
+        return execution_data
 
     def _sanitize_data(self, data):
         if data is None:
@@ -161,9 +175,53 @@ class JournalRecord:
     def construct_key(self) -> str:
         return f"{JOURNAL_KEY_PREFIX}{self.instance_type[0]}-{int(self.started_at.timestamp() * 1000)}"
     
-    def save(self, result: Literal["success", "error", "stopped"]) -> None:
+    def set_result(self, result: Literal["success", "error", "stopped"]) -> None:
+        self.result = result
+
+    def add_nested_execution(self, nested_record: "JournalRecord") -> None:
+        for graph_node in nested_record.graph.nodes:
+            if graph_node.id not in self.block_outputs:
+                self.block_outputs[graph_node.id] = nested_record.block_outputs[graph_node.id]
+            self.block_outputs[graph_node.id]["executions"].append(nested_record.get_execution_data(graph_node))
+    
+    def save(self) -> None:
         if "journal" not in Config.feature_flags or not writer_kv_storage.is_accessible():
             return
         data = self.to_dict()
-        data["result"] = result
         writer_kv_storage.save(self.construct_key(), data)
+
+
+_parent_journal_record: ContextVar[Optional[JournalRecord]] = ContextVar("parent_journal_record", default=None)
+_current_journal_record: ContextVar[Optional[JournalRecord]] = ContextVar("current_journal_record", default=None)
+
+@contextlib.contextmanager
+def use_journal_record_context(
+    execution_environment: Dict,
+    title: str,
+    graph: "Graph"
+):
+    parent_record = _parent_journal_record.get()
+    current_record = JournalRecord(execution_environment, title, graph)
+    _current_journal_record.set(current_record)
+    if parent_record is None:
+        _parent_journal_record.set(current_record)
+
+    try:
+        yield current_record
+    except BaseException as e:
+        current_record.set_result("error")
+        raise e
+    finally:
+        _current_journal_record.set(None)
+        if parent_record is not None:
+            parent_record.add_nested_execution(current_record)
+        else:
+            try:
+                current_record.save()
+            except Exception:
+                logger.exception("Failed to save a Journal entry")
+            _parent_journal_record.set(None)
+
+
+def get_current_journal_record() -> Optional[JournalRecord]:
+    return _current_journal_record.get()

--- a/tests/backend/test_journal.py
+++ b/tests/backend/test_journal.py
@@ -41,28 +41,36 @@ class TestJournal:
             },
             "blockOutputs": {
                 "qfqpqmjdpzuu8fe9": {
-                    "result": {"proposedSessionId": None},
-                    "outcome": "trigger",
                     "component": {
                         "type": "blueprints_apitrigger",
                         "id": "qfqpqmjdpzuu8fe9",
                         "title": "API alias",
                         "category": "Triggers",
                     },
-                    "startedAt": ANY,
-                    "executionTimeInSeconds": ANY,
+                    "executions": [
+                        {
+                            "result": {"proposedSessionId": None},
+                            "outcome": "trigger",
+                            "startedAt": ANY,
+                            "executionTimeInSeconds": ANY,
+                        }
+                    ],
                 },
                 "pa448833kc2pis3a": {
-                    "result": "AAA",
-                    "outcome": "success",
                     "component": {
                         "type": "blueprints_logmessage",
                         "id": "pa448833kc2pis3a",
                         "title": "Log message",
                         "category": "Other",
                     },
-                    "startedAt": ANY,
-                    "executionTimeInSeconds": ANY,
+                    "executions": [
+                        {
+                            "result": "AAA",
+                            "outcome": "success",
+                            "startedAt": ANY,
+                            "executionTimeInSeconds": ANY,
+                        }
+                    ],
                 },
             },
             "isRunable": True,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Per-block outputs now preserve multiple executions and expose a public BlockOutput type; UI displays the first execution (status, timing, logs, stdout, message, result).
  * Component metadata gains an optional category and trigger payloads are treated as structured JSON.
  * Journal records include execution_environment and aggregate nested executions for consolidated reporting.

* **Bug Fixes**
  * Block ordering now sorts by the first execution start time.
  * Journal lifecycle uses a context-managed flow for consistent stopped/success recording.

* **Tests**
  * Tests updated to reflect execution arrays replacing prior top-level timing/result fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->