### PR TITLE
Gate ABv1 editing and add remigration dialog

### DIFF
--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -9,6 +9,7 @@
 			@dismiss="onDismissBanner"
 		/>
 		<div
+			v-if="canEditAgent"
 			class="mainGrid"
 			:class="{ openPanels: ssbm.openPanels.value.size > 0 }"
 		>
@@ -85,10 +86,11 @@
 				</template>
 			</ShareResizeVertical>
 		</div>
+		<BuilderEditBlockedState v-else />
 
 		<!-- INSTANCE TRACKERS -->
 
-		<template v-if="builderMode !== 'preview'">
+		<template v-if="canEditAgent && builderMode !== 'preview'">
 			<BuilderCollaborationTracker
 				class="collaborationTracker"
 			></BuilderCollaborationTracker>
@@ -121,7 +123,7 @@
 
 		<!-- NOTES -->
 
-		<template v-if="builderMode === 'ui'">
+		<template v-if="canEditAgent && builderMode === 'ui'">
 			<BuilderInstanceTracker
 				v-for="note of notes"
 				:key="note.id"
@@ -145,6 +147,9 @@
 		<div id="drawer"></div>
 
 		<BuilderAppSocketTimeoutModal />
+		<BuilderRemigrationWarningDialog
+			v-model:is-open="showRemigrationWarningDialog"
+		/>
 		<!-- TOOLTIP -->
 
 		<BuilderTooltip id="tooltip" />
@@ -185,9 +190,12 @@ import BuilderAppSocketTimeoutModal from "./BuilderAppSocketTimeoutModal.vue";
 import { useSocketTimeout } from "./useSocketTimeout";
 import BlueprintsNavigationStack from "@/components/blueprints/BlueprintsNavigationStack.vue";
 import BuilderDeprecationBanner from "./BuilderDeprecationBanner.vue";
+import BuilderEditBlockedState from "./BuilderEditBlockedState.vue";
+import BuilderRemigrationWarningDialog from "./BuilderRemigrationWarningDialog.vue";
 
 const DEPRECATION_BANNER_DISMISSED_KEY =
 	"customAgentDeprecationBannerDismissed";
+const REMIGRATION_WARNING_QUERY_PARAM = "showRemigrationWarning";
 
 provide(injectionKeys.isAutogenModalShown, ref(false));
 
@@ -227,17 +235,56 @@ const isPostCutoff = computed(() =>
 	wf.featureFlags.value.includes("afterDeprecationCutoffAbv2"),
 );
 const isOrganizationAdmin = computed(() => wf.isOrganizationAdmin.value);
+const canEditAgent = computed(() => wf.canEditAgent.value);
 const showDeprecationBanner = computed(
 	() =>
 		wf.isWriterCloudApp.value &&
 		(isPostCutoff.value ||
 			(isPreCutoffFlagEnabled.value && !dismissed.value)),
 );
+const showRemigrationWarningDialog = ref(false);
 
 function onDismissBanner() {
 	localStorage.setItem(DEPRECATION_BANNER_DISMISSED_KEY, "true");
 	dismissed.value = true;
 }
+
+function isPageRefresh() {
+	const navigation = performance.getEntriesByType("navigation")[0] as
+		| PerformanceNavigationTiming
+		| undefined;
+
+	return navigation?.type === "reload";
+}
+
+function consumeRemigrationWarningQueryParam() {
+	const url = new URL(window.location.href);
+	const shouldShowFromOpener =
+		url.searchParams.get(REMIGRATION_WARNING_QUERY_PARAM) === "true";
+
+	if (shouldShowFromOpener) {
+		url.searchParams.delete(REMIGRATION_WARNING_QUERY_PARAM);
+		window.history.replaceState(
+			window.history.state,
+			document.title,
+			url.toString(),
+		);
+	}
+
+	return shouldShowFromOpener;
+}
+
+onMounted(() => {
+	const shouldShowFromOpener = consumeRemigrationWarningQueryParam();
+
+	showRemigrationWarningDialog.value =
+		shouldShowFromOpener &&
+		!isPageRefresh() &&
+		canEditAgent.value &&
+		wf.isWriterCloudApp.value &&
+		isPreCutoffFlagEnabled.value &&
+		!isPostCutoff.value;
+});
 
 const tracking = useWriterTracking(wf);
 const toasts = useToasts();
