### PR TITLE
feat: restrict shared blueprints visibility based on toolkit mode

### DIFF
--- a/src/ui/src/builder/sidebar/BuilderSidebarToolkit.vue
+++ b/src/ui/src/builder/sidebar/BuilderSidebarToolkit.vue
@@ -219,6 +219,10 @@ const placeholder = computed(() => {
 
 function getRelevantToolsInCategory(categoryId: string) {
 	if (categoryId === "Shared Blueprints") {
+		// Only show shared blueprints in blueprints mode, not in interface mode
+		if (activeToolkit.value !== "blueprints") {
+			return [];
+		}
 		// Don't show shared blueprints when editing a shared blueprint (no nesting for now)
 		if (
 			!isSharedBlueprintsEnabled.value ||


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shared blueprints visibility in the sidebar. Shared blueprints now only display when the blueprints toolkit is active. In interface mode and other non-blueprints toolkit modes, shared blueprints are properly hidden from the sidebar category listings, providing a cleaner interface that better matches the context of each toolkit mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->