### PR TITLE
GITHUB SECRETS MIGRATION: migrate writer/writer-framework to Infisical

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      id-token: write
     outputs:
       version: ${{ steps.set_version.outputs.version }}
 
@@ -31,7 +34,17 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          ref: ${{ github.event.inputs.commit_sha || github.ref_name }}
+          ref: ${{ github.event.inputs['commit_sha'] || github.ref_name }}
+
+      - name: Fetch secrets from Infisical
+        uses: WriterInternal/devops-github-actions/infisical-secrets@cf0625c0cb6646c057b9bc81c49c8554b2313e27 # v2.3.0
+        with:
+          org-identity-id: ${{ secrets.INFISICAL_ORG_IDENTITY_UUID }}
+          org-project-slug: ${{ secrets.INFISICAL_ORG_PROJECT_SLUG }}
+          repo-identity-id: ${{ secrets.INFISICAL_REPO_IDENTITY_UUID }}
+          repo-project-slug: ${{ secrets.INFISICAL_REPO_PROJECT_SLUG }}
+          env-slug: prod
+          required-keys: LAUNCHDARKLY_ACCESS_TOKEN PYPI_TOKEN
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -81,10 +94,12 @@ jobs:
 
       - name: Determine final version
         id: set_version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs['version'] }}
         run: |
           # Determine version based on workflow inputs or tags
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
           elif [ "${GITHUB_REF_NAME}" = "dev" ]; then
             VERSION="${{ steps.bump_version.outputs.version }}"
           elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
@@ -116,7 +131,7 @@ jobs:
       - name: Upload sourcemaps to LaunchDarkly
         shell: bash
         env:
-          LAUNCHDARKLY_ACCESS_TOKEN: ${{ secrets.LAUNCHDARKLY_ACCESS_TOKEN }}
+          LAUNCHDARKLY_ACCESS_TOKEN: ${{ env.LAUNCHDARKLY_ACCESS_TOKEN }}
           RELEASE_VERSION: ${{ steps.set_version.outputs.version }}
           BASE_PATH: /static
           PROJECT: writer-framework
@@ -130,7 +145,7 @@ jobs:
           WRITER_FRAMEWORK_VERSION=${{ steps.set_version.outputs.version }} poetry run alfred install.ci
           WRITER_FRAMEWORK_VERSION=${{ steps.set_version.outputs.version }} poetry run alfred publish.pypi
         env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          PYPI_TOKEN: ${{ env.PYPI_TOKEN }}
 
       - name: Create and push tag for RC (only dev)
         if: github.ref_name == 'dev'
@@ -148,9 +163,15 @@ jobs:
   trigger-agent-manager:
     needs: [build]
     if: github.ref_name == 'dev'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/trigger-workflow.yml
     with:
       event_type: framework_updated
       extra_payload: '{"tag": "writer-framework-${{ needs.build.outputs.version }}", "version": "${{ needs.build.outputs.version }}"}'
     secrets:
-      AGENT_MANAGER_PAT: ${{ secrets.AGENT_MANAGER_PAT }}
+      INFISICAL_ORG_IDENTITY_UUID: ${{ secrets.INFISICAL_ORG_IDENTITY_UUID }}
+      INFISICAL_ORG_PROJECT_SLUG: ${{ secrets.INFISICAL_ORG_PROJECT_SLUG }}
+      INFISICAL_REPO_IDENTITY_UUID: ${{ secrets.INFISICAL_REPO_IDENTITY_UUID }}
+      INFISICAL_REPO_PROJECT_SLUG: ${{ secrets.INFISICAL_REPO_PROJECT_SLUG }}

--- a/.github/workflows/trigger-workflow.yml
+++ b/.github/workflows/trigger-workflow.yml
@@ -13,8 +13,13 @@ on:
         type: string
         default: "{}"
     secrets:
-      AGENT_MANAGER_PAT:
-        description: 'Personal Access Token for triggering agent manager repo'
+      INFISICAL_ORG_IDENTITY_UUID:
+        required: true
+      INFISICAL_ORG_PROJECT_SLUG:
+        required: true
+      INFISICAL_REPO_IDENTITY_UUID:
+        required: true
+      INFISICAL_REPO_PROJECT_SLUG:
         required: true
 
 permissions:
@@ -23,15 +28,31 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
+    - name: Fetch secrets from Infisical
+      uses: WriterInternal/devops-github-actions/infisical-secrets@cf0625c0cb6646c057b9bc81c49c8554b2313e27 # v2.3.0
+      with:
+        org-identity-id: ${{ secrets.INFISICAL_ORG_IDENTITY_UUID }}
+        org-project-slug: ${{ secrets.INFISICAL_ORG_PROJECT_SLUG }}
+        repo-identity-id: ${{ secrets.INFISICAL_REPO_IDENTITY_UUID }}
+        repo-project-slug: ${{ secrets.INFISICAL_REPO_PROJECT_SLUG }}
+        env-slug: prod
+        required-keys: AGENT_MANAGER_PAT
+
     - name: Trigger agent manager
+      env:
+        EVENT_TYPE: ${{ inputs.event_type }}
+        EXTRA_PAYLOAD: ${{ inputs.extra_payload }}
       run: |
         repo_owner="WriterInternal"
         repo_name="be.agent-manager"
-        event_type="${{ inputs.event_type }}"
+        event_type="$EVENT_TYPE"
         commit_sha="${{ github.sha }}"
-        extra_payload='${{ inputs.extra_payload }}'
+        extra_payload="$EXTRA_PAYLOAD"
 
         echo "Triggering agent manager with event_type=$event_type"
         echo "Extra payload (raw): $extra_payload"
@@ -48,7 +69,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.AGENT_MANAGER_PAT }}" \
+          -H "Authorization: Bearer $AGENT_MANAGER_PAT" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
           -d "{\"event_type\": \"$event_type\", \"client_payload\": $merged_payload}"


### PR DESCRIPTION
## Summary

Automated Infisical migration PR (orchestrator opened after verifier gate).

<!-- infisical-migration-contract: contract=composite-v2 composite-sha=cf0625c0cb6646c057b9bc81c49c8554b2313e27 generated=2026-06-26T14:44:34Z -->

---
_Harness contract: `composite-v2`, centralized composite `cf0625c0cb66` (v2.3.0). If the composite SHA has advanced past this, this PR may be drifted — re-verify against the current contract before merge._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Permissions**
  * Updated workflow permissions and secret handling for safer automated releases.
  * Switched several publish and trigger steps to use environment-based values instead of direct secret references.
* **Bug Fixes**
  * Improved version selection logic so release version input is handled more reliably.
  * Updated workflow dispatch behavior to pass event details consistently through job variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->