### PR TITLE
feat!: remove versioning and make shared blueprint title unique - AB-857

### DIFF
--- a/src/ui/src/builder/panels/BuilderBlueprintLibraryItem.vue
+++ b/src/ui/src/builder/panels/BuilderBlueprintLibraryItem.vue
@@ -4,9 +4,6 @@
 			<h3 class="BuilderBlueprintLibraryItem__title">
 				{{ block.title }}
 			</h3>
-			<span class="BuilderBlueprintLibraryItem__version"
-				>v{{ block.version_number }}</span
-			>
 		</div>
 		<p class="BuilderBlueprintLibraryItem__description">
 			{{ block.description }}
@@ -40,7 +37,7 @@ const props = defineProps<{
 		id: string;
 		title: string;
 		description: string;
-		version_number: number;
+		createdBy: number;
 	};
 }>();
 
@@ -75,13 +72,12 @@ async function handleInstall() {
 		);
 
 		// Install blueprint
-		const components = blueprint.version.components as Component[];
+		const components = blueprint.components as Component[];
 
 		const _blueprintId = installSharedBlueprint({
 			id: blueprint.id,
 			title: blueprint.title,
-			version: blueprint.version.version,
-			description: blueprint.version.description || undefined,
+			description: blueprint.description || undefined,
 			components,
 		});
 
@@ -130,12 +126,6 @@ async function handleInstall() {
 	font-weight: 600;
 	margin: 0;
 	flex: 1;
-}
-
-.BuilderBlueprintLibraryItem__version {
-	font-size: 12px;
-	color: var(--builderSecondaryTextColor);
-	white-space: nowrap;
 }
 
 .BuilderBlueprintLibraryItem__description {

--- a/src/ui/src/builder/panels/BuilderBlueprintLibraryPanel.vue
+++ b/src/ui/src/builder/panels/BuilderBlueprintLibraryPanel.vue
@@ -78,7 +78,7 @@ const blueprints = ref<
 		title: string;
 		description: string;
 		category: string;
-		version_number: number;
+		createdBy: number;
 	}>
 >([]);
 const isLoading = ref(false);
