### PR TITLE
fix: put add blueprint plus button behind FF - AB-824

### DIFF
--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTree.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTree.vue
@@ -19,17 +19,18 @@
 				:key="section.key"
 				class="section"
 			>
-				<div class="section__header">
-					<span class="section__title">{{ section.title }}</span>
-					<WdsButton
-						variant="neutral"
-						size="smallIcon"
-						:data-automation-action="section.addAction"
-						@click="section.onAdd"
-					>
-						<WdsIcon name="plus" />
-					</WdsButton>
-				</div>
+			<div class="section__header">
+				<span class="section__title">{{ section.title }}</span>
+				<WdsButton
+					v-if="section.showAddButton"
+					variant="neutral"
+					size="smallIcon"
+					:data-automation-action="section.addAction"
+					@click="section.onAdd"
+				>
+					<WdsIcon name="plus" />
+				</WdsButton>
+			</div>
 				<div class="section__content">
 					<BuilderSidebarComponentTreeBranch
 						v-for="blueprint in section.items"
@@ -59,16 +60,16 @@
 					<WdsIcon name="plus" />
 					Add page
 				</WdsButton>
-				<WdsButton
-					v-if="rootComponentId == 'blueprints_root'"
-					variant="special"
-					size="small"
-					data-automation-action="add-blueprint-footer"
-					@click="addBlueprint"
-				>
-					<WdsIcon name="plus" />
-					Add blueprint
-				</WdsButton>
+			<WdsButton
+				v-if="rootComponentId == 'blueprints_root'"
+				variant="special"
+				size="small"
+				data-automation-action="add-blueprint-footer"
+				@click="addBlueprint"
+			>
+				<WdsIcon name="plus" />
+				Add blueprint
+			</WdsButton>
 			</div>
 		</template>
 	</BuilderSidebarPanel>
@@ -120,6 +121,10 @@ const sharedBlueprintItems = computed(() => {
 	return allBlueprints.value.filter((c) => isSharedBlueprint(c));
 });
 
+const isSharedBlueprintsEnabled = computed(() =>
+	wf.featureFlags.value?.includes("shared_blueprints"),
+);
+
 const blueprintSections = computed(() => {
 	const sections = [
 		{
@@ -129,10 +134,11 @@ const blueprintSections = computed(() => {
 			addAction: "add-blueprint",
 			onAdd: addBlueprint,
 			emptyText: "No blueprints yet",
+			showAddButton: isSharedBlueprintsEnabled.value,
 		},
 	];
 
-	if (wf.featureFlags.value?.includes("shared_blueprints")) {
+	if (isSharedBlueprintsEnabled.value) {
 		sections.push({
 			key: "shared-blueprints",
 			title: "Shared Blueprints",
@@ -140,6 +146,7 @@ const blueprintSections = computed(() => {
 			addAction: "add-shared-blueprint",
 			onAdd: addSharedBlueprint,
 			emptyText: "No shared blueprints yet",
+			showAddButton: true,
 		});
 	}
 

--- a/src/ui/src/builder/sidebar/BuilderSidebarComponentTree.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarComponentTree.vue
@@ -19,18 +19,18 @@
 				:key="section.key"
 				class="section"
 			>
-			<div class="section__header">
-				<span class="section__title">{{ section.title }}</span>
-				<WdsButton
-					v-if="section.showAddButton"
-					variant="neutral"
-					size="smallIcon"
-					:data-automation-action="section.addAction"
-					@click="section.onAdd"
-				>
-					<WdsIcon name="plus" />
-				</WdsButton>
-			</div>
+				<div class="section__header">
+					<span class="section__title">{{ section.title }}</span>
+					<WdsButton
+						v-if="section.showAddButton"
+						variant="neutral"
+						size="smallIcon"
+						:data-automation-action="section.addAction"
+						@click="section.onAdd"
+					>
+						<WdsIcon name="plus" />
+					</WdsButton>
+				</div>
 				<div class="section__content">
 					<BuilderSidebarComponentTreeBranch
 						v-for="blueprint in section.items"
@@ -60,16 +60,16 @@
 					<WdsIcon name="plus" />
 					Add page
 				</WdsButton>
-			<WdsButton
-				v-if="rootComponentId == 'blueprints_root'"
-				variant="special"
-				size="small"
-				data-automation-action="add-blueprint-footer"
-				@click="addBlueprint"
-			>
-				<WdsIcon name="plus" />
-				Add blueprint
-			</WdsButton>
+				<WdsButton
+					v-if="rootComponentId == 'blueprints_root'"
+					variant="special"
+					size="small"
+					data-automation-action="add-blueprint-footer"
+					@click="addBlueprint"
+				>
+					<WdsIcon name="plus" />
+					Add blueprint
+				</WdsButton>
 			</div>
 		</template>
 	</BuilderSidebarPanel>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Section header add-buttons now show or hide per section based on feature configuration, including explicit enablement for the "Shared Blueprints" section when available.

* **Refactor**
  * Unified the feature-flag logic used to determine section inclusion and add-button visibility for more consistent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->