### PR TITLE
feat(SharedBlueprints): put global blueprint proposals behind FF - AB…

### DIFF
--- a/src/ui/src/builder/settings/BuilderSettingsDeploySharedBlueprint.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsDeploySharedBlueprint.vue
@@ -28,7 +28,10 @@
 				/>
 			</WdsFieldWrapper>
 
-			<div class="DeploySharedBlueprint__globalOption">
+			<div
+				v-if="isGlobalBlueprintProposalsEnabled"
+				class="DeploySharedBlueprint__globalOption"
+			>
 				<label class="DeploySharedBlueprint__checkbox">
 					<input v-model="form.proposeAsGlobal" type="checkbox" />
 					<span>Propose as global blueprint</span>
@@ -77,6 +80,12 @@ const tracking = useWriterTracking(wf);
 const { writerApi } = useWriterApi();
 
 const blueprint = computed(() => wf.getComponentById(props.blueprintId));
+
+const isGlobalBlueprintProposalsEnabled = computed(
+	() =>
+		Array.isArray(wf.featureFlags.value) &&
+		wf.featureFlags.value.includes("global_blueprint_proposals"),
+);
 
 const blueprintName = computed(
 	() => blueprint.value?.content?.key || "Shared Blueprint",


### PR DESCRIPTION
…-908

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented feature flag control for the global blueprint proposal functionality, allowing the "Propose as global blueprint" option to be conditionally displayed based on feature enablement status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->