### PR TITLE
fix(BlueprintLibrary): fickering issue when searching - AB-850

### DIFF
--- a/src/ui/src/builder/panels/BuilderBlueprintLibraryPanel.vue
+++ b/src/ui/src/builder/panels/BuilderBlueprintLibraryPanel.vue
@@ -132,6 +132,7 @@ const blueprints = ref<
 	}>
 >([]);
 const isLoading = ref(false);
+const hasLoadedOnce = ref(false);
 
 const globalBlueprints = computed(() =>
 	blueprints.value.filter((bp) => bp.isReadonly === true),
@@ -154,7 +155,10 @@ async function loadBlueprints() {
 		return;
 	}
 
-	isLoading.value = true;
+	// Only show loading state on initial load, not during search refinements
+	if (!hasLoadedOnce.value) {
+		isLoading.value = true;
+	}
 	try {
 		const results = await writerApi.listSharedBlueprints(
 			orgId,
@@ -170,6 +174,7 @@ async function loadBlueprints() {
 			isReadonly: Boolean(bp.isReadonly),
 			createdBy: bp.createdBy,
 		}));
+		hasLoadedOnce.value = true;
 	} catch (error) {
 		pushToast({
 			type: "error",
@@ -186,6 +191,8 @@ watch(searchQuery, debouncedLoadBlueprints);
 
 function handleClose() {
 	isOpen.value = false;
+	hasLoadedOnce.value = false;
+	searchQuery.value = "";
 }
 
 watch(isOpen, (newValue) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized Blueprint Library Panel loading: the loading indicator now appears only on initial load rather than on each search refinement, improving the speed and smoothness of library searches.
  * Blueprint Library Panel search is cleared when closing the panel.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->