### PR TITLE
feat(writer): allow CRON trigger block to be run - WF-881

### DIFF
--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -232,7 +232,6 @@ class BlueprintRunner:
     def run_blueprint_via_api(
         self,
         blueprint_id: str,
-        trigger_type: Literal["API", "Cron"],
         branch_id: Optional[str] = None,
         execution_environment: Optional[Dict[str, Any]] = None
     ):
@@ -240,7 +239,6 @@ class BlueprintRunner:
         Executes a blueprint by its key via the API.
 
         :param blueprint_id: The blueprint identifier.
-        :param trigger_type: The type of trigger ("API" or "Cron").
         :param branch_id: Optional branch ID to start execution from.
         :param execution_environment: The execution environment for
         the blueprint.
@@ -250,13 +248,24 @@ class BlueprintRunner:
             execution_environment = {}
 
         trigger_id = branch_id
-        if trigger_id is None:
-            if trigger_type == "Cron" or not self.is_blueprint_api_available(blueprint_id):
-                trigger_id = self.get_blueprint_cron_trigger(blueprint_id)
+        if trigger_id is not None:
+            # Determine trigger type from the component
+            component = self.session.session_component_tree.get_component(trigger_id)
+            if component and component.type == "blueprints_apitrigger":
+                trigger_type = "API"
+            elif component and component.type == "blueprints_crontrigger":
                 trigger_type = "Cron"
             else:
-                trigger_id = self.get_blueprint_api_trigger(blueprint_id)
-
+                trigger_type = "Branch"
+        elif self.is_blueprint_api_available(blueprint_id):
+            # Prioritize API trigger over Cron if both exist
+            trigger_id = self.get_blueprint_api_trigger(blueprint_id)
+            trigger_type = "API"
+        elif self.is_blueprint_cron_available(blueprint_id):
+            trigger_id = self.get_blueprint_cron_trigger(blueprint_id)
+            trigger_type = "Cron"
+        else:
+            raise ValueError(f'No trigger found for blueprint "{blueprint_id}".')
         return self.run_branch(
             trigger_id,
             None,

--- a/src/writer/blueprints.py
+++ b/src/writer/blueprints.py
@@ -69,6 +69,10 @@ class BlueprintRunner:
     def api_blueprints(self):
         return self._gather_api_blueprints()
 
+    @property
+    def cron_blueprints(self):
+        return self._gather_cron_blueprints()
+
     @contextmanager
     def _get_executor(self) -> Generator[ThreadPoolExecutor, None, None]:
         """Return the application's thread pool executor.
@@ -137,6 +141,17 @@ class BlueprintRunner:
         """
         return blueprint_id in self.api_blueprints
 
+    def is_blueprint_cron_available(
+        self, blueprint_id: str
+    ):
+        """
+        Checks if a blueprint with the given key is available for Cron execution.
+
+        :param blueprint_id: The blueprint identifier.
+        :return: True if the blueprint is available for Cron execution, False otherwise.
+        """
+        return blueprint_id in self.cron_blueprints
+
     def get_blueprint_api_trigger(
         self, blueprint_id: str
     ):
@@ -152,17 +167,33 @@ class BlueprintRunner:
             )
         return self.api_blueprints[blueprint_id]
 
-    def _gather_api_blueprints(self):
+    def get_blueprint_cron_trigger(
+        self, blueprint_id: str
+    ):
         """
-        Gathers all blueprints that have an API trigger.
+        Retrieves the Cron trigger for a given blueprint key.
 
-        :return: A set of blueprint keys that have an API trigger.
+        :param blueprint_key: The blueprint identifier.
+        :return: The Cron trigger component.
+        """
+        if not self.is_blueprint_cron_available(blueprint_id):
+            raise ValueError(
+                f'Cron trigger not found for blueprint "{blueprint_id}".'
+            )
+        return self.cron_blueprints[blueprint_id]
+
+    def _gather_blueprints_by_trigger(self, trigger_type: str):
+        """
+        Gathers all blueprints that have a trigger of the specified type.
+
+        :param trigger_type: The trigger component type (e.g., "blueprints_apitrigger").
+        :return: A dict mapping blueprint IDs to their trigger IDs.
         """
         triggers = [
             c for c in self.session.session_component_tree.components.values()
-            if c.type == "blueprints_apitrigger"
-            ]
-        api_blueprints = {}
+            if c.type == trigger_type
+        ]
+        blueprints = {}
 
         for trigger in triggers:
             parent_blueprint_id = \
@@ -170,7 +201,7 @@ class BlueprintRunner:
             parent_blueprint = \
                 self.session.session_component_tree.get_component(
                     parent_blueprint_id
-                    )
+                )
 
             if (
                 parent_blueprint
@@ -178,10 +209,25 @@ class BlueprintRunner:
                 parent_blueprint.type == "blueprints_blueprint"
             ):
                 # Store the blueprint key against its trigger ID
-                api_blueprints[parent_blueprint_id] = \
-                    trigger.id
+                blueprints[parent_blueprint_id] = trigger.id
 
