### PR TITLE
fix(writer): correct state mutation in code block - AB-791

### DIFF
--- a/src/writer/blocks/code.py
+++ b/src/writer/blocks/code.py
@@ -1,4 +1,3 @@
-import io
 import logging
 import sys
 import traceback
@@ -74,12 +73,13 @@ class CodeBlock(BlueprintBlock):
 
             writeruserapp = sys.modules.get("writeruserapp")
             block_globals = (
-                {
-                    "state": self.runner.session.session_state,
-                }
-                | self.execution_environment
+                self.execution_environment
                 | writeruserapp.__dict__
-                | {"set_output": self.set_output}
+                | {
+                    "state": self.runner.session.session_state,
+                    "set_output": self.set_output,
+                    "logger": exec_logger,
+                }
             )
 
             with (
@@ -92,7 +92,7 @@ class CodeBlock(BlueprintBlock):
                     lambda entry: setattr(self, 'captured_logs', entry)
                 ]),
             ):
-                exec(code, block_globals | {"logger": exec_logger})
+                exec(code, block_globals)
 
             self.outcome = "success"
         except BaseException as e:


### PR DESCRIPTION
`state` injected in the code execution block was overridden by `writeruserapp.__dict__` which made side effect.

<img width="1221" height="1316" alt="Screenshot 2025-11-28 at 12 42 09" src="https://github.com/user-attachments/assets/22cb9ae5-e1a3-4cb2-b697-3402792b0023" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the Python code block execution environment to improve how variables and utilities are made available during code execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->