### PR TITLE
fix: flag-gate ABv1 edit block behind deprecation flags [ACTION-5731]

### DIFF
--- a/src/ui/src/core/index.ts
+++ b/src/ui/src/core/index.ts
@@ -148,8 +148,19 @@ export function generateCore() {
 	const isWriterCloudApp = computed(() =>
 		Boolean(writerAppId.value || writerOrgId.value),
 	);
+	// ABv1 edit gating is only enforced while an ABv2 deprecation flag is
+	// active. Without a deprecation flag (e.g. the producer that sends the
+	// permission headers hasn't shipped, or the org is not in the deprecation
+	// rollout), editing is always permitted so the block cannot engage
+	// unintentionally.
+	const isAbv1EditGatingEnabled = computed(
+		() =>
+			featureFlags.value.includes("beforeDeprecationCutoffAbv2") ||
+			featureFlags.value.includes("afterDeprecationCutoffAbv2"),
+	);
 	const canEditAgent = computed(
 		() =>
+			!isAbv1EditGatingEnabled.value ||
 			!isWriterCloudApp.value ||
 			isOrganizationAdmin.value ||
 			Boolean(writerApplication.value?.canEdit),

--- a/src/ui/src/tests/canEditAgent.spec.ts
+++ b/src/ui/src/tests/canEditAgent.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { buildMockCore } from "./mocks";
+
+describe("canEditAgent gating", () => {
+	function setup() {
+		const { core, featureFlags, writerApplication } = buildMockCore();
+		return { core, featureFlags, writerApplication };
+	}
+
+	it("allows editing outside of Writer cloud", () => {
+		const { core, featureFlags } = setup();
+		featureFlags.value = ["beforeDeprecationCutoffAbv2"];
+		expect(core.canEditAgent.value).toBe(true);
+	});
+
+	it("does not block editing when no deprecation flag is active", () => {
+		const { core, featureFlags, writerApplication } = setup();
+		writerApplication.value = {
+			id: "app-1",
+			organizationId: "1",
+			isOrganizationAdmin: false,
+			canEdit: false,
+		};
+		featureFlags.value = [];
+		expect(core.canEditAgent.value).toBe(true);
+	});
+
+	it.each(["beforeDeprecationCutoffAbv2", "afterDeprecationCutoffAbv2"])(
+		"blocks editing for a non-admin without edit access when %s is active",
+		(flag) => {
+			const { core, featureFlags, writerApplication } = setup();
+			writerApplication.value = {
+				id: "app-1",
+				organizationId: "1",
+				isOrganizationAdmin: false,
+				canEdit: false,
+			};
+			featureFlags.value = [flag];
+			expect(core.canEditAgent.value).toBe(false);
+		},
+	);
+
+	it("allows editing for an org admin when gating is active", () => {
+		const { core, featureFlags, writerApplication } = setup();
+		writerApplication.value = {
+			id: "app-1",
+			organizationId: "1",
+			isOrganizationAdmin: true,
+			canEdit: false,
+		};
+		featureFlags.value = ["beforeDeprecationCutoffAbv2"];
+		expect(core.canEditAgent.value).toBe(true);
+	});
+
+	it("allows editing when canEdit is granted and gating is active", () => {
+		const { core, featureFlags, writerApplication } = setup();
+		writerApplication.value = {
+			id: "app-1",
+			organizationId: "1",
+			isOrganizationAdmin: false,
+			canEdit: true,
+		};
+		featureFlags.value = ["afterDeprecationCutoffAbv2"];
+		expect(core.canEditAgent.value).toBe(true);
+	});
+});

--- a/src/ui/src/tests/mocks.ts
+++ b/src/ui/src/tests/mocks.ts
@@ -78,6 +78,10 @@ export function buildMockCore() {
 	);
 	core.canEditAgent = computed(
 		() =>
+			!(
+				featureFlags.value.includes("beforeDeprecationCutoffAbv2") ||
+				featureFlags.value.includes("afterDeprecationCutoffAbv2")
+			) ||
 			!core.isWriterCloudApp.value ||
 			core.isOrganizationAdmin.value ||
 			Boolean(writerApplication.value?.canEdit),


### PR DESCRIPTION
## Summary

The ABv1 edit block (`BuilderEditBlockedState` overlay + disabled canvas interactions) is currently enforced purely from the `x-is-org-admin` / `x-can-edit-agent` request headers read in `app_runner.py`. **Those headers have no producer yet** — nothing in `be.agent-manager`, the platform gateway, or `fe.web-app` sets them (PR #1291 added only the reader and notes the agent-manager side is a follow-up).

Because of that, in any Writer cloud session both headers resolve to `false`, so `canEditAgent` becomes `false` for **everyone — including org admins** — which blocks all editing. That makes the framework unshippable ahead of the header producer.

This PR gates the edit-block enforcement behind the existing ABv2 deprecation flags (`beforeDeprecationCutoffAbv2` / `afterDeprecationCutoffAbv2`):

- When **neither** flag is active, `canEditAgent` is always `true`, so the block can never engage unintentionally (safe to deploy before the header producer ships, and for orgs not in the deprecation rollout).
- When a deprecation flag **is** active, the existing permission logic (`isOrganizationAdmin` / `canEdit`) applies exactly as before.

The banner and remigration dialog were already flag-gated; this brings the edit block in line with them.

## Changes

- `core/index.ts`: `canEditAgent` now short-circuits to `true` unless a deprecation flag is present.
- `tests/mocks.ts`: mock `canEditAgent` mirrors the real gating so builder tests stay accurate.
- `tests/canEditAgent.spec.ts`: new spec covering the gating matrix (no flag → editable; flag + non-admin/no-edit → blocked; flag + admin or canEdit → editable).

## Design note

I gated behind **either** deprecation flag since the whole ABv1 edit-gating is part of the ABv2 deprecation rollout. If we'd rather only block editing **post-cutoff** (`afterDeprecationCutoffAbv2` only) or introduce a **dedicated** flag for finer control, that's an easy change — happy to adjust.

## Test plan

- [x] `vitest run src/tests/canEditAgent.spec.ts` (6 passing)
- [x] eslint + prettier clean on changed files
- [ ] Verify in dev with `beforeDeprecationCutoffAbv2` off: editing works normally (no block)
- [ ] Verify with flag on + non-admin/no edit access: block shows as before

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated agent editing access to respect deprecation cutoff feature flags.
  * Preserved editing access for organization administrators and users with explicit edit permission.
  * Allowed editing without additional gating when the relevant feature flags are inactive.

* **Tests**
  * Added coverage for editing permissions across gated, unrestricted, administrator, and explicitly permitted scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->