### PR TITLE
fix: blank shared blueprint visible in logic section - AB-848

### DIFF
--- a/src/ui/src/builder/sidebar/BuilderSidebarToolkit.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarToolkit.vue
@@ -283,7 +283,7 @@ function getRelevantToolsInCategory(categoryId: string) {
 
 	const typeList = getSupportedComponentTypes().filter((type) => {
 		const def = getComponentDefinition(type);
-		if (type.startsWith("shared_")) return false;
+		if (type === "blueprints_shared") return false;
 		if (def.category != categoryId) return false;
 		if (!def.toolkit && activeToolkit.value !== "core") return false;
 		if (def.toolkit && def.toolkit !== activeToolkit.value) return false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined sidebar blueprint filtering logic to apply more precise categorization rules. Blueprint items are now correctly displayed in their appropriate sections with improved visibility, while maintaining proper separation between shared and non-shared blueprint categories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->