@@ -110,7 +110,7 @@ async function loadBlueprints() {
 			title: bp.title,
 			description: bp.description,
 			category: bp.category || "Shared Blueprints",
-			version_number: bp.version_number,
+			createdBy: bp.createdBy,
 		}));
 	} catch (error) {
 		pushToast({

--- a/src/ui/src/builder/settings/BuilderSettingsDeploySharedBlueprint.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsDeploySharedBlueprint.vue
@@ -7,22 +7,6 @@
 		@close="handleClose"
 	>
 		<div class="DeploySharedBlueprint">
-			<!-- Version info -->
-			<div
-				v-if="currentVersion"
-				class="DeploySharedBlueprint__versionInfo"
-			>
-				<WdsIcon name="package" />
-				<span
-					>Currently published:
-					<strong>v{{ currentVersion }}</strong></span
-				>
-			</div>
-			<div v-else class="DeploySharedBlueprint__versionInfo">
-				<WdsIcon name="package" />
-				<span>Not yet published</span>
-			</div>
-
 			<WdsFieldWrapper label="Name" required>
 				<WdsTextInput
 					v-model="form.name"
@@ -52,7 +36,6 @@ import { ref, computed, watch, inject, shallowRef } from "vue";
 import WdsModal, { ModalAction } from "@/wds/WdsModal.vue";
 import WdsFieldWrapper from "@/wds/WdsFieldWrapper.vue";
 import WdsTextInput from "@/wds/WdsTextInput.vue";
-import WdsIcon from "@/wds/WdsIcon.vue";
 import injectionKeys from "@/injectionKeys";
 import { useToasts } from "@/builder/useToast";
 import { useComponentActions } from "@/builder/useComponentActions";
@@ -76,10 +59,6 @@ const tracking = useWriterTracking(wf);
 const { writerApi } = useWriterApi();
 
 const blueprint = computed(() => wf.getComponentById(props.blueprintId));
-
-const currentVersion = computed(
-	() => blueprint.value?.content?.deployedVersion || null,
-);
 
 const blueprintName = computed(
 	() => blueprint.value?.content?.key || "Shared Blueprint",
@@ -138,28 +117,18 @@ async function handleDeploy() {
 		// Extract components from frontend
 		const components = extractBlueprintComponents(props.blueprintId);
 
-		// Get existing snippet ID if this is an update
-		const existingSnippetId =
-			blueprint.value?.content?.publishedSnippetId || null;
-
 		const data = await writerApi.publishSharedBlueprint(orgId, {
 			title: form.value.name.trim(),
 			description: form.value.description.trim(),
 			components: components,
 			metadata: {},
-			existingSnippetId,
 		});
 
-		// Update blueprint's published snippet ID, version, and description
+		// Update blueprint's published snippet ID and description
 		setContentValue(
 			props.blueprintId,
 			"publishedSnippetId",
 			data.snippet_id,
-		);
-		setContentValue(
-			props.blueprintId,
-			"deployedVersion",
-			String(data.version),
 		);
 		setContentValue(
 			props.blueprintId,
@@ -169,7 +138,7 @@ async function handleDeploy() {
 
 		pushToast({
 			type: "success",
-			message: `Blueprint "${form.value.name.trim()}" published (v${data.version})`,
+			message: `Blueprint "${form.value.name.trim()}" published successfully`,
 		});
 		tracking.track("blueprints_shared_published");
 
@@ -238,17 +207,6 @@ watch(isOpen, (newValue) => {
 	flex-direction: column;
 	gap: 16px;
 	padding: 16px;
-}
-
-.DeploySharedBlueprint__versionInfo {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	padding: 12px;
-	background: var(--builderSubtleBackgroundColor, #f8fafc);
-	border-radius: 8px;
-	font-size: 13px;
-	color: var(--builderSecondaryTextColor);
 }
 
 .DeploySharedBlueprint__textarea {

--- a/src/ui/src/builder/useComponentActions.ts
+++ b/src/ui/src/builder/useComponentActions.ts
@@ -1157,7 +1157,6 @@ export function useComponentActions(
 	function installSharedBlueprint(blueprintData: {
 		id: string;
 		title: string;
-		version: number;
 		description?: string;
 		components: Component[];
 	}): Component["id"] {
@@ -1172,7 +1171,6 @@ export function useComponentActions(
 					key: blueprintData.title,
 					isSharedBlueprint: SHARED_BLUEPRINT_FLAG_VALUE,
 					sourceBlueprintId: blueprintData.id,
-					deployedVersion: String(blueprintData.version),
 					deployedDescription: blueprintData.description,
 				},
 			},

--- a/src/ui/src/writerApi.ts
+++ b/src/ui/src/writerApi.ts
@@ -415,9 +415,8 @@ export class WriterApi {
 				dependencies?: unknown[];
 				author?: string;
 			};
-			existingSnippetId?: string | null;
 		},
-	): Promise<{ snippet_id: string; version: number }> {
+	): Promise<{ snippet_id: string }> {
 		const baseUrl = this.#getAgentStorageBaseUrl();
 		const url = new URL(
 			`/api/agent-storage/v1/organization/${orgId}/shared-blueprints`,
@@ -432,7 +431,6 @@ export class WriterApi {
 				description: data.description,
 				components: data.components,
 				metadata: data.metadata,
-				existing_snippet_id: data.existingSnippetId || null,
 			}),
 		});
 		if (!res.ok) throw Error(await res.text());
@@ -447,12 +445,7 @@ export class WriterApi {
 		Array<
 			Pick<
 				WriterApiSharedBlueprint,
-				| "id"
-				| "title"
-				| "description"
-				| "category"
-				| "version_number"
-				| "createdBy"
+				"id" | "title" | "description" | "category" | "createdBy"
 			>
 		>
 	> {
@@ -516,17 +509,11 @@ export type WriterApiSharedBlueprint = {
 	title: string;
 	description: string;
 	category: string;
-	version_number: number;
 	visibility: string;
 	orgId: string;
 	createdBy: number;
-	version: {
-		version: number;
-		description: string | null;
-		components: unknown;
-		metadata: unknown;
-		createdAt: string;
-	};
+	components: unknown;
+	metadata: unknown;
 	createdAt: string;
 	updatedAt: string;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed version tracking from shared blueprints across the library, deploy modal, and install flow.
  * UI now hides version labels and related styling; deploy success message is now generic.
  * Blueprint listings and details show creator information instead of version.
  * Publishing and installation flows pass blueprint components/description without version or existing-snippet identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->