### PR TITLE
fix(writer): correct state in if/else block - AB-791

### DIFF
--- a/src/writer/blocks/ifelse.py
+++ b/src/writer/blocks/ifelse.py
@@ -53,9 +53,9 @@ class IfElseBlock(BlueprintBlock):
         try:
             writeruserapp = sys.modules.get("writeruserapp")
             block_globals = {
-                "state": self.runner.session.session_state,
                 **self.execution_environment,
                 **(writeruserapp.__dict__ if writeruserapp else {}),
+                "state": self.runner.session.session_state,
             }
             # Evaluate the expression and set the result
             compiled_expr = compile(expression, "<expression>", mode="eval")


### PR DESCRIPTION
we need to use `session_state` instead of any var named `state` in `main.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed internal state handling to ensure proper value precedence in conditional block execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->