@@ -310,6 +357,8 @@ const notes = computed(() =>
 );
 
 async function handleKeydown(ev: KeyboardEvent) {
+	if (!canEditAgent.value) return;
+
 	if (ev.key === "Escape") {
 		ssbm.setSelection(null);
 		ssbm.expandedEditorForComponent.value = null;
@@ -406,11 +455,13 @@ async function handleKeydown(ev: KeyboardEvent) {
 }
 
 function handleRendererDragover(ev: DragEvent) {
+	if (!canEditAgent.value) return;
 	if (builderMode.value === "preview") return;
 	assignInsertionCandidacy(ev);
 }
 
 function handleRendererDrop(ev: DragEvent) {
+	if (!canEditAgent.value) return;
 	if (builderMode.value === "preview") return;
 	ssbm.setSelection(null);
 	const dropInfo = dropComponent(ev);
@@ -425,6 +476,7 @@ function handleRendererDrop(ev: DragEvent) {
 }
 
 function handleRendererClick(ev: PointerEvent): void {
+	if (!canEditAgent.value) return;
 	if (builderMode.value === "preview") return;
 
 	const unselectableEl = (ev.target as HTMLElement).closest<HTMLElement>(
@@ -471,10 +523,12 @@ function handleRendererClick(ev: PointerEvent): void {
 	ssbm.handleSelectionFromEvent(ev, targetId, targetInstancePath, "click");
 }
 function handleRendererDblClick() {
+	if (!canEditAgent.value) return;
 	ssbm.isSettingsBarCollapsed.value = false;
 }
 
 const handleRendererDragStart = (ev: DragEvent) => {
+	if (!canEditAgent.value) return;
 	if (builderMode.value === "preview") return;
 
 	const targetEl = (ev.target as HTMLElement).closest<HTMLElement>(
@@ -499,6 +553,7 @@ const handleRendererDragStart = (ev: DragEvent) => {
 };
 
 function handleRendererDragEnd(ev: DragEvent) {
+	if (!canEditAgent.value) return;
 	ssbm.setSelection(null);
 	removeInsertionCandidacy(ev);
 }

--- a/src/ui/src/builder/BuilderApp.vue
+++ b/src/ui/src/builder/BuilderApp.vue
@@ -9,9 +9,11 @@
 			@dismiss="onDismissBanner"
 		/>
 		<div
-			v-if="canEditAgent"
 			class="mainGrid"
-			:class="{ openPanels: ssbm.openPanels.value.size > 0 }"
+			:class="{
+				openPanels: ssbm.openPanels.value.size > 0,
+				blocked: !canEditAgent,
+			}"
 		>
 			<BuilderHeader class="builderHeader" />
 			<BuilderSidebar
@@ -86,7 +88,7 @@
 				</template>
 			</ShareResizeVertical>
 		</div>
-		<BuilderEditBlockedState v-else />
+		<BuilderEditBlockedState v-if="!canEditAgent" />
 
 		<!-- INSTANCE TRACKERS -->
 
@@ -646,6 +648,12 @@ onUnmounted(() => {
 	grid-template-columns: auto 1fr;
 	grid-template-rows: var(--builderTopBarHeight) minmax(0, 1fr);
 	display: grid;
+}
+
+.mainGrid.blocked {
+	pointer-events: none;
+	filter: grayscale(1);
+	opacity: 0.52;
 }
 
 .builderHeader {

--- a/src/ui/src/builder/BuilderEditBlockedState.vue
+++ b/src/ui/src/builder/BuilderEditBlockedState.vue
@@ -12,12 +12,15 @@
 
 <style scoped>
 .BuilderEditBlockedState {
-	flex: 1;
+	position: absolute;
+	inset: 0;
+	z-index: 20;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	padding: 32px;
-	background: var(--builderBackgroundColor);
+	background: rgb(255 255 255 / 64%);
+	backdrop-filter: grayscale(1);
 }
 
 .BuilderEditBlockedState__card {

--- a/src/ui/src/builder/BuilderEditBlockedState.vue
+++ b/src/ui/src/builder/BuilderEditBlockedState.vue
@@ -1,0 +1,47 @@
+<template>
+	<div class="BuilderEditBlockedState">
+		<div class="BuilderEditBlockedState__card">
+			<h2>You don't have permission to edit this agent</h2>
+			<p>
+				Ask an org admin or AI Studio full access user to update this
+				agent, or to grant you AI Studio builder access.
+			</p>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.BuilderEditBlockedState {
+	flex: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 32px;
+	background: var(--builderBackgroundColor);
+}
+
+.BuilderEditBlockedState__card {
+	max-width: 520px;
+	padding: 32px;
+	border: 1px solid var(--builderSeparatorColor);
+	border-radius: 8px;
+	background: var(--wdsColorWhite);
+	box-shadow: 0px 3px 40px 0px rgba(172, 185, 220, 0.24);
+	text-align: center;
+}
+
+.BuilderEditBlockedState__card h2 {
+	margin: 0 0 12px;
+	color: var(--primaryTextColor);
+	font-size: 24px;
+	font-weight: 500;
+	line-height: 1.4;
+}
+
+.BuilderEditBlockedState__card p {
+	margin: 0;
+	color: var(--secondaryTextColor);
+	font-size: 16px;
+	line-height: 1.6;
+}
+</style>

--- a/src/ui/src/builder/BuilderRemigrationWarningDialog.vue
+++ b/src/ui/src/builder/BuilderRemigrationWarningDialog.vue
@@ -1,0 +1,42 @@
+<template>
+	<WdsModal
+		v-if="isOpen"
+		title="Migrate again to update your app"
+		size="compact"
+		display-close-button
+		:actions="actions"
+		@close="closeDialog"
+	>
+		<p class="BuilderRemigrationWarningDialog__body">
+			Changes made here won't sync automatically. If you already migrated
+			to Agent Builder v2, please migrate again to update your app.
+		</p>
+	</WdsModal>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import WdsModal, { type ModalAction } from "@/wds/WdsModal.vue";
+
+const isOpen = defineModel("isOpen", { type: Boolean, default: false });
+
+const actions = computed<ModalAction[]>(() => [
+	{
+		desc: "I understand",
+		fn: closeDialog,
+	},
+]);
+
+function closeDialog() {
+	isOpen.value = false;
+}
+</script>
+
+<style scoped>
+.BuilderRemigrationWarningDialog__body {
+	margin: 0 0 4px;
+	color: var(--primaryTextColor);
+	font-size: 16px;
+	line-height: 1.6;
+}
+</style>

--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -71,6 +71,7 @@ export function generateCore() {
 				apiKey?: string;
 				baseUrl?: string;
 				isOrganizationAdmin?: boolean;
+				canEdit?: boolean;
 		  }
 		| undefined
 	>();
@@ -146,6 +147,12 @@ export function generateCore() {
 	);
 	const isWriterCloudApp = computed(() =>
 		Boolean(writerAppId.value || writerOrgId.value),
+	);
+	const canEditAgent = computed(
+		() =>
+			!isWriterCloudApp.value ||
+			isOrganizationAdmin.value ||
+			Boolean(writerApplication.value?.canEdit),
 	);
 
 	/**
@@ -1176,6 +1183,7 @@ export function generateCore() {
 		writerApiKey,
 		writerBaseUrl,
 		isOrganizationAdmin,
+		canEditAgent,
 		...navigationStack,
 		getFirstBlueprint,
 		getFirstPage,

--- a/src/ui/src/tests/mocks.ts
+++ b/src/ui/src/tests/mocks.ts
@@ -44,7 +44,13 @@ export function buildMockCore() {
 	const userFunctions = shallowRef<UserFunction[]>([]);
 	const featureFlags = shallowRef<string[]>([]);
 	const writerApplication = shallowRef<
-		{ id: string; organizationId: string } | undefined
+		| {
+				id: string;
+				organizationId: string;
+				isOrganizationAdmin?: boolean;
+				canEdit?: boolean;
+		  }
+		| undefined
 	>();
 
 	core.userFunctions = userFunctions;
@@ -67,6 +73,15 @@ export function buildMockCore() {
 		() => Number(writerApplication.value?.organizationId) || undefined,
 	);
 	core.writerAppId = computed(() => writerApplication.value?.id);
+	core.isOrganizationAdmin = computed(
+		() => writerApplication.value?.isOrganizationAdmin ?? false,
+	);
+	core.canEditAgent = computed(
+		() =>
+			!core.isWriterCloudApp.value ||
+			core.isOrganizationAdmin.value ||
+			Boolean(writerApplication.value?.canEdit),
+	);
 
 	vi.spyOn(core, "sendComponentUpdate").mockImplementation(async () => {});
 

--- a/src/ui/src/wds/WdsModal.vue
+++ b/src/ui/src/wds/WdsModal.vue
@@ -5,6 +5,7 @@
 			class="WdsModal colorTransformer"
 			:class="{
 				'WdsModal--overflow': allowOverflow,
+				'WdsModal--compact': size == 'compact',
 				'WdsModal--wide': size == 'wide',
 			}"
 			tabindex="-1"
@@ -78,7 +79,7 @@ export type ModalAction = {
 const props = defineProps({
 	title: { type: String, required: false, default: null },
 	size: {
-		type: String as PropType<"normal" | "wide">,
+		type: String as PropType<"compact" | "normal" | "wide">,
 		required: false,
 		default: "normal",
 	},
@@ -130,6 +131,13 @@ const { title, actions } = toRefs(props);
 
 .WdsModal--wide .WdsModal__main {
 	max-width: 240ch;
+}
+
+.WdsModal--compact .WdsModal__main {
+	width: min(560px, calc(100vw - 32px));
+	max-width: calc(100vw - 32px);
+	gap: 20px;
+	padding: 24px;
 }
 
 .WdsModal--overflow .WdsModal__main,

--- a/src/writer/app_runner.py
+++ b/src/writer/app_runner.py
@@ -191,12 +191,15 @@ class AppProcess(multiprocessing.Process):
         writer_base_url = os.getenv("WRITER_BASE_URL", "https://api.writer.com")
         is_org_admin_header = headers.get("x-is-org-admin", "").lower()
         is_org_admin = is_org_admin_header == "true"
+        can_edit_header = headers.get("x-can-edit-agent", "").lower()
+        can_edit = is_org_admin or can_edit_header == "true"
         if writer_app_id is not None and writer_org_id is not None:
             writer_application = WriterApplicationInformation(
                 id=writer_app_id,
                 organizationId=writer_org_id,
                 baseUrl=writer_base_url,
                 isOrganizationAdmin=is_org_admin,
+                canEdit=can_edit,
             )
             if writer.Config.mode == "edit":
                 writer_application.apiKey = os.getenv("WRITER_API_KEY")

--- a/src/writer/ss_types.py
+++ b/src/writer/ss_types.py
@@ -74,6 +74,7 @@ class WriterApplicationInformation(BaseModel):
     baseUrl: Optional[str] = None
     apiKey: Optional[str] = None
     isOrganizationAdmin: Optional[bool] = False
+    canEdit: Optional[bool] = False
 
 
 class AutogenRequestBody(BaseModel):


### PR DESCRIPTION
## Summary
- Add a compact remigration warning dialog that opens only from the fe.web-app editor launch path and is suppressed on refresh.
- Gate ABv1 edit actions behind server-provided edit access, while preserving org-admin access as a fallback.
- Keep the editor visible for blocked users, but grey it out with a blocking overlay and guard global edit handlers.

## Test plan
- npm exec -w writer-ui -- eslint src/tests/mocks.ts src/core/index.ts src/builder/BuilderApp.vue src/builder/BuilderEditBlockedState.vue src/builder/BuilderRemigrationWarningDialog.vue src/wds/WdsModal.vue --ext .vue,.ts,.js,.jsx,.cjs,.mjs --ignore-path ../../.gitignore --ignore-path .gitignore
- python3 -m py_compile src/writer/app_runner.py src/writer/ss_types.py
- Local preview: opened http://localhost:5173/?showRemigrationWarning=true and confirmed allowed/admin sessions render editor tabs and the dialog.

## Notes
- agent-manager should pass x-can-edit-agent: true for non-admin AIS users who can edit ABv1 agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear blocked-editing state for builder mode when the user lacks edit permission.
  * Added a compact “Migrate again to update your app” remigration warning dialog (triggered via URL query).
  * Added support for a `compact` modal size.
* **Bug Fixes**
  * Blocked editor interactions (keyboard, selection, drag-and-drop, clicks) when editing is disabled.
  * Ensured instance and note trackers render only when editing is permitted (with tighter UI-mode conditions).
  * Restricted when the remigration warning is shown to the appropriate app and navigation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->