-        return api_blueprints
+        return blueprints
+
+    def _gather_api_blueprints(self):
+        """
+        Gathers all blueprints that have an API trigger.
+
+        :return: A dict mapping blueprint IDs to their API trigger IDs.
+        """
+        return self._gather_blueprints_by_trigger("blueprints_apitrigger")
+
+    def _gather_cron_blueprints(self):
+        """
+        Gathers all blueprints that have a Cron trigger.
+
+        :return: A dict mapping blueprint IDs to their Cron trigger IDs.
+        """
+        return self._gather_blueprints_by_trigger("blueprints_crontrigger")
 
     def run_blueprint_via_api(
         self,
@@ -194,6 +240,8 @@ class BlueprintRunner:
         Executes a blueprint by its key via the API.
 
         :param blueprint_id: The blueprint identifier.
+        :param trigger_type: The type of trigger ("API" or "Cron").
+        :param branch_id: Optional branch ID to start execution from.
         :param execution_environment: The execution environment for
         the blueprint.
         :return: The result of the blueprint execution.
@@ -203,7 +251,11 @@ class BlueprintRunner:
 
         trigger_id = branch_id
         if trigger_id is None:
-            trigger_id = self.get_blueprint_api_trigger(blueprint_id)
+            if trigger_type == "Cron" or not self.is_blueprint_api_available(blueprint_id):
+                trigger_id = self.get_blueprint_cron_trigger(blueprint_id)
+                trigger_type = "Cron"
+            else:
+                trigger_id = self.get_blueprint_api_trigger(blueprint_id)
 
         return self.run_branch(
             trigger_id,

--- a/src/writer/core.py
+++ b/src/writer/core.py
@@ -1283,15 +1283,11 @@ class EventHandlerRegistry:
         blueprint_id = payload.pop("blueprint_id", None)
         if not blueprint_id:
             raise ValueError("Missing blueprint_id in payload")
-        trigger_type = payload.pop("trigger_type", None)
-        if not trigger_type:
-            raise ValueError("Missing trigger_type in payload")
         execution_environment = EventHandler._get_blueprint_execution_environment(
             payload, context, session, vault
         )
         return blueprint_runner.run_blueprint_via_api(
             blueprint_id=blueprint_id,
-            trigger_type=trigger_type,
             branch_id=payload.pop("branch_id", None),
             execution_environment=execution_environment,
         )

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -539,39 +539,21 @@ def get_asgi_app(
 
                 await queue.put(await format_event("status", {"status": "executing", "msg": (f"Executing branch: {branch_id}..." if branch_id else f"Executing blueprint: {blueprint_id}...")}))
 
-                if branch_id:
-                    task = asyncio.create_task(
-                        app_runner.handle_event(
-                            session_id,
-                            WriterEvent(
-                                type="wf-run-blueprint-via-api",
-                                isSafe=True,
-                                handler="run_blueprint_via_api",
-                                payload={
-                                    "blueprint_id": blueprint_id,
-                                    "trigger_type": "Cron",
-                                    "branch_id": branch_id,
-                                    **(payload or {})
-                                },
-                            )
+                task = asyncio.create_task(
+                    app_runner.handle_event(
+                        session_id,
+                        WriterEvent(
+                            type="wf-run-blueprint-via-api",
+                            isSafe=True,
+                            handler="run_blueprint_via_api",
+                            payload={
+                                "blueprint_id": blueprint_id,
+                                "branch_id": branch_id,
+                                **(payload or {})
+                            },
                         )
                     )
-                else:
-                    task = asyncio.create_task(
-                        app_runner.handle_event(
-                            session_id,
-                            WriterEvent(
-                                type="wf-run-blueprint-via-api",
-                                isSafe=True,
-                                handler="run_blueprint_via_api",
-                                payload={
-                                    "blueprint_id": blueprint_id,
-                                    "trigger_type": "API",
-                                    **(payload or {})
-                                },
-                            )
-                        )
-                    )
+                )
 
                 await queue.put(await format_event("status", {"status": "running", "msg": ("Branch is running. Awaiting output..." if branch_id else "Blueprint is running. Awaiting output...")}))
 

--- a/src/writer/serve.py
+++ b/src/writer/serve.py
@@ -385,12 +385,13 @@ def get_asgi_app(
             raise HTTPException(status_code=400, detail="Cannot parse the payload.")
         return payload
     
-    def has_api_trigger(app_runner: AppRunner, blueprint_id: str) -> bool:
-        # Check if blueprint has at least one API trigger component
+    def is_blueprint_triggerable(app_runner: AppRunner, blueprint_id: str) -> bool:
+        """Check if blueprint has at least one supported trigger (API or Cron)."""
         if not app_runner.bmc_components:
             return False
+        supported_triggers = ("blueprints_apitrigger", "blueprints_crontrigger")
         return any(
-            comp["type"] == "blueprints_apitrigger" and comp.get("parentId") == blueprint_id
+            comp["type"] in supported_triggers and comp.get("parentId") == blueprint_id
             for comp in app_runner.bmc_components.values()
         )
 
@@ -409,7 +410,7 @@ def get_asgi_app(
             }
             for comp in app_runner.bmc_components.values()
             if comp["type"] == "blueprints_blueprint"
-            and has_api_trigger(app_runner, comp["id"])
+            and is_blueprint_triggerable(app_runner, comp["id"])
         ]
 
         return JSONResponse(content=blueprints)
@@ -520,9 +521,9 @@ def get_asgi_app(
                     }))
                     return
 
-                if not branch_id and not has_api_trigger(app_runner, blueprint_id):
+                if not branch_id and not is_blueprint_triggerable(app_runner, blueprint_id):
                     await queue.put(await format_event("error", {
-                        "msg": f"Blueprint '{blueprint_id}' lacks an API trigger.",
+                        "msg": f"Blueprint '{blueprint_id}' lacks a supported trigger (API or Cron).",
                         "finished_at": int(time.time())
                     }))
                     return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blueprints can be triggered via Cron scheduling in addition to API triggers.
  * Exposed Cron availability and trigger lookup for blueprints; payloads no longer require a trigger type.

* **Refactor**
  * Trigger detection unified to recognize both API and Cron triggers.
  * Run flow simplified to a single consistent execution path that auto-selects API (preferred) or Cron.

* **Bug Fixes**
  * Clearer error messages when no supported trigger is available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->