### PR TITLE
feat: AB-755 | Add frontend publishing and settings

### DIFF
--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -372,10 +372,21 @@ function handleRendererDrop(ev: DragEvent) {
 	ssbm.setSelection(null);
 	const dropInfo = dropComponent(ev);
 	if (!dropInfo) return;
-	const { draggedType, draggedId, parentId, position } = dropInfo;
+	const { draggedType, draggedId, parentId, position, dragContent } =
+		dropInfo;
 
 	if (!draggedId) {
-		createAndInsertComponent(draggedType, parentId, position);
+		// Pass dragContent as initial content for the component
+		const initProperties =
+			Object.keys(dragContent).length > 0
+				? { content: dragContent as Record<string, string> }
+				: undefined;
+		createAndInsertComponent(
+			draggedType,
+			parentId,
+			position,
+			initProperties,
+		);
 	} else {
 		moveComponent(draggedId, parentId, position);
 	}

--- a/src/ui/src/builder/settings/BuilderSettings.vue
+++ b/src/ui/src/builder/settings/BuilderSettings.vue
@@ -41,7 +41,7 @@
 			class="BuilderSettings__titleBar"
 		>
 			<p class="BuilderSettings__titleBar__title">
-				{{ componentDefinition.name }}
+				{{ displayName }}
 			</p>
 			<div class="BuilderSettings__titleBar__actions">
 				<WdsButton
@@ -110,6 +110,7 @@ import BuilderSettingsAddComponentModal from "./BuilderSettingsAddComponentModal
 import { useComponentInformation } from "@/composables/useComponentInformation";
 import { useBlueprintComponentResultId } from "@/composables/useBlueprintComponentResultId";
 import { useElementClientHeight } from "@/composables/useComponentClientHeight";
+import { getSourceBlueprintName } from "@/builder/useComponentDescription";
 
 const wf = inject(injectionKeys.core);
 const ssbm = inject(injectionKeys.builderManager);
@@ -127,6 +128,15 @@ const { component, definition: componentDefinition } = useComponentInformation(
 	ssbm.firstSelectedId,
 );
 const resultId = useBlueprintComponentResultId(component, componentDefinition);
+
+const displayName = computed(() => {
+	if (!component.value) return "Unknown";
+	return (
+		getSourceBlueprintName(wf, component.value) ||
+		componentDefinition.value?.name ||
+		"Unknown"
+	);
+});
 
 const { copy, copied: isComponentIdCopied } = useClipboard();
 

--- a/src/ui/src/builder/settings/BuilderSettingsDeploySharedBlueprint.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsDeploySharedBlueprint.vue
@@ -1,0 +1,267 @@
+<template>
+	<WdsModal
+		v-if="isOpen"
+		:actions="modalActions"
+		title="Publish Blueprint"
+		display-close-button
+		@close="handleClose"
+	>
+		<div class="DeploySharedBlueprint">
+			<!-- Version info -->
+			<div
+				v-if="currentVersion"
+				class="DeploySharedBlueprint__versionInfo"
+			>
+				<WdsIcon name="package" />
+				<span
+					>Currently published:
+					<strong>v{{ currentVersion }}</strong></span
+				>
+			</div>
+			<div v-else class="DeploySharedBlueprint__versionInfo">
+				<WdsIcon name="package" />
+				<span>Not yet published</span>
+			</div>
+
+			<WdsFieldWrapper label="Name" required>
+				<WdsTextInput
+					v-model="form.name"
+					placeholder="e.g., Data Fetch Pipeline"
+					:error="errors.name"
+					@update:model-value="handleNameChange"
+				/>
+			</WdsFieldWrapper>
+
+			<WdsFieldWrapper label="Description" required>
+				<textarea
+					v-model="form.description"
+					placeholder="Describe what this shared blueprint does"
+					class="DeploySharedBlueprint__textarea"
+					:class="{
+						'DeploySharedBlueprint__textarea--error':
+							errors.description,
+					}"
+				/>
+			</WdsFieldWrapper>
+		</div>
+	</WdsModal>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, inject } from "vue";
+import WdsModal, { ModalAction } from "@/wds/WdsModal.vue";
+import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
+import WdsTextInput from "@/wds/WdsTextInput.vue";
+import WdsIcon from "@/wds/WdsIcon.vue";
+import injectionKeys from "@/injectionKeys";
+import { useToasts } from "@/builder/useToast";
+import { useComponentActions } from "@/builder/useComponentActions";
+import { useWriterTracking } from "@/composables/useWriterTracking";
+
+const wf = inject(injectionKeys.core);
+const wfbm = inject(injectionKeys.builderManager);
+const { pushToast } = useToasts();
+const { setContentValue } = useComponentActions(wf, wfbm);
+const tracking = useWriterTracking(wf);
+
+const props = defineProps<{
+	modelValue: boolean;
+	blueprintId: string;
+}>();
+
+const emit = defineEmits<{
+	"update:modelValue": [value: boolean];
+}>();
+
+const isOpen = computed({
+	get: () => props.modelValue,
+	set: (value) => emit("update:modelValue", value),
+});
+
+const blueprint = computed(() => wf.getComponentById(props.blueprintId));
+
+const currentVersion = computed(
+	() => blueprint.value?.content?.deployedVersion || null,
+);
+
+const blueprintName = computed(
+	() => blueprint.value?.content?.key || "Shared Blueprint",
+);
+
+const blueprintDescription = computed(
+	() => blueprint.value?.content?.deployedDescription || "",
+);
+
+const form = ref({
+	name: "",
+	description: "",
+});
+
+const errors = ref<Record<string, string>>({});
+const isDeploying = ref(false);
+
+function validateForm(): boolean {
+	errors.value = {};
+
+	if (!form.value.name.trim()) {
+		errors.value.name = "Name is required";
+	}
+	if (!form.value.description.trim()) {
+		errors.value.description = "Description is required";
+	}
+
+	return Object.keys(errors.value).length === 0;
+}
+
+// Sync name changes back to blueprint key
+function handleNameChange(newName: string) {
+	if (props.blueprintId && newName.trim()) {
+		setContentValue(props.blueprintId, "key", newName.trim());
+	}
+}
+
+async function handleDeploy() {
+	if (!validateForm()) {
+		return;
+	}
+
+	isDeploying.value = true;
+	try {
+		const response = await fetch("/api/shared-blueprints/deploy", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				blueprint_id: props.blueprintId,
+				name: form.value.name.trim(),
+				description: form.value.description.trim(),
+			}),
+		});
+
+		if (!response.ok) {
+			const error = await response.json();
+			throw new Error(error.detail || "Failed to publish blueprint");
+		}
+
+		const data = await response.json();
+
+		// Update blueprint's published snippet ID, version, and description
+		setContentValue(
+			props.blueprintId,
+			"publishedSnippetId",
+			data.snippet_id,
+		);
+		setContentValue(props.blueprintId, "deployedVersion", data.version);
+		setContentValue(
+			props.blueprintId,
+			"deployedDescription",
+			form.value.description.trim(),
+		);
+
+		pushToast({
+			type: "success",
+			message: `Blueprint "${form.value.name.trim()}" published (v${data.version})`,
+		});
+		tracking.track("shared_blueprint_published");
+
+		resetForm();
+		isOpen.value = false;
+
+		try {
+			await wf.init();
+		} catch (_error) {
+			pushToast({
+				type: "error",
+				message:
+					"Blueprint published but failed to reload. Please refresh the page.",
+			});
+		}
+	} catch (error) {
+		pushToast({
+			type: "error",
+			message: `Error publishing blueprint: ${error instanceof Error ? error.message : String(error)}`,
+		});
+	} finally {
+		isDeploying.value = false;
+	}
+}
+
+function handleClose() {
+	if (!isDeploying.value) {
+		resetForm();
+		isOpen.value = false;
+	}
+}
+
+function resetForm() {
+	form.value = {
+		name: blueprintName.value,
+		description: blueprintDescription.value,
+	};
+	errors.value = {};
+}
+
+const modalActions = computed<ModalAction[]>(() => {
+	return [
+		{
+			desc: "Cancel",
+			fn: () => {
+				handleClose();
+			},
+		},
+		{
+			desc: isDeploying.value ? "Publishing..." : "Publish",
+			fn: handleDeploy,
+			disabled: isDeploying.value,
+		},
+	];
+});
+
+// Initialize form when modal opens
+watch(isOpen, (newValue) => {
+	if (newValue) {
+		resetForm();
+	}
+});
+</script>
+
+<style scoped>
+.DeploySharedBlueprint {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding: 16px;
+}
+
+.DeploySharedBlueprint__versionInfo {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 12px;
+	background: var(--builderSubtleBackgroundColor, #f8fafc);
+	border-radius: 8px;
+	font-size: 13px;
+	color: var(--builderSecondaryTextColor);
+}
+
+.DeploySharedBlueprint__textarea {
+	width: 100%;
+	min-height: 100px;
+	padding: 8px;
+	border: 1px solid var(--builderSeparatorColor);
+	border-radius: 4px;
+	font-size: 14px;
+	font-family: inherit;
+	resize: vertical;
+}
+
+.DeploySharedBlueprint__textarea:focus {
+	outline: none;
+	border-color: var(--builderPrimaryColor);
+}
+
+.DeploySharedBlueprint__textarea--error {
+	border-color: var(--builderErrorColor);
+}
+</style>

--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTree.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTree.vue
@@ -5,12 +5,46 @@
 		placeholder="Component tree"
 		:search-count="searchResultCount"
 	>
-		<div>
+		<div v-if="rootComponentId == 'root'">
 			<BuilderSidebarComponentTreeBranch
 				class="rootBranch"
 				:component-id="rootComponentId"
 				:query="query"
 			/>
+		</div>
+
+		<div v-else-if="rootComponentId == 'blueprints_root'" class="sections">
+			<div
+				v-for="section in blueprintSections"
+				:key="section.key"
+				class="section"
+			>
+				<div class="section__header">
+					<span class="section__title">{{ section.title }}</span>
+					<WdsButton
+						variant="neutral"
+						size="smallIcon"
+						:data-automation-action="section.addAction"
+						@click="section.onAdd"
+					>
+						<WdsIcon name="plus" />
+					</WdsButton>
+				</div>
+				<div class="section__content">
+					<BuilderSidebarComponentTreeBranch
+						v-for="blueprint in section.items"
+						:key="blueprint.id"
+						:component-id="blueprint.id"
+						:query="query"
+					/>
+					<div
+						v-if="section.items.length === 0"
+						class="section__empty"
+					>
+						{{ section.emptyText }}
+					</div>
+				</div>
+			</div>
 		</div>
 
 		<template #footer>
@@ -29,7 +63,7 @@
 					v-if="rootComponentId == 'blueprints_root'"
 					variant="special"
 					size="small"
-					data-automation-action="add-blueprint"
+					data-automation-action="add-blueprint-footer"
 					@click="addBlueprint"
 				>
 					<WdsIcon name="plus" />
@@ -41,7 +75,7 @@
 </template>
 
 <script setup lang="ts">
-import { inject, nextTick, ref } from "vue";
+import { computed, inject, nextTick, ref } from "vue";
 import BuilderSidebarPanel from "./BuilderSidebarPanel.vue";
 import injectionKeys from "@/injectionKeys";
 import BuilderSidebarComponentTreeBranch from "./BuilderSidebarComponentTreeBranch.vue";
@@ -56,7 +90,11 @@ const wfbm = inject(injectionKeys.builderManager);
 const query = ref("");
 
 const tracking = useWriterTracking(wf);
-const { createAndInsertComponent } = useComponentActions(wf, wfbm, tracking);
+const { createAndInsertComponent, setContentValue } = useComponentActions(
+	wf,
+	wfbm,
+	tracking,
+);
 
 const rootComponentId = wfbm.activeRootId;
 
@@ -65,6 +103,44 @@ const { searchResultCount } = useComponentsTreeSearchResults(
 	query,
 	rootComponentId,
 );
+
+const allBlueprints = computed(() => {
+	return wf.getComponents("blueprints_root", { sortedByPosition: true });
+});
+
+const regularBlueprints = computed(() => {
+	return allBlueprints.value.filter((c) => !c.content?.isSharedBlueprint);
+});
+
+const sharedBlueprintItems = computed(() => {
+	return allBlueprints.value.filter((c) => c.content?.isSharedBlueprint);
+});
+
+const blueprintSections = computed(() => {
+	const sections = [
+		{
+			key: "blueprints",
+			title: "Blueprints",
+			items: regularBlueprints.value,
+			addAction: "add-blueprint",
+			onAdd: addBlueprint,
+			emptyText: "No blueprints yet",
+		},
+	];
+
+	if (wf.featureFlags.value?.includes("shared_blueprints")) {
+		sections.push({
+			key: "shared-blueprints",
+			title: "Shared Blueprints",
+			items: sharedBlueprintItems.value,
+			addAction: "add-shared-blueprint",
+			onAdd: addSharedBlueprint,
+			emptyText: "No shared blueprints yet",
+		});
+	}
+
+	return sections;
+});
 
 async function addPage() {
 	const pageId = createAndInsertComponent("page", "root");
@@ -83,6 +159,18 @@ async function addBlueprint() {
 	await nextTick();
 	wfbm.setSelection(pageId);
 	tracking.track("blueprints_new_added");
+}
+
+async function addSharedBlueprint() {
+	const pageId = createAndInsertComponent(
+		"blueprints_blueprint",
+		"blueprints_root",
+	);
+	setContentValue(pageId, "isSharedBlueprint", true);
+	wf.setActivePageId(pageId);
+	await nextTick();
+	wfbm.setSelection(pageId);
+	tracking.track("shared_blueprint_added");
 }
 </script>
 
@@ -124,5 +212,43 @@ async function addBlueprint() {
 	justify-content: center;
 	border-top: 1px solid var(--builderSeparatorColor);
 	background: var(--builderBackgroundColor);
+}
+
+.sections {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.section {
+	display: flex;
+	flex-direction: column;
+}
+
+.section__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 8px 16px;
+	border-bottom: 1px solid var(--builderSeparatorColor);
+}
+
+.section__title {
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: var(--builderSecondaryTextColor);
+}
+
+.section__content {
+	padding: 8px 0;
+}
+
+.section__empty {
+	padding: 8px 16px;
+	font-size: 12px;
+	color: var(--builderSecondaryTextColor);
+	font-style: italic;
 }
 </style>

--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTreeBranch.vue
@@ -181,10 +181,19 @@ function handleDragOver(ev: DragEvent) {
 function handleDrop(ev: DragEvent) {
 	const dragInfo = getComponentInfoFromDrag(ev);
 	if (!dragInfo) return;
-	const { draggedType, draggedId } = dragInfo;
+	const { draggedType, draggedId, sourceBlueprintId } = dragInfo;
 
 	if (!draggedId) {
-		createAndInsertComponent(draggedType, component.value.id);
+		const initProperties = sourceBlueprintId
+			? { content: { sourceBlueprintId } }
+			: undefined;
+
+		createAndInsertComponent(
+			draggedType,
+			component.value.id,
+			undefined,
+			initProperties,
+		);
 	} else {
 		moveComponent(draggedId, component.value.id);
 	}

--- a/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
+++ b/src/ui/src/components/blueprints/BlueprintsBlueprint.vue
@@ -112,12 +112,17 @@
 		<BlueprintToolbar
 			class="blueprintsToolbar"
 			@autogen-click="showAutogen"
+			@deploy="showDeploy"
 		/>
 		<WdsModal v-if="isAutogenModalShown">
 			<BlueprintsAutogen
 				@block-generation="handleBlockGeneration"
 			></BlueprintsAutogen>
 		</WdsModal>
+		<BuilderSettingsDeploySharedBlueprint
+			v-model="isDeployModalShown"
+			:blueprint-id="blueprintComponentId"
+		/>
 		<BlueprintNavigator
 			v-if="nodeContainerEl"
 			:node-container-el="nodeContainerEl"
@@ -228,6 +233,11 @@ const BlueprintToolbar = defineAsyncComponentWithLoader({
 	loadingComponentProps: { width: "250px", height: "40px" },
 });
 
+const BuilderSettingsDeploySharedBlueprint = defineAsyncComponentWithLoader({
+	loader: () =>
+		import("@/builder/settings/BuilderSettingsDeploySharedBlueprint.vue"),
+});
+
 const wf = inject(injectionKeys.core);
 const wfbm = inject(injectionKeys.builderManager);
 const notesManager = inject(injectionKeys.notesManager);
@@ -240,6 +250,11 @@ const isAutogenModalShown = inject(
 );
 function showAutogen() {
 	isAutogenModalShown.value = true;
+}
+
+const isDeployModalShown = ref(false);
+function showDeploy() {
+	isDeployModalShown.value = true;
 }
 
 const rootEl = useTemplateRef("rootEl");
@@ -564,13 +579,14 @@ function handleDrop(ev: DragEvent) {
 	const dropInfo = getComponentInfoFromDrag(ev);
 
 	if (!dropInfo) return;
-	const { draggedType, draggedId } = dropInfo;
+	const { draggedType, draggedId, sourceBlueprintId } = dropInfo;
 	if (draggedId) return;
 
 	const { x, y } = getAdjustedCoordinates(ev);
 	if (x < 0 || y < 0) return;
 
-	createNode(draggedType, { x, y });
+	const dragContent = sourceBlueprintId ? { sourceBlueprintId } : undefined;
+	createNode(draggedType, { x, y }, dragContent);
 }
 
 function handleArrowClick(ev: MouseEvent, arrowId: number) {
@@ -845,7 +861,11 @@ async function handleMouseup(ev: MouseEvent) {
 	});
 }
 
-function createNode(type: string, point: Point) {
+function createNode(
+	type: string,
+	point: Point,
+	content?: Record<string, unknown>,
+) {
 	const otherRectangles = nodes.value
 		.map((c) => getNodeRectange(c.id))
 		.filter(Boolean);
@@ -854,7 +874,12 @@ function createNode(type: string, point: Point) {
 		otherRectangles,
 		GRID_TICK,
 	);
-	createAndInsertComponent(type, blueprintComponentId, undefined, { x, y });
+	// Pass content for shared blueprints (includes sourceBlueprintId)
+	const initProps =
+		Object.keys(content ?? {}).length > 0
+			? { x, y, content: content as Record<string, string> }
+			: { x, y };
+	createAndInsertComponent(type, blueprintComponentId, undefined, initProps);
 }
 
 function findAndCenterBlock(componentId: Component["id"]) {

--- a/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
+++ b/src/ui/src/components/blueprints/abstract/BlueprintsNode.vue
@@ -30,7 +30,7 @@
 				<BlueprintsNodeNamer
 					:component-id="componentId"
 					class="nodeNamer"
-					:block-name="def.name"
+					:block-name="displayName"
 				></BlueprintsNodeNamer>
 				<div v-if="isDeprecated" class="deprecationNotice">
 					Deprecated
@@ -150,6 +150,7 @@ import BlueprintsNodeOutput from "./BlueprintsNodeOutput.vue";
 import BlueprintsNodeLogs from "./BlueprintsNodeLogs.vue";
 import BlueprintsNodeTools from "./BlueprintsNodeTools.vue";
 import { useBlueprintNodeTools } from "@/composables/useBlueprintNodeTools";
+import { getSourceBlueprintName } from "@/builder/useComponentDescription";
 
 const emit = defineEmits(["outMousedown", "engaged"]);
 const wf = inject(injectionKeys.core);
@@ -171,6 +172,15 @@ const isDeprecated = computed(() => {
 });
 
 const { component, definition: def } = useComponentInformation(wf, componentId);
+
+const displayName = computed(() => {
+	if (!component.value) return "Unknown";
+	return (
+		getSourceBlueprintName(wf, component.value) ||
+		def.value?.name ||
+		"Unknown"
+	);
+});
 
 const completionStyle = computed(() => {
 	if (latestKnownOutcome.value == null) return null;

--- a/src/ui/src/components/blueprints/base/BlueprintToolbar.vue
+++ b/src/ui/src/components/blueprints/base/BlueprintToolbar.vue
@@ -7,8 +7,9 @@ import injectionKeys from "@/injectionKeys";
 import { computed, inject, shallowRef, toRaw, useTemplateRef } from "vue";
 import BlueprintToolbarBlocksDropdown from "./BlueprintToolbarBlocksDropdown.vue";
 
-defineEmits({
+const emit = defineEmits({
 	autogenClick: () => true,
+	deploy: () => true,
 });
 
 const wf = inject(injectionKeys.core);
@@ -22,6 +23,18 @@ const {
 	stop: handleStop,
 	isRunning,
 } = useBlueprintRun(wf, wfbm, blueprintComponentId);
+
+const isBlueprintLibraryEnabled = computed(
+	() =>
+		Array.isArray(wf.featureFlags.value) &&
+		wf.featureFlags.value.includes("blueprint_library"),
+);
+
+// Check if the current blueprint is a shared blueprint
+const isSharedBlueprint = computed(() => {
+	const blueprint = wf.getComponentById(blueprintComponentId);
+	return blueprint?.content?.isSharedBlueprint === true;
+});
 
 const triggerComponents = computed(() =>
 	wf
@@ -66,9 +79,20 @@ async function runBlueprint(componentId?: string) {
 			data-automation-action="run-autogen"
 			data-writer-tooltip="Autogen"
 			data-writer-tooltip-placement="bottom"
-			@click="$emit('autogenClick')"
+			@click="emit('autogenClick')"
 		>
 			<WdsIcon name="wand-sparkles" />
+		</WdsButton>
+		<WdsButton
+			v-if="isBlueprintLibraryEnabled && isSharedBlueprint"
+			variant="special"
+			data-automation-action="publish-shared-blueprint"
+			data-writer-tooltip="Publish this shared blueprint"
+			data-writer-tooltip-placement="bottom"
+			@click="emit('deploy')"
+		>
+			<WdsIcon name="rocket" />
+			Publish blueprint
 		</WdsButton>
 		<WdsButtonSplit
 			v-if="triggerComponents.length && !isRunning"


### PR DESCRIPTION
- Add BuilderSettingsDeploySharedBlueprint.vue for publish modal
- Update BuilderSettings.vue with deploy settings integration
- Update BuilderApp.vue with shared blueprint support
- Update BuilderSidebarComponentTree.vue and branch component
- Update BlueprintsBlueprint.vue, BlueprintsNode.vue, BlueprintToolbar.vue

Includes all previous PR files as dependencies (complete feature)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Shared blueprints: Create and publish reusable blueprint templates with version control.
  * Blueprint library: Browse and install pre-built blocks directly into your workspace.
  * Drag-and-drop shared blueprints: Drop reusable templates onto the canvas with automatic property initialization.

* **UI Improvements**
  * New publish workflow for shared blueprints.
  * Blueprint library panel with search and install capabilities.
  * Enhanced blueprint toolbar with publish button.
  * Shared blueprint management in sidebar with delete functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->