### PR TITLE
fix: add error toast for required fields in shared blueprint deployme…

### DIFF
--- a/src/ui/src/builder/settings/BuilderSettingsDeploySharedBlueprint.vue
+++ b/src/ui/src/builder/settings/BuilderSettingsDeploySharedBlueprint.vue
@@ -128,6 +128,10 @@ function handleNameChange(newName: string) {
 
 async function handleDeploy() {
 	if (!validateForm()) {
+		pushToast({
+			type: "error",
+			message: "Please fill in all required fields",
+		});
 		return;
 	}
 


### PR DESCRIPTION
…nt - AB-849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error notification to inform users when form validation fails, displaying a message about required